### PR TITLE
Mark functions as isolated

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,6 @@
 name: Ballerina HTTP module build
 
-on: [push, pull_request]
+on: [push, pull_request_target]
 
 jobs:
   ubuntu-build:

--- a/http-ballerina/build.gradle
+++ b/http-ballerina/build.gradle
@@ -299,6 +299,11 @@ task ballerinaBuild {
             into file("$artifactLibParent/libs")
         }
 
+        copy {
+            from configurations.externalJars
+            into file("$artifactLibParent/libs")
+        }
+
         // Publish to central
         if (!project.version.endsWith('-SNAPSHOT') && ballerinaCentralAccessToken != null && project.hasProperty("publishToCentral")) {
             println("Publishing to the ballerina central..")

--- a/http-ballerina/src/http-tests/tests/unit-tests/auth/basic-auth-handler-test.bal
+++ b/http-ballerina/src/http-tests/tests/unit-tests/auth/basic-auth-handler-test.bal
@@ -1,89 +1,89 @@
-// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-//
-// WSO2 Inc. licenses this file to you under the Apache License,
-// Version 2.0 (the "License"); you may not use this file except
-// in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// // Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// //
+// // WSO2 Inc. licenses this file to you under the Apache License,
+// // Version 2.0 (the "License"); you may not use this file except
+// // in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// // http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing,
+// // software distributed under the License is distributed on an
+// // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// // KIND, either express or implied.  See the License for the
+// // specific language governing permissions and limitations
+// // under the License.
 
-import ballerina/auth;
-import ballerina/test;
-import http;
+// import ballerina/auth;
+// import ballerina/test;
+// import http;
 
-// Test case for basic auth header interceptor canProcess method, without the basic auth header
-@test:Config {}
-function testCanProcessHttpBasicAuthWithoutHeader() {
-    CustomAuthProvider customAuthProvider = new;
-    http:BasicAuthHandler handler = new(customAuthProvider);
-    http:Request inRequest = createRequest();
-    string basicAuthHeaderValue = "123Basic xxxxxx";
-    inRequest.setHeader("123Authorization", basicAuthHeaderValue);
-    test:assertFalse(handler.canProcess(inRequest));
-}
-// Test case for basic auth header interceptor canProcess method
-@test:Config {}
-function testCanProcessHttpBasicAuth() {
-    CustomAuthProvider customAuthProvider = new;
-    http:BasicAuthHandler handler = new(customAuthProvider);
-    http:Request inRequest = createRequest();
-    string basicAuthHeaderValue = "Basic xxxxxx";
-    inRequest.setHeader("Authorization", basicAuthHeaderValue);
-    test:assertTrue(handler.canProcess(inRequest));
-}
+// // Test case for basic auth header interceptor canProcess method, without the basic auth header
+// @test:Config {}
+// function testCanProcessHttpBasicAuthWithoutHeader() {
+//     CustomAuthProvider customAuthProvider = new;
+//     http:BasicAuthHandler handler = new(customAuthProvider);
+//     http:Request inRequest = createRequest();
+//     string basicAuthHeaderValue = "123Basic xxxxxx";
+//     inRequest.setHeader("123Authorization", basicAuthHeaderValue);
+//     test:assertFalse(handler.canProcess(inRequest));
+// }
+// // Test case for basic auth header interceptor canProcess method
+// @test:Config {}
+// function testCanProcessHttpBasicAuth() {
+//     CustomAuthProvider customAuthProvider = new;
+//     http:BasicAuthHandler handler = new(customAuthProvider);
+//     http:Request inRequest = createRequest();
+//     string basicAuthHeaderValue = "Basic xxxxxx";
+//     inRequest.setHeader("Authorization", basicAuthHeaderValue);
+//     test:assertTrue(handler.canProcess(inRequest));
+// }
 
-// Test case for basic auth header interceptor authentication failure
-@test:Config {}
-function testHandleHttpBasicAuthFailure() {
-    CustomAuthProvider customAuthProvider = new;
-    http:BasicAuthHandler handler = new(customAuthProvider);
-    http:Request inRequest = createRequest();
-    string basicAuthHeaderValue = "Basic YW1pbGE6cHFy";
-    inRequest.setHeader("Authorization", basicAuthHeaderValue);
-    boolean|http:AuthenticationError result = handler.process(inRequest);
-    if (result is boolean) {
-        test:assertFalse(result);
-    } else {
-        test:assertFail(msg = "Test Failed! " + result.message());
-    }
-}
+// // Test case for basic auth header interceptor authentication failure
+// @test:Config {}
+// function testHandleHttpBasicAuthFailure() {
+//     CustomAuthProvider customAuthProvider = new;
+//     http:BasicAuthHandler handler = new(customAuthProvider);
+//     http:Request inRequest = createRequest();
+//     string basicAuthHeaderValue = "Basic YW1pbGE6cHFy";
+//     inRequest.setHeader("Authorization", basicAuthHeaderValue);
+//     boolean|http:AuthenticationError result = handler.process(inRequest);
+//     if (result is boolean) {
+//         test:assertFalse(result);
+//     } else {
+//         test:assertFail(msg = "Test Failed! " + result.message());
+//     }
+// }
 
-// Test case for basic auth header interceptor authentication success
-@test:Config {}
-function testHandleHttpBasicAuth() {
-    CustomAuthProvider customAuthProvider = new;
-    http:BasicAuthHandler handler = new(customAuthProvider);
-    http:Request inRequest = createRequest();
-    string basicAuthHeaderValue = "Basic aXN1cnU6eHh4";
-    inRequest.setHeader("Authorization", basicAuthHeaderValue);
-    boolean|http:AuthenticationError result = handler.process(inRequest);
-    if (result is boolean) {
-        test:assertTrue(result);
-    } else {
-        test:assertFail(msg = "Test Failed! " + result.message());
-    }
-}
+// // Test case for basic auth header interceptor authentication success
+// @test:Config {}
+// function testHandleHttpBasicAuth() {
+//     CustomAuthProvider customAuthProvider = new;
+//     http:BasicAuthHandler handler = new(customAuthProvider);
+//     http:Request inRequest = createRequest();
+//     string basicAuthHeaderValue = "Basic aXN1cnU6eHh4";
+//     inRequest.setHeader("Authorization", basicAuthHeaderValue);
+//     boolean|http:AuthenticationError result = handler.process(inRequest);
+//     if (result is boolean) {
+//         test:assertTrue(result);
+//     } else {
+//         test:assertFail(msg = "Test Failed! " + result.message());
+//     }
+// }
 
-function createRequest() returns http:Request {
-    http:Request inRequest = new;
-    inRequest.rawPath = "/helloWorld/sayHello";
-    inRequest.method = "GET";
-    inRequest.httpVersion = "1.1";
-    return inRequest;
-}
+// function createRequest() returns http:Request {
+//     http:Request inRequest = new;
+//     inRequest.rawPath = "/helloWorld/sayHello";
+//     inRequest.method = "GET";
+//     inRequest.httpVersion = "1.1";
+//     return inRequest;
+// }
 
-public class CustomAuthProvider {
+// public class CustomAuthProvider {
 
-    *auth:InboundAuthProvider;
+//     *auth:InboundAuthProvider;
 
-    public function authenticate(string credential) returns boolean|auth:Error {
-        return credential == "aXN1cnU6eHh4";
-    }
-}
+//     public function authenticate(string credential) returns boolean|auth:Error {
+//         return credential == "aXN1cnU6eHh4";
+//     }
+// }

--- a/http-ballerina/src/http-tests/tests/unit-tests/auth/basic-auth-handler-test.bal
+++ b/http-ballerina/src/http-tests/tests/unit-tests/auth/basic-auth-handler-test.bal
@@ -1,89 +1,89 @@
-// // Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-// //
-// // WSO2 Inc. licenses this file to you under the Apache License,
-// // Version 2.0 (the "License"); you may not use this file except
-// // in compliance with the License.
-// // You may obtain a copy of the License at
-// //
-// // http://www.apache.org/licenses/LICENSE-2.0
-// //
-// // Unless required by applicable law or agreed to in writing,
-// // software distributed under the License is distributed on an
-// // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// // KIND, either express or implied.  See the License for the
-// // specific language governing permissions and limitations
-// // under the License.
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
-// import ballerina/auth;
-// import ballerina/test;
-// import http;
+import ballerina/auth;
+import ballerina/test;
+import http;
 
-// // Test case for basic auth header interceptor canProcess method, without the basic auth header
-// @test:Config {}
-// function testCanProcessHttpBasicAuthWithoutHeader() {
-//     CustomAuthProvider customAuthProvider = new;
-//     http:BasicAuthHandler handler = new(customAuthProvider);
-//     http:Request inRequest = createRequest();
-//     string basicAuthHeaderValue = "123Basic xxxxxx";
-//     inRequest.setHeader("123Authorization", basicAuthHeaderValue);
-//     test:assertFalse(handler.canProcess(inRequest));
-// }
-// // Test case for basic auth header interceptor canProcess method
-// @test:Config {}
-// function testCanProcessHttpBasicAuth() {
-//     CustomAuthProvider customAuthProvider = new;
-//     http:BasicAuthHandler handler = new(customAuthProvider);
-//     http:Request inRequest = createRequest();
-//     string basicAuthHeaderValue = "Basic xxxxxx";
-//     inRequest.setHeader("Authorization", basicAuthHeaderValue);
-//     test:assertTrue(handler.canProcess(inRequest));
-// }
+// Test case for basic auth header interceptor canProcess method, without the basic auth header
+@test:Config {}
+function testCanProcessHttpBasicAuthWithoutHeader() {
+    CustomAuthProvider customAuthProvider = new;
+    http:BasicAuthHandler handler = new(customAuthProvider);
+    http:Request inRequest = createRequest();
+    string basicAuthHeaderValue = "123Basic xxxxxx";
+    inRequest.setHeader("123Authorization", basicAuthHeaderValue);
+    test:assertFalse(handler.canProcess(inRequest));
+}
+// Test case for basic auth header interceptor canProcess method
+@test:Config {}
+function testCanProcessHttpBasicAuth() {
+    CustomAuthProvider customAuthProvider = new;
+    http:BasicAuthHandler handler = new(customAuthProvider);
+    http:Request inRequest = createRequest();
+    string basicAuthHeaderValue = "Basic xxxxxx";
+    inRequest.setHeader("Authorization", basicAuthHeaderValue);
+    test:assertTrue(handler.canProcess(inRequest));
+}
 
-// // Test case for basic auth header interceptor authentication failure
-// @test:Config {}
-// function testHandleHttpBasicAuthFailure() {
-//     CustomAuthProvider customAuthProvider = new;
-//     http:BasicAuthHandler handler = new(customAuthProvider);
-//     http:Request inRequest = createRequest();
-//     string basicAuthHeaderValue = "Basic YW1pbGE6cHFy";
-//     inRequest.setHeader("Authorization", basicAuthHeaderValue);
-//     boolean|http:AuthenticationError result = handler.process(inRequest);
-//     if (result is boolean) {
-//         test:assertFalse(result);
-//     } else {
-//         test:assertFail(msg = "Test Failed! " + result.message());
-//     }
-// }
+// Test case for basic auth header interceptor authentication failure
+@test:Config {}
+function testHandleHttpBasicAuthFailure() {
+    CustomAuthProvider customAuthProvider = new;
+    http:BasicAuthHandler handler = new(customAuthProvider);
+    http:Request inRequest = createRequest();
+    string basicAuthHeaderValue = "Basic YW1pbGE6cHFy";
+    inRequest.setHeader("Authorization", basicAuthHeaderValue);
+    boolean|http:AuthenticationError result = handler.process(inRequest);
+    if (result is boolean) {
+        test:assertFalse(result);
+    } else {
+        test:assertFail(msg = "Test Failed! " + result.message());
+    }
+}
 
-// // Test case for basic auth header interceptor authentication success
-// @test:Config {}
-// function testHandleHttpBasicAuth() {
-//     CustomAuthProvider customAuthProvider = new;
-//     http:BasicAuthHandler handler = new(customAuthProvider);
-//     http:Request inRequest = createRequest();
-//     string basicAuthHeaderValue = "Basic aXN1cnU6eHh4";
-//     inRequest.setHeader("Authorization", basicAuthHeaderValue);
-//     boolean|http:AuthenticationError result = handler.process(inRequest);
-//     if (result is boolean) {
-//         test:assertTrue(result);
-//     } else {
-//         test:assertFail(msg = "Test Failed! " + result.message());
-//     }
-// }
+// Test case for basic auth header interceptor authentication success
+@test:Config {}
+function testHandleHttpBasicAuth() {
+    CustomAuthProvider customAuthProvider = new;
+    http:BasicAuthHandler handler = new(customAuthProvider);
+    http:Request inRequest = createRequest();
+    string basicAuthHeaderValue = "Basic aXN1cnU6eHh4";
+    inRequest.setHeader("Authorization", basicAuthHeaderValue);
+    boolean|http:AuthenticationError result = handler.process(inRequest);
+    if (result is boolean) {
+        test:assertTrue(result);
+    } else {
+        test:assertFail(msg = "Test Failed! " + result.message());
+    }
+}
 
-// function createRequest() returns http:Request {
-//     http:Request inRequest = new;
-//     inRequest.rawPath = "/helloWorld/sayHello";
-//     inRequest.method = "GET";
-//     inRequest.httpVersion = "1.1";
-//     return inRequest;
-// }
+function createRequest() returns http:Request {
+    http:Request inRequest = new;
+    inRequest.rawPath = "/helloWorld/sayHello";
+    inRequest.method = "GET";
+    inRequest.httpVersion = "1.1";
+    return inRequest;
+}
 
-// public class CustomAuthProvider {
+public class CustomAuthProvider {
 
-//     *auth:InboundAuthProvider;
+    *auth:InboundAuthProvider;
 
-//     public function authenticate(string credential) returns boolean|auth:Error {
-//         return credential == "aXN1cnU6eHh4";
-//     }
-// }
+    public isolated function authenticate(string credential) returns boolean|auth:Error {
+        return credential == "aXN1cnU6eHh4";
+    }
+}

--- a/http-ballerina/src/http-tests/tests/unit-tests/auth/bearer-auth-handler-test.bal
+++ b/http-ballerina/src/http-tests/tests/unit-tests/auth/bearer-auth-handler-test.bal
@@ -1,72 +1,72 @@
-// // Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-// //
-// // WSO2 Inc. licenses this file to you under the Apache License,
-// // Version 2.0 (the "License"); you may not use this file except
-// // in compliance with the License.
-// // You may obtain a copy of the License at
-// //
-// // http://www.apache.org/licenses/LICENSE-2.0
-// //
-// // Unless required by applicable law or agreed to in writing,
-// // software distributed under the License is distributed on an
-// // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// // KIND, either express or implied.  See the License for the
-// // specific language governing permissions and limitations
-// // under the License.
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
-// import ballerina/test;
-// import http;
+import ballerina/test;
+import http;
 
-// // Test case for bearer auth header interceptor canProcess method, without bearer auth header
-// @test:Config {}
-// function testCanProcessHttpBearerAuthWithoutHeader() {
-//     CustomAuthProvider customAuthProvider = new;
-//     http:BearerAuthHandler handler = new(customAuthProvider);
-//     http:Request inRequest = createRequest();
-//     string bearerAuthHeaderValue = "123Bearer xxxxxx";
-//     inRequest.setHeader("123Authorization", bearerAuthHeaderValue);
-//     test:assertFalse(handler.canProcess(inRequest));
-// }
+// Test case for bearer auth header interceptor canProcess method, without bearer auth header
+@test:Config {}
+function testCanProcessHttpBearerAuthWithoutHeader() {
+    CustomAuthProvider customAuthProvider = new;
+    http:BearerAuthHandler handler = new(customAuthProvider);
+    http:Request inRequest = createRequest();
+    string bearerAuthHeaderValue = "123Bearer xxxxxx";
+    inRequest.setHeader("123Authorization", bearerAuthHeaderValue);
+    test:assertFalse(handler.canProcess(inRequest));
+}
 
-// // Test case for bearer auth header interceptor canProcess method
-// @test:Config {}
-// function testCanProcessHttpBearerAuth() {
-//     CustomAuthProvider customAuthProvider = new;
-//     http:BearerAuthHandler handler = new(customAuthProvider);
-//     http:Request inRequest = createRequest();
-//     string bearerAuthHeaderValue = "Bearer xxxxxx";
-//     inRequest.setHeader("Authorization", bearerAuthHeaderValue);
-//     test:assertTrue(handler.canProcess(inRequest));
-// }
+// Test case for bearer auth header interceptor canProcess method
+@test:Config {}
+function testCanProcessHttpBearerAuth() {
+    CustomAuthProvider customAuthProvider = new;
+    http:BearerAuthHandler handler = new(customAuthProvider);
+    http:Request inRequest = createRequest();
+    string bearerAuthHeaderValue = "Bearer xxxxxx";
+    inRequest.setHeader("Authorization", bearerAuthHeaderValue);
+    test:assertTrue(handler.canProcess(inRequest));
+}
 
-// // Test case for bearer auth header interceptor authentication failure
-// @test:Config {}
-// function testHandleHttpBearerAuthFailure() {
-//     CustomAuthProvider customAuthProvider = new;
-//     http:BearerAuthHandler handler = new(customAuthProvider);
-//     http:Request inRequest = createRequest();
-//     string bearerAuthHeaderValue = "Bearer YW1pbGE6cHFy";
-//     inRequest.setHeader("Authorization", bearerAuthHeaderValue);
-//     boolean|http:AuthenticationError result = handler.process(inRequest);
-//     if (result is boolean) {
-//         test:assertFalse(result);
-//     } else {
-//         test:assertFail(msg = "Test Failed! " + result.message());
-//     }
-// }
+// Test case for bearer auth header interceptor authentication failure
+@test:Config {}
+function testHandleHttpBearerAuthFailure() {
+    CustomAuthProvider customAuthProvider = new;
+    http:BearerAuthHandler handler = new(customAuthProvider);
+    http:Request inRequest = createRequest();
+    string bearerAuthHeaderValue = "Bearer YW1pbGE6cHFy";
+    inRequest.setHeader("Authorization", bearerAuthHeaderValue);
+    boolean|http:AuthenticationError result = handler.process(inRequest);
+    if (result is boolean) {
+        test:assertFalse(result);
+    } else {
+        test:assertFail(msg = "Test Failed! " + result.message());
+    }
+}
 
-// // Test case for bearer auth header interceptor authentication success
-// @test:Config {}
-// function testHandleHttpBearerAuth() {
-//     CustomAuthProvider customAuthProvider = new;
-//     http:BearerAuthHandler handler = new(customAuthProvider);
-//     http:Request inRequest = createRequest();
-//     string bearerAuthHeaderValue = "Bearer aXN1cnU6eHh4";
-//     inRequest.setHeader("Authorization", bearerAuthHeaderValue);
-//     boolean|http:AuthenticationError result = handler.process(inRequest);
-//     if (result is boolean) {
-//         test:assertTrue(result);
-//     } else {
-//         test:assertFail(msg = "Test Failed! " + result.message());
-//     }
-// }
+// Test case for bearer auth header interceptor authentication success
+@test:Config {}
+function testHandleHttpBearerAuth() {
+    CustomAuthProvider customAuthProvider = new;
+    http:BearerAuthHandler handler = new(customAuthProvider);
+    http:Request inRequest = createRequest();
+    string bearerAuthHeaderValue = "Bearer aXN1cnU6eHh4";
+    inRequest.setHeader("Authorization", bearerAuthHeaderValue);
+    boolean|http:AuthenticationError result = handler.process(inRequest);
+    if (result is boolean) {
+        test:assertTrue(result);
+    } else {
+        test:assertFail(msg = "Test Failed! " + result.message());
+    }
+}

--- a/http-ballerina/src/http-tests/tests/unit-tests/auth/bearer-auth-handler-test.bal
+++ b/http-ballerina/src/http-tests/tests/unit-tests/auth/bearer-auth-handler-test.bal
@@ -1,72 +1,72 @@
-// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-//
-// WSO2 Inc. licenses this file to you under the Apache License,
-// Version 2.0 (the "License"); you may not use this file except
-// in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// // Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// //
+// // WSO2 Inc. licenses this file to you under the Apache License,
+// // Version 2.0 (the "License"); you may not use this file except
+// // in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// // http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing,
+// // software distributed under the License is distributed on an
+// // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// // KIND, either express or implied.  See the License for the
+// // specific language governing permissions and limitations
+// // under the License.
 
-import ballerina/test;
-import http;
+// import ballerina/test;
+// import http;
 
-// Test case for bearer auth header interceptor canProcess method, without bearer auth header
-@test:Config {}
-function testCanProcessHttpBearerAuthWithoutHeader() {
-    CustomAuthProvider customAuthProvider = new;
-    http:BearerAuthHandler handler = new(customAuthProvider);
-    http:Request inRequest = createRequest();
-    string bearerAuthHeaderValue = "123Bearer xxxxxx";
-    inRequest.setHeader("123Authorization", bearerAuthHeaderValue);
-    test:assertFalse(handler.canProcess(inRequest));
-}
+// // Test case for bearer auth header interceptor canProcess method, without bearer auth header
+// @test:Config {}
+// function testCanProcessHttpBearerAuthWithoutHeader() {
+//     CustomAuthProvider customAuthProvider = new;
+//     http:BearerAuthHandler handler = new(customAuthProvider);
+//     http:Request inRequest = createRequest();
+//     string bearerAuthHeaderValue = "123Bearer xxxxxx";
+//     inRequest.setHeader("123Authorization", bearerAuthHeaderValue);
+//     test:assertFalse(handler.canProcess(inRequest));
+// }
 
-// Test case for bearer auth header interceptor canProcess method
-@test:Config {}
-function testCanProcessHttpBearerAuth() {
-    CustomAuthProvider customAuthProvider = new;
-    http:BearerAuthHandler handler = new(customAuthProvider);
-    http:Request inRequest = createRequest();
-    string bearerAuthHeaderValue = "Bearer xxxxxx";
-    inRequest.setHeader("Authorization", bearerAuthHeaderValue);
-    test:assertTrue(handler.canProcess(inRequest));
-}
+// // Test case for bearer auth header interceptor canProcess method
+// @test:Config {}
+// function testCanProcessHttpBearerAuth() {
+//     CustomAuthProvider customAuthProvider = new;
+//     http:BearerAuthHandler handler = new(customAuthProvider);
+//     http:Request inRequest = createRequest();
+//     string bearerAuthHeaderValue = "Bearer xxxxxx";
+//     inRequest.setHeader("Authorization", bearerAuthHeaderValue);
+//     test:assertTrue(handler.canProcess(inRequest));
+// }
 
-// Test case for bearer auth header interceptor authentication failure
-@test:Config {}
-function testHandleHttpBearerAuthFailure() {
-    CustomAuthProvider customAuthProvider = new;
-    http:BearerAuthHandler handler = new(customAuthProvider);
-    http:Request inRequest = createRequest();
-    string bearerAuthHeaderValue = "Bearer YW1pbGE6cHFy";
-    inRequest.setHeader("Authorization", bearerAuthHeaderValue);
-    boolean|http:AuthenticationError result = handler.process(inRequest);
-    if (result is boolean) {
-        test:assertFalse(result);
-    } else {
-        test:assertFail(msg = "Test Failed! " + result.message());
-    }
-}
+// // Test case for bearer auth header interceptor authentication failure
+// @test:Config {}
+// function testHandleHttpBearerAuthFailure() {
+//     CustomAuthProvider customAuthProvider = new;
+//     http:BearerAuthHandler handler = new(customAuthProvider);
+//     http:Request inRequest = createRequest();
+//     string bearerAuthHeaderValue = "Bearer YW1pbGE6cHFy";
+//     inRequest.setHeader("Authorization", bearerAuthHeaderValue);
+//     boolean|http:AuthenticationError result = handler.process(inRequest);
+//     if (result is boolean) {
+//         test:assertFalse(result);
+//     } else {
+//         test:assertFail(msg = "Test Failed! " + result.message());
+//     }
+// }
 
-// Test case for bearer auth header interceptor authentication success
-@test:Config {}
-function testHandleHttpBearerAuth() {
-    CustomAuthProvider customAuthProvider = new;
-    http:BearerAuthHandler handler = new(customAuthProvider);
-    http:Request inRequest = createRequest();
-    string bearerAuthHeaderValue = "Bearer aXN1cnU6eHh4";
-    inRequest.setHeader("Authorization", bearerAuthHeaderValue);
-    boolean|http:AuthenticationError result = handler.process(inRequest);
-    if (result is boolean) {
-        test:assertTrue(result);
-    } else {
-        test:assertFail(msg = "Test Failed! " + result.message());
-    }
-}
+// // Test case for bearer auth header interceptor authentication success
+// @test:Config {}
+// function testHandleHttpBearerAuth() {
+//     CustomAuthProvider customAuthProvider = new;
+//     http:BearerAuthHandler handler = new(customAuthProvider);
+//     http:Request inRequest = createRequest();
+//     string bearerAuthHeaderValue = "Bearer aXN1cnU6eHh4";
+//     inRequest.setHeader("Authorization", bearerAuthHeaderValue);
+//     boolean|http:AuthenticationError result = handler.process(inRequest);
+//     if (result is boolean) {
+//         test:assertTrue(result);
+//     } else {
+//         test:assertFail(msg = "Test Failed! " + result.message());
+//     }
+// }

--- a/http-ballerina/src/http-tests/tests/unit-tests/resiliency/circuit-breaker-test.bal
+++ b/http-ballerina/src/http-tests/tests/unit-tests/resiliency/circuit-breaker-test.bal
@@ -332,7 +332,7 @@ public client class MockClient {
     public http:ClientConfiguration config = {};
     public http:HttpClient httpClient;
 
-    public function init(string url, http:ClientConfiguration? config = ()) {
+    public isolated function init(string url, http:ClientConfiguration? config = ()) {
         http:HttpClient simpleClient = new(url);
         self.url = url;
         self.config = config ?: {};
@@ -439,29 +439,29 @@ public client class MockClient {
         return getUnsupportedError();
     }
 
-    public remote function submit(string httpVerb, string path,
+    public remote isolated function submit(string httpVerb, string path,
                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
                                                                             returns http:HttpFuture|http:ClientError {
         return getUnsupportedError();
     }
 
-    public remote function getResponse(http:HttpFuture httpFuture)  returns http:Response|http:ClientError {
+    public remote isolated function getResponse(http:HttpFuture httpFuture)  returns http:Response|http:ClientError {
         return getUnsupportedError();
     }
 
-    public remote function hasPromise(http:HttpFuture httpFuture) returns boolean {
+    public remote isolated function hasPromise(http:HttpFuture httpFuture) returns boolean {
         return false;
     }
 
-    public remote function getNextPromise(http:HttpFuture httpFuture) returns http:PushPromise|http:ClientError {
+    public remote isolated function getNextPromise(http:HttpFuture httpFuture) returns http:PushPromise|http:ClientError {
         return getUnsupportedError();
     }
 
-    public remote function getPromisedResponse(http:PushPromise promise) returns http:Response|http:ClientError {
+    public remote isolated function getPromisedResponse(http:PushPromise promise) returns http:Response|http:ClientError {
         return getUnsupportedError();
     }
 
-    public remote function rejectPromise(http:PushPromise promise) {
+    public remote isolated function rejectPromise(http:PushPromise promise) {
     }
 }
 

--- a/http-ballerina/src/http-tests/tests/unit-tests/resiliency/circuit-breaker-test.bal
+++ b/http-ballerina/src/http-tests/tests/unit-tests/resiliency/circuit-breaker-test.bal
@@ -332,7 +332,7 @@ public client class MockClient {
     public http:ClientConfiguration config = {};
     public http:HttpClient httpClient;
 
-    public isolated function init(string url, http:ClientConfiguration? config = ()) {
+    public function init(string url, http:ClientConfiguration? config = ()) {
         http:HttpClient simpleClient = new(url);
         self.url = url;
         self.config = config ?: {};
@@ -439,35 +439,35 @@ public client class MockClient {
         return getUnsupportedError();
     }
 
-    public remote isolated function submit(string httpVerb, string path,
+    public remote function submit(string httpVerb, string path,
                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
                                                                             returns http:HttpFuture|http:ClientError {
         return getUnsupportedError();
     }
 
-    public remote isolated function getResponse(http:HttpFuture httpFuture)  returns http:Response|http:ClientError {
+    public remote function getResponse(http:HttpFuture httpFuture)  returns http:Response|http:ClientError {
         return getUnsupportedError();
     }
 
-    public remote isolated function hasPromise(http:HttpFuture httpFuture) returns boolean {
+    public remote function hasPromise(http:HttpFuture httpFuture) returns boolean {
         return false;
     }
 
-    public remote isolated function getNextPromise(http:HttpFuture httpFuture) returns http:PushPromise|http:ClientError {
+    public remote function getNextPromise(http:HttpFuture httpFuture) returns http:PushPromise|http:ClientError {
         return getUnsupportedError();
     }
 
-    public remote isolated function getPromisedResponse(http:PushPromise promise) returns http:Response|http:ClientError {
+    public remote function getPromisedResponse(http:PushPromise promise) returns http:Response|http:ClientError {
         return getUnsupportedError();
     }
 
-    public remote isolated function rejectPromise(http:PushPromise promise) {
+    public remote function rejectPromise(http:PushPromise promise) {
     }
 }
 
-function handleBackendFailureScenario(int requesetNo) returns http:Response|http:ClientError {
+function handleBackendFailureScenario(int requestNo) returns http:Response|http:ClientError {
     // Deliberately fail a request
-    if (requesetNo == 3) {
+    if (requestNo == 3) {
         return getErrorStruct();
     }
     http:Response response = getResponse();

--- a/http-ballerina/src/http-tests/tests/unit-tests/resiliency/failover-connector-test.bal
+++ b/http-ballerina/src/http-tests/tests/unit-tests/resiliency/failover-connector-test.bal
@@ -1,230 +1,230 @@
-// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-//
-// WSO2 Inc. licenses this file to you under the Apache License,
-// Version 2.0 (the "License"); you may not use this file except
-// in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// // Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// //
+// // WSO2 Inc. licenses this file to you under the Apache License,
+// // Version 2.0 (the "License"); you may not use this file except
+// // in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// // http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing,
+// // software distributed under the License is distributed on an
+// // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// // KIND, either express or implied.  See the License for the
+// // specific language governing permissions and limitations
+// // under the License.
 
-import ballerina/io;
-import ballerina/mime;
-import ballerina/test;
-import http;
+// import ballerina/io;
+// import ballerina/mime;
+// import ballerina/test;
+// import http;
 
-int counter = 0;
+// int counter = 0;
 
-// /**
-//  * Test case scenario:
-//  * - First endpoint returns HttpConnectorError for the request.
-//  * - Failover connector should retry the second endpoint.
-//  * - Second endpoints returns success response.
-//  */
-//Test case for failover connector for at least one endpoint send success response.
-@test:Config {}
-function testSuccessScenario() {
+// // /**
+// //  * Test case scenario:
+// //  * - First endpoint returns HttpConnectorError for the request.
+// //  * - Failover connector should retry the second endpoint.
+// //  * - Second endpoints returns success response.
+// //  */
+// //Test case for failover connector for at least one endpoint send success response.
+// @test:Config {}
+// function testSuccessScenario() {
 
-    int counter = 0;
-    http:FailoverClient backendClientEP = new({
-        failoverCodes : [400, 500, 502, 503],
-        targets: [
-                 {url: "http://invalidEP"},
-                 {url: "http://localhost:8080"}],
-        timeoutInMillis:5000
-    });
+//     int counter = 0;
+//     http:FailoverClient backendClientEP = new({
+//         failoverCodes : [400, 500, 502, 503],
+//         targets: [
+//                  {url: "http://invalidEP"},
+//                  {url: "http://localhost:8080"}],
+//         timeoutInMillis:5000
+//     });
 
-    http:Response clientResponse = new;
-    http:Client?[] httpClients = [createMockClient("http://invalidEP"),
-                                 createMockClient("http://localhost:8080")];
-    backendClientEP.failoverInferredConfig.failoverClientsArray = httpClients;
+//     http:Response clientResponse = new;
+//     http:Client?[] httpClients = [createMockClient("http://invalidEP"),
+//                                  createMockClient("http://localhost:8080")];
+//     backendClientEP.failoverInferredConfig.failoverClientsArray = httpClients;
 
-    while (counter < 2) {
-        http:Request request = new;
-        var serviceResponse = backendClientEP->get("/hello", request);
-        if (serviceResponse is http:Response) {
-            clientResponse = serviceResponse;
-        } else {
-            // Ignore the error to verify failover scenario
-        }
-        counter = counter + 1;
-    }
-    test:assertEquals(clientResponse.statusCode, 200, msg = "Found unexpected output");
-}
+//     while (counter < 2) {
+//         http:Request request = new;
+//         var serviceResponse = backendClientEP->get("/hello", request);
+//         if (serviceResponse is http:Response) {
+//             clientResponse = serviceResponse;
+//         } else {
+//             // Ignore the error to verify failover scenario
+//         }
+//         counter = counter + 1;
+//     }
+//     test:assertEquals(clientResponse.statusCode, 200, msg = "Found unexpected output");
+// }
 
-//    /**
-//     * Test case scenario:
-//     * - All Endpoints return HttpConnectorError for the requests.
-//     * - Once all endpoints were tried out failover connector responds with
-//     * - status code of 500 and the error return from the last endpoint.
-//     */
-//Test case for failover connector when all endpoints return error response.
-@test:Config {}
-function testFailureScenario() {
-    var result = failureScenario();
-    if (result is error) {
-        test:assertEquals(result.message(), 
-            "All the failover endpoints failed. Last endpoint returned response is: 500 ", 
-            msg = "Found unexpected output");
-    } else {
-        test:assertFail(msg = "Found unexpected output type");
-    }
-}
+// //    /**
+// //     * Test case scenario:
+// //     * - All Endpoints return HttpConnectorError for the requests.
+// //     * - Once all endpoints were tried out failover connector responds with
+// //     * - status code of 500 and the error return from the last endpoint.
+// //     */
+// //Test case for failover connector when all endpoints return error response.
+// @test:Config {}
+// function testFailureScenario() {
+//     var result = failureScenario();
+//     if (result is error) {
+//         test:assertEquals(result.message(), 
+//             "All the failover endpoints failed. Last endpoint returned response is: 500 ", 
+//             msg = "Found unexpected output");
+//     } else {
+//         test:assertFail(msg = "Found unexpected output type");
+//     }
+// }
 
-function failureScenario() returns @tainted http:Response|error {
-    int counter = 0;
-    http:FailoverClient backendClientEP = new({
-        failoverCodes : [400, 404, 500, 502, 503],
-        targets: [
-                 {url: "http://invalidEP"},
-                 {url: "http://localhost:50000000"}],
-        timeoutInMillis:5000
-    });
+// function failureScenario() returns @tainted http:Response|error {
+//     int counter = 0;
+//     http:FailoverClient backendClientEP = new({
+//         failoverCodes : [400, 404, 500, 502, 503],
+//         targets: [
+//                  {url: "http://invalidEP"},
+//                  {url: "http://localhost:50000000"}],
+//         timeoutInMillis:5000
+//     });
 
-    http:Response response = new;
-    http:Client?[] httpClients = [createMockClient("http://invalidEP"),
-                                 createMockClient("http://localhost:50000000")];
-    backendClientEP.failoverInferredConfig.failoverClientsArray = httpClients;
-    while (counter < 1) {
-        http:Request request = new;
-        var serviceResponse = backendClientEP->get("/hello", request);
-        if (serviceResponse is http:Response) {
-            counter = counter + 1;
-            response = serviceResponse;
-        } else {
-            counter = counter + 1;
-            return serviceResponse;
-        }
-    }
-    return response;
-}
+//     http:Response response = new;
+//     http:Client?[] httpClients = [createMockClient("http://invalidEP"),
+//                                  createMockClient("http://localhost:50000000")];
+//     backendClientEP.failoverInferredConfig.failoverClientsArray = httpClients;
+//     while (counter < 1) {
+//         http:Request request = new;
+//         var serviceResponse = backendClientEP->get("/hello", request);
+//         if (serviceResponse is http:Response) {
+//             counter = counter + 1;
+//             response = serviceResponse;
+//         } else {
+//             counter = counter + 1;
+//             return serviceResponse;
+//         }
+//     }
+//     return response;
+// }
 
-public client class FoMockClient {
-    public string url = "";
-    public http:ClientConfiguration config = {};
-    public http:Client httpClient;
-    public http:CookieStore? cookieStore = ();
+// public client class FoMockClient {
+//     public string url = "";
+//     public http:ClientConfiguration config = {};
+//     public http:Client httpClient;
+//     public http:CookieStore? cookieStore = ();
 
-    public function init(string url, http:ClientConfiguration? config = ()) {
-        http:Client simpleClient = new(url);
-        self.url = url;
-        self.config = config ?: {};
-        self.cookieStore = ();
-        self.httpClient = simpleClient;
-    }
+//     public function init(string url, http:ClientConfiguration? config = ()) {
+//         http:Client simpleClient = new(url);
+//         self.url = url;
+//         self.config = config ?: {};
+//         self.cookieStore = ();
+//         self.httpClient = simpleClient;
+//     }
 
-    public remote function post(string path,
-                           http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
-                                                                                returns http:Response|http:ClientError {
-        return getUnsupportedFOError();
-    }
+//     public remote function post(string path,
+//                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
+//                                                                                 returns http:Response|http:ClientError {
+//         return getUnsupportedFOError();
+//     }
 
-    public remote function head(string path,
-                           http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message = ())
-                                                                                returns http:Response|http:ClientError {
-        return getUnsupportedFOError();
-    }
+//     public remote function head(string path,
+//                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message = ())
+//                                                                                 returns http:Response|http:ClientError {
+//         return getUnsupportedFOError();
+//     }
 
-    public remote function put(string path,
-                               http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
-                                                                                returns http:Response|http:ClientError {
-        return getUnsupportedFOError();
-    }
+//     public remote function put(string path,
+//                                http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
+//                                                                                 returns http:Response|http:ClientError {
+//         return getUnsupportedFOError();
+//     }
 
-    public remote function execute(string httpVerb, string path,
-                                   http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|()
-                                        message) returns http:Response|http:ClientError {
-        return getUnsupportedFOError();
-    }
+//     public remote function execute(string httpVerb, string path,
+//                                    http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|()
+//                                         message) returns http:Response|http:ClientError {
+//         return getUnsupportedFOError();
+//     }
 
-    public remote function patch(string path,
-                           http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
-                                                                                returns http:Response|http:ClientError {
-        return getUnsupportedFOError();
-    }
+//     public remote function patch(string path,
+//                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
+//                                                                                 returns http:Response|http:ClientError {
+//         return getUnsupportedFOError();
+//     }
 
-    public remote function delete(string path,
-                           http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
-                                                                                returns http:Response|http:ClientError {
-        return getUnsupportedFOError();
-    }
+//     public remote function delete(string path,
+//                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
+//                                                                                 returns http:Response|http:ClientError {
+//         return getUnsupportedFOError();
+//     }
 
-    public remote function get(string path,
-                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
-                                                                                returns http:Response|http:ClientError {
-        http:Response response = new;
-        var result = handleFailoverScenario(counter);
-        if (result is http:Response) {
-            response = result;
-        } else {
-            string errMessage = result.message();
-            response.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
-            response.setTextPayload(errMessage);
-        }
-        return response;
-    }
+//     public remote function get(string path,
+//                             http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
+//                                                                                 returns http:Response|http:ClientError {
+//         http:Response response = new;
+//         var result = handleFailoverScenario(counter);
+//         if (result is http:Response) {
+//             response = result;
+//         } else {
+//             string errMessage = result.message();
+//             response.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
+//             response.setTextPayload(errMessage);
+//         }
+//         return response;
+//     }
 
-    public remote function options(string path,
-           http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message = ())
-                                                                                returns http:Response|http:ClientError {
-        return getUnsupportedFOError();
-    }
+//     public remote function options(string path,
+//            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message = ())
+//                                                                                 returns http:Response|http:ClientError {
+//         return getUnsupportedFOError();
+//     }
 
-    public remote function forward(string path, http:Request req) returns http:Response|http:ClientError {
-        return getUnsupportedFOError();
-    }
+//     public remote function forward(string path, http:Request req) returns http:Response|http:ClientError {
+//         return getUnsupportedFOError();
+//     }
 
-    public remote function submit(string httpVerb, string path,
-                           http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
-                                                                            returns http:HttpFuture|http:ClientError {
-        return getUnsupportedFOError();
-    }
+//     public remote function submit(string httpVerb, string path,
+//                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
+//                                                                             returns http:HttpFuture|http:ClientError {
+//         return getUnsupportedFOError();
+//     }
 
-    public remote function getResponse(http:HttpFuture httpFuture)  returns http:Response|http:ClientError {
-        return getUnsupportedFOError();
-    }
+//     public remote function getResponse(http:HttpFuture httpFuture)  returns http:Response|http:ClientError {
+//         return getUnsupportedFOError();
+//     }
 
-    public remote function hasPromise(http:HttpFuture httpFuture) returns boolean {
-        return false;
-    }
+//     public remote function hasPromise(http:HttpFuture httpFuture) returns boolean {
+//         return false;
+//     }
 
-    public remote function getNextPromise(http:HttpFuture httpFuture) returns http:PushPromise|http:ClientError {
-        return getUnsupportedFOError();
-    }
+//     public remote function getNextPromise(http:HttpFuture httpFuture) returns http:PushPromise|http:ClientError {
+//         return getUnsupportedFOError();
+//     }
 
-    public remote function getPromisedResponse(http:PushPromise promise) returns http:Response|http:ClientError {
-        return getUnsupportedFOError();
-    }
+//     public remote function getPromisedResponse(http:PushPromise promise) returns http:Response|http:ClientError {
+//         return getUnsupportedFOError();
+//     }
 
-    public remote function rejectPromise(http:PushPromise promise) {
-    }
+//     public remote function rejectPromise(http:PushPromise promise) {
+//     }
 
-    public function getCookieStore() returns http:CookieStore? {
-        return self.cookieStore;
-    }
-}
+//     public function getCookieStore() returns http:CookieStore? {
+//         return self.cookieStore;
+//     }
+// }
 
-function handleFailoverScenario (int count) returns (http:Response | http:ClientError) {
-    if (count == 0) {
-        return http:GenericClientError("Connection refused");
-    } else {
-        http:Response inResponse = new;
-        inResponse.statusCode = http:STATUS_OK;
-        return inResponse;
-    }
-}
+// function handleFailoverScenario (int count) returns (http:Response | http:ClientError) {
+//     if (count == 0) {
+//         return http:GenericClientError("Connection refused");
+//     } else {
+//         http:Response inResponse = new;
+//         inResponse.statusCode = http:STATUS_OK;
+//         return inResponse;
+//     }
+// }
 
-function getUnsupportedFOError() returns http:ClientError {
-    return http:GenericClientError("Unsupported fucntion for MockClient");
-}
+// function getUnsupportedFOError() returns http:ClientError {
+//     return http:GenericClientError("Unsupported fucntion for MockClient");
+// }
 
-function createMockClient(string url) returns FoMockClient {
-    FoMockClient mockClient = new(url);
-    return mockClient;
-}
+// function createMockClient(string url) returns FoMockClient {
+//     FoMockClient mockClient = new(url);
+//     return mockClient;
+// }

--- a/http-ballerina/src/http-tests/tests/unit-tests/resiliency/failover-connector-test.bal
+++ b/http-ballerina/src/http-tests/tests/unit-tests/resiliency/failover-connector-test.bal
@@ -1,230 +1,230 @@
-// // Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-// //
-// // WSO2 Inc. licenses this file to you under the Apache License,
-// // Version 2.0 (the "License"); you may not use this file except
-// // in compliance with the License.
-// // You may obtain a copy of the License at
-// //
-// // http://www.apache.org/licenses/LICENSE-2.0
-// //
-// // Unless required by applicable law or agreed to in writing,
-// // software distributed under the License is distributed on an
-// // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// // KIND, either express or implied.  See the License for the
-// // specific language governing permissions and limitations
-// // under the License.
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
-// import ballerina/io;
-// import ballerina/mime;
-// import ballerina/test;
-// import http;
+import ballerina/io;
+import ballerina/mime;
+import ballerina/test;
+import http;
 
-// int counter = 0;
+int counter = 0;
 
-// // /**
-// //  * Test case scenario:
-// //  * - First endpoint returns HttpConnectorError for the request.
-// //  * - Failover connector should retry the second endpoint.
-// //  * - Second endpoints returns success response.
-// //  */
-// //Test case for failover connector for at least one endpoint send success response.
-// @test:Config {}
-// function testSuccessScenario() {
+// /**
+//  * Test case scenario:
+//  * - First endpoint returns HttpConnectorError for the request.
+//  * - Failover connector should retry the second endpoint.
+//  * - Second endpoints returns success response.
+//  */
+//Test case for failover connector for at least one endpoint send success response.
+@test:Config {}
+function testSuccessScenario() {
 
-//     int counter = 0;
-//     http:FailoverClient backendClientEP = new({
-//         failoverCodes : [400, 500, 502, 503],
-//         targets: [
-//                  {url: "http://invalidEP"},
-//                  {url: "http://localhost:8080"}],
-//         timeoutInMillis:5000
-//     });
+    int counter = 0;
+    http:FailoverClient backendClientEP = new({
+        failoverCodes : [400, 500, 502, 503],
+        targets: [
+                 {url: "http://invalidEP"},
+                 {url: "http://localhost:8080"}],
+        timeoutInMillis:5000
+    });
 
-//     http:Response clientResponse = new;
-//     http:Client?[] httpClients = [createMockClient("http://invalidEP"),
-//                                  createMockClient("http://localhost:8080")];
-//     backendClientEP.failoverInferredConfig.failoverClientsArray = httpClients;
+    http:Response clientResponse = new;
+    http:Client?[] httpClients = [createMockClient("http://invalidEP"),
+                                 createMockClient("http://localhost:8080")];
+    backendClientEP.failoverInferredConfig.failoverClientsArray = httpClients;
 
-//     while (counter < 2) {
-//         http:Request request = new;
-//         var serviceResponse = backendClientEP->get("/hello", request);
-//         if (serviceResponse is http:Response) {
-//             clientResponse = serviceResponse;
-//         } else {
-//             // Ignore the error to verify failover scenario
-//         }
-//         counter = counter + 1;
-//     }
-//     test:assertEquals(clientResponse.statusCode, 200, msg = "Found unexpected output");
-// }
+    while (counter < 2) {
+        http:Request request = new;
+        var serviceResponse = backendClientEP->get("/hello", request);
+        if (serviceResponse is http:Response) {
+            clientResponse = serviceResponse;
+        } else {
+            // Ignore the error to verify failover scenario
+        }
+        counter = counter + 1;
+    }
+    test:assertEquals(clientResponse.statusCode, 200, msg = "Found unexpected output");
+}
 
-// //    /**
-// //     * Test case scenario:
-// //     * - All Endpoints return HttpConnectorError for the requests.
-// //     * - Once all endpoints were tried out failover connector responds with
-// //     * - status code of 500 and the error return from the last endpoint.
-// //     */
-// //Test case for failover connector when all endpoints return error response.
-// @test:Config {}
-// function testFailureScenario() {
-//     var result = failureScenario();
-//     if (result is error) {
-//         test:assertEquals(result.message(), 
-//             "All the failover endpoints failed. Last endpoint returned response is: 500 ", 
-//             msg = "Found unexpected output");
-//     } else {
-//         test:assertFail(msg = "Found unexpected output type");
-//     }
-// }
+//    /**
+//     * Test case scenario:
+//     * - All Endpoints return HttpConnectorError for the requests.
+//     * - Once all endpoints were tried out failover connector responds with
+//     * - status code of 500 and the error return from the last endpoint.
+//     */
+//Test case for failover connector when all endpoints return error response.
+@test:Config {}
+function testFailureScenario() {
+    var result = failureScenario();
+    if (result is error) {
+        test:assertEquals(result.message(), 
+            "All the failover endpoints failed. Last endpoint returned response is: 500 ", 
+            msg = "Found unexpected output");
+    } else {
+        test:assertFail(msg = "Found unexpected output type");
+    }
+}
 
-// function failureScenario() returns @tainted http:Response|error {
-//     int counter = 0;
-//     http:FailoverClient backendClientEP = new({
-//         failoverCodes : [400, 404, 500, 502, 503],
-//         targets: [
-//                  {url: "http://invalidEP"},
-//                  {url: "http://localhost:50000000"}],
-//         timeoutInMillis:5000
-//     });
+function failureScenario() returns @tainted http:Response|error {
+    int counter = 0;
+    http:FailoverClient backendClientEP = new({
+        failoverCodes : [400, 404, 500, 502, 503],
+        targets: [
+                 {url: "http://invalidEP"},
+                 {url: "http://localhost:50000000"}],
+        timeoutInMillis:5000
+    });
 
-//     http:Response response = new;
-//     http:Client?[] httpClients = [createMockClient("http://invalidEP"),
-//                                  createMockClient("http://localhost:50000000")];
-//     backendClientEP.failoverInferredConfig.failoverClientsArray = httpClients;
-//     while (counter < 1) {
-//         http:Request request = new;
-//         var serviceResponse = backendClientEP->get("/hello", request);
-//         if (serviceResponse is http:Response) {
-//             counter = counter + 1;
-//             response = serviceResponse;
-//         } else {
-//             counter = counter + 1;
-//             return serviceResponse;
-//         }
-//     }
-//     return response;
-// }
+    http:Response response = new;
+    http:Client?[] httpClients = [createMockClient("http://invalidEP"),
+                                 createMockClient("http://localhost:50000000")];
+    backendClientEP.failoverInferredConfig.failoverClientsArray = httpClients;
+    while (counter < 1) {
+        http:Request request = new;
+        var serviceResponse = backendClientEP->get("/hello", request);
+        if (serviceResponse is http:Response) {
+            counter = counter + 1;
+            response = serviceResponse;
+        } else {
+            counter = counter + 1;
+            return serviceResponse;
+        }
+    }
+    return response;
+}
 
-// public client class FoMockClient {
-//     public string url = "";
-//     public http:ClientConfiguration config = {};
-//     public http:Client httpClient;
-//     public http:CookieStore? cookieStore = ();
+public client class FoMockClient {
+    public string url = "";
+    public http:ClientConfiguration config = {};
+    public http:Client httpClient;
+    public http:CookieStore? cookieStore = ();
 
-//     public function init(string url, http:ClientConfiguration? config = ()) {
-//         http:Client simpleClient = new(url);
-//         self.url = url;
-//         self.config = config ?: {};
-//         self.cookieStore = ();
-//         self.httpClient = simpleClient;
-//     }
+    public function init(string url, http:ClientConfiguration? config = ()) {
+        http:Client simpleClient = new(url);
+        self.url = url;
+        self.config = config ?: {};
+        self.cookieStore = ();
+        self.httpClient = simpleClient;
+    }
 
-//     public remote function post(string path,
-//                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
-//                                                                                 returns http:Response|http:ClientError {
-//         return getUnsupportedFOError();
-//     }
+    public remote function post(string path,
+                           http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
+                                                                                returns http:Response|http:ClientError {
+        return getUnsupportedFOError();
+    }
 
-//     public remote function head(string path,
-//                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message = ())
-//                                                                                 returns http:Response|http:ClientError {
-//         return getUnsupportedFOError();
-//     }
+    public remote function head(string path,
+                           http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message = ())
+                                                                                returns http:Response|http:ClientError {
+        return getUnsupportedFOError();
+    }
 
-//     public remote function put(string path,
-//                                http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
-//                                                                                 returns http:Response|http:ClientError {
-//         return getUnsupportedFOError();
-//     }
+    public remote function put(string path,
+                               http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
+                                                                                returns http:Response|http:ClientError {
+        return getUnsupportedFOError();
+    }
 
-//     public remote function execute(string httpVerb, string path,
-//                                    http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|()
-//                                         message) returns http:Response|http:ClientError {
-//         return getUnsupportedFOError();
-//     }
+    public remote function execute(string httpVerb, string path,
+                                   http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|()
+                                        message) returns http:Response|http:ClientError {
+        return getUnsupportedFOError();
+    }
 
-//     public remote function patch(string path,
-//                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
-//                                                                                 returns http:Response|http:ClientError {
-//         return getUnsupportedFOError();
-//     }
+    public remote function patch(string path,
+                           http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
+                                                                                returns http:Response|http:ClientError {
+        return getUnsupportedFOError();
+    }
 
-//     public remote function delete(string path,
-//                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
-//                                                                                 returns http:Response|http:ClientError {
-//         return getUnsupportedFOError();
-//     }
+    public remote function delete(string path,
+                           http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
+                                                                                returns http:Response|http:ClientError {
+        return getUnsupportedFOError();
+    }
 
-//     public remote function get(string path,
-//                             http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
-//                                                                                 returns http:Response|http:ClientError {
-//         http:Response response = new;
-//         var result = handleFailoverScenario(counter);
-//         if (result is http:Response) {
-//             response = result;
-//         } else {
-//             string errMessage = result.message();
-//             response.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
-//             response.setTextPayload(errMessage);
-//         }
-//         return response;
-//     }
+    public remote function get(string path,
+                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
+                                                                                returns http:Response|http:ClientError {
+        http:Response response = new;
+        var result = handleFailoverScenario(counter);
+        if (result is http:Response) {
+            response = result;
+        } else {
+            string errMessage = result.message();
+            response.statusCode = http:STATUS_INTERNAL_SERVER_ERROR;
+            response.setTextPayload(errMessage);
+        }
+        return response;
+    }
 
-//     public remote function options(string path,
-//            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message = ())
-//                                                                                 returns http:Response|http:ClientError {
-//         return getUnsupportedFOError();
-//     }
+    public remote function options(string path,
+           http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message = ())
+                                                                                returns http:Response|http:ClientError {
+        return getUnsupportedFOError();
+    }
 
-//     public remote function forward(string path, http:Request req) returns http:Response|http:ClientError {
-//         return getUnsupportedFOError();
-//     }
+    public remote function forward(string path, http:Request req) returns http:Response|http:ClientError {
+        return getUnsupportedFOError();
+    }
 
-//     public remote function submit(string httpVerb, string path,
-//                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
-//                                                                             returns http:HttpFuture|http:ClientError {
-//         return getUnsupportedFOError();
-//     }
+    public remote function submit(string httpVerb, string path,
+                           http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
+                                                                            returns http:HttpFuture|http:ClientError {
+        return getUnsupportedFOError();
+    }
 
-//     public remote function getResponse(http:HttpFuture httpFuture)  returns http:Response|http:ClientError {
-//         return getUnsupportedFOError();
-//     }
+    public remote function getResponse(http:HttpFuture httpFuture)  returns http:Response|http:ClientError {
+        return getUnsupportedFOError();
+    }
 
-//     public remote function hasPromise(http:HttpFuture httpFuture) returns boolean {
-//         return false;
-//     }
+    public remote function hasPromise(http:HttpFuture httpFuture) returns boolean {
+        return false;
+    }
 
-//     public remote function getNextPromise(http:HttpFuture httpFuture) returns http:PushPromise|http:ClientError {
-//         return getUnsupportedFOError();
-//     }
+    public remote function getNextPromise(http:HttpFuture httpFuture) returns http:PushPromise|http:ClientError {
+        return getUnsupportedFOError();
+    }
 
-//     public remote function getPromisedResponse(http:PushPromise promise) returns http:Response|http:ClientError {
-//         return getUnsupportedFOError();
-//     }
+    public remote function getPromisedResponse(http:PushPromise promise) returns http:Response|http:ClientError {
+        return getUnsupportedFOError();
+    }
 
-//     public remote function rejectPromise(http:PushPromise promise) {
-//     }
+    public remote function rejectPromise(http:PushPromise promise) {
+    }
 
-//     public function getCookieStore() returns http:CookieStore? {
-//         return self.cookieStore;
-//     }
-// }
+    public function getCookieStore() returns http:CookieStore? {
+        return self.cookieStore;
+    }
+}
 
-// function handleFailoverScenario (int count) returns (http:Response | http:ClientError) {
-//     if (count == 0) {
-//         return http:GenericClientError("Connection refused");
-//     } else {
-//         http:Response inResponse = new;
-//         inResponse.statusCode = http:STATUS_OK;
-//         return inResponse;
-//     }
-// }
+function handleFailoverScenario (int count) returns (http:Response | http:ClientError) {
+    if (count == 0) {
+        return http:GenericClientError("Connection refused");
+    } else {
+        http:Response inResponse = new;
+        inResponse.statusCode = http:STATUS_OK;
+        return inResponse;
+    }
+}
 
-// function getUnsupportedFOError() returns http:ClientError {
-//     return http:GenericClientError("Unsupported fucntion for MockClient");
-// }
+function getUnsupportedFOError() returns http:ClientError {
+    return http:GenericClientError("Unsupported function for MockClient");
+}
 
-// function createMockClient(string url) returns FoMockClient {
-//     FoMockClient mockClient = new(url);
-//     return mockClient;
-// }
+function createMockClient(string url) returns FoMockClient {
+    FoMockClient mockClient = new(url);
+    return mockClient;
+}

--- a/http-ballerina/src/http-tests/tests/unit-tests/services/dispatching/uri-template-matching.bal
+++ b/http-ballerina/src/http-tests/tests/unit-tests/services/dispatching/uri-template-matching.bal
@@ -824,14 +824,16 @@ function testIntegerQueryParam() {
 function testFloatQueryParam() {
     var response = utmClient->get("/hello/echo14?foo=1.11");
     if (response is http:Response) {
-        assertJsonValue(response.getJsonPayload(), "echo14", 1.11);
+        decimal dValue = 1.11;
+        assertJsonValue(response.getJsonPayload(), "echo14", dValue);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }
 
     response = utmClient->get("/hello/echo14?foo=");
     if (response is http:Response) {
-        assertJsonValue(response.getJsonPayload(), "echo14", 0.0);
+        decimal dValue = 0.0;
+        assertJsonValue(response.getJsonPayload(), "echo14", dValue);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }
@@ -1104,9 +1106,10 @@ function testTwistedPathSegmentsInTheSignature() {
 function testMultiTypePathSegmentsInTheSignature() {
     var response = utmClient->get("/uri/type/20/ballerina/true/15.6");
     if (response is http:Response) {
+        decimal dValue = 18.55;
         assertJsonValue(response.getJsonPayload(), "Name", "ballerina");
         assertJsonValue(response.getJsonPayload(), "Age", 21);
-        assertJsonValue(response.getJsonPayload(), "Weight", 18.55);
+        assertJsonValue(response.getJsonPayload(), "Weight", dValue);
         assertJsonValue(response.getJsonPayload(), "Status", true);
         assertJsonValue(response.getJsonPayload(), "Lang", "ballerina");
     } else {
@@ -1115,9 +1118,10 @@ function testMultiTypePathSegmentsInTheSignature() {
 
     response = utmClient->get("/uri/type/120/hello/false/15.9");
     if (response is http:Response) {
+        decimal dValue = 18.85;
         assertJsonValue(response.getJsonPayload(), "Name", "hello");
         assertJsonValue(response.getJsonPayload(), "Age", 121);
-        assertJsonValue(response.getJsonPayload(), "Weight", 18.85);
+        assertJsonValue(response.getJsonPayload(), "Weight", dValue);
         assertJsonValue(response.getJsonPayload(), "Status", false);
         assertJsonValue(response.getJsonPayload(), "Lang", "hello false");
     } else {

--- a/http-ballerina/src/http/auth/authn_filter.bal
+++ b/http-ballerina/src/http/auth/authn_filter.bal
@@ -26,7 +26,7 @@ public class AuthnFilter {
     # Initializes the `AuthnFilter` object.
     #
     # + authHandlers - An array of authentication handlers or an array consisting of arrays of authentication handlers
-    public function init(InboundAuthHandlers authHandlers) {
+    public isolated function init(InboundAuthHandlers authHandlers) {
         self.authHandlers = authHandlers;
     }
 
@@ -36,7 +36,7 @@ public class AuthnFilter {
     # + request - An inbound HTTP request message
     # + context - The `http:FilterContext` instance
     # + return - A flag to indicate if the request flow should be continued(true) or aborted(false)
-    public function filterRequest(Caller caller, Request request, FilterContext context) returns boolean {
+    public isolated function filterRequest(Caller caller, Request request, FilterContext context) returns boolean {
         boolean|AuthenticationError authenticated = true;
         InboundAuthHandlers|boolean authHandlers = getAuthHandlers(context);
         if (authHandlers is InboundAuthHandlers) {
@@ -54,7 +54,7 @@ public class AuthnFilter {
     }
 }
 
-function handleAuthRequest(InboundAuthHandlers authHandlers, Request request) returns boolean|AuthenticationError {
+isolated function handleAuthRequest(InboundAuthHandlers authHandlers, Request request) returns boolean|AuthenticationError {
     if (authHandlers is InboundAuthHandler[]) {
         return checkForAuthHandlers(authHandlers, request);
     } else {
@@ -72,7 +72,7 @@ function handleAuthRequest(InboundAuthHandlers authHandlers, Request request) re
     }
 }
 
-function checkForAuthHandlers(InboundAuthHandler[] authHandlers, Request request) returns boolean|AuthenticationError {
+isolated function checkForAuthHandlers(InboundAuthHandler[] authHandlers, Request request) returns boolean|AuthenticationError {
     AuthenticationError? err = ();
     foreach InboundAuthHandler authHandler in authHandlers {
         boolean canProcessResponse = authHandler.canProcess(request);
@@ -96,7 +96,7 @@ function checkForAuthHandlers(InboundAuthHandler[] authHandlers, Request request
     return false;
 }
 
-function send401(Caller caller, FilterContext context) {
+isolated function send401(Caller caller, FilterContext context) {
     if (isWebSocketUpgradeRequest(context)) {
         error? err = caller->cancelWebSocketUpgrade(401, "Authentication failure.");
         if (err is error) {

--- a/http-ballerina/src/http/auth/authz_filter.bal
+++ b/http-ballerina/src/http/auth/authz_filter.bal
@@ -29,7 +29,7 @@ public class AuthzFilter {
     #
     # + authzHandler - The `http:AuthzHandler` instance for handling authorization
     # + scopes - An array of scopes or an array consisting of arrays of scopes
-    public function init(AuthzHandler authzHandler, Scopes? scopes) {
+    public isolated function init(AuthzHandler authzHandler, Scopes? scopes) {
         self.authzHandler = authzHandler;
         self.scopes = scopes;
     }
@@ -40,7 +40,7 @@ public class AuthzFilter {
     # + request - An inbound HTTP request message
     # + context - The `http:FilterContext` instance
     # + return - A flag to indicate if the request flow should be continued(true) or aborted(false)
-    public function filterRequest(Caller caller, Request request, FilterContext context) returns boolean {
+    public isolated function filterRequest(Caller caller, Request request, FilterContext context) returns boolean {
         boolean|AuthorizationError authorized = true;
         Scopes|boolean scopes = getScopes(context);
         if (scopes is Scopes) {
@@ -67,7 +67,7 @@ public class AuthzFilter {
     }
 }
 
-function send403(Caller caller, FilterContext context) {
+isolated function send403(Caller caller, FilterContext context) {
     if (isWebSocketUpgradeRequest(context)) {
         error? err = caller->cancelWebSocketUpgrade(403, "Authorization failure.");
         if (err is error) {

--- a/http-ballerina/src/http/auth/basic_auth_handler.bal
+++ b/http-ballerina/src/http/auth/basic_auth_handler.bal
@@ -27,7 +27,7 @@ public class BasicAuthHandler {
     # Initializes the `BasicAuthHandler` object.
     #
     # + authProvider - The `auth:InboundAuthProvider` instance or the `auth:OutboundAuthProvider` instance
-    public function init(auth:InboundAuthProvider|auth:OutboundAuthProvider authProvider) {
+    public isolated function init(auth:InboundAuthProvider|auth:OutboundAuthProvider authProvider) {
         self.authProvider = authProvider;
     }
 
@@ -35,7 +35,7 @@ public class BasicAuthHandler {
     #
     # + req - The `http:Request` instance
     # + return - `true` if authentication is successful or else `false`
-    public function canProcess(Request req) returns @tainted boolean {
+    public isolated function canProcess(Request req) returns @tainted boolean {
         if (req.hasHeader(AUTH_HEADER)) {
             string headerValue = extractAuthorizationHeaderValue(req);
             return headerValue.startsWith(auth:AUTH_SCHEME_BASIC);
@@ -48,7 +48,7 @@ public class BasicAuthHandler {
     # + req - The `http:Request` instance
     # + return - `true` if it is possible to authenticate with Basic Auth, `false` otherwise, or else
     #                 an `http:AuthenticationError` in case of an error
-    public function process(Request req) returns boolean|AuthenticationError {
+    public isolated function process(Request req) returns boolean|AuthenticationError {
         string headerValue = extractAuthorizationHeaderValue(req);
         string credential = headerValue.substring(5, headerValue.length());
         credential = credential.trim();
@@ -69,7 +69,7 @@ public class BasicAuthHandler {
     #
     # + req - The `http:Request` instance
     # + return - The updated `http:Request` instance or else an `http:AuthenticationError` in case of an error
-    public function prepare(Request req) returns Request|AuthenticationError {
+    public isolated function prepare(Request req) returns Request|AuthenticationError {
         auth:InboundAuthProvider|auth:OutboundAuthProvider authProvider = self.authProvider;
         if (authProvider is auth:OutboundAuthProvider) {
             string|auth:Error token = authProvider.generateToken();
@@ -90,7 +90,7 @@ public class BasicAuthHandler {
     # + resp - The `http:Response` instance
     # + return - The updated `http:Request` instance or the `http:AuthenticationError` in case of an error
     #                 or else `()` if nothing is to be returned
-    public function inspect(Request req, Response resp) returns Request|AuthenticationError? {
+    public isolated function inspect(Request req, Response resp) returns Request|AuthenticationError? {
         auth:InboundAuthProvider|auth:OutboundAuthProvider authProvider = self.authProvider;
         if (authProvider is auth:OutboundAuthProvider) {
             map<anydata> headerMap = createResponseHeaderMap(resp);

--- a/http-ballerina/src/http/auth/bearer_auth_handler.bal
+++ b/http-ballerina/src/http/auth/bearer_auth_handler.bal
@@ -27,7 +27,7 @@ public class BearerAuthHandler {
     # Initializes the `BearerAuthHandler` object.
     #
     # + authProvider - The `auth:InboundAuthProvider` instance or the `auth:OutboundAuthProvider` instance
-    public function init(auth:InboundAuthProvider|auth:OutboundAuthProvider authProvider) {
+    public isolated function init(auth:InboundAuthProvider|auth:OutboundAuthProvider authProvider) {
         self.authProvider = authProvider;
     }
 
@@ -35,7 +35,7 @@ public class BearerAuthHandler {
     #
     # + req - The `http:Request` instance
     # + return - `true` if it can be authenticated or else `false`
-    public function canProcess(Request req) returns @tainted boolean {
+    public isolated function canProcess(Request req) returns @tainted boolean {
         if (req.hasHeader(AUTH_HEADER)) {
             string headerValue = extractAuthorizationHeaderValue(req);
             return headerValue.startsWith(auth:AUTH_SCHEME_BEARER);
@@ -48,7 +48,7 @@ public class BearerAuthHandler {
     # + req - The `http:Request` instance
     # + return - `true` if authenticated successfully, `false` otherwise,
     #                 or else an `http:AuthenticationError` in case of an error
-    public function process(Request req) returns boolean|AuthenticationError {
+    public isolated function process(Request req) returns boolean|AuthenticationError {
         string headerValue = extractAuthorizationHeaderValue(req);
         string credential = headerValue.substring(6, headerValue.length()).trim();
         auth:InboundAuthProvider|auth:OutboundAuthProvider authProvider = self.authProvider;
@@ -68,7 +68,7 @@ public class BearerAuthHandler {
     #
     # + req - The`http:Request` instance
     # + return - The updated `http:Request` instance or else an `http:AuthenticationError` in case of an error
-    public function prepare(Request req) returns Request|AuthenticationError {
+    public isolated function prepare(Request req) returns Request|AuthenticationError {
         auth:InboundAuthProvider|auth:OutboundAuthProvider authProvider = self.authProvider;
         if (authProvider is auth:OutboundAuthProvider) {
             string|auth:Error token = authProvider.generateToken();
@@ -89,7 +89,7 @@ public class BearerAuthHandler {
     # + resp - The `http:Response` instance
     # + return - The updated `http:Request` instance, an `http:AuthenticationError` in case of an error,
     #                 or else `()` if nothing is to be returned
-    public function inspect(Request req, Response resp) returns Request|AuthenticationError? {
+    public isolated function inspect(Request req, Response resp) returns Request|AuthenticationError? {
         auth:InboundAuthProvider|auth:OutboundAuthProvider authProvider = self.authProvider;
         if (authProvider is auth:OutboundAuthProvider) {
             map<anydata> headerMap = createResponseHeaderMap(resp);

--- a/http-ballerina/src/http/auth/inbound_auth_handler.bal
+++ b/http-ballerina/src/http/auth/inbound_auth_handler.bal
@@ -21,11 +21,11 @@ public type InboundAuthHandler object {
     #
     # + req - The `http:Request` instance
     # + return - `true` if it can be authenticated or else `false`
-    public function canProcess(Request req) returns boolean;
+    public isolated function canProcess(Request req) returns boolean;
 
     # Tries to authenticate the request with the relevant `InboundAuthHandler` implementation.
     #
     # + req - The `http:Request` instance
     # + return - `true` if it authenticated successfully, `false` otherwise, or else an `http:AuthenticationError` in case of errors
-    public function process(Request req) returns boolean|AuthenticationError;
+    public isolated function process(Request req) returns boolean|AuthenticationError;
 };

--- a/http-ballerina/src/http/auth/outbound_auth_handler.bal
+++ b/http-ballerina/src/http/auth/outbound_auth_handler.bal
@@ -21,7 +21,7 @@ public type OutboundAuthHandler object {
     #
     # + req - The `http:Request` instance
     # + return - The updated `http:Request` instance or else an `http:AuthenticationError` in case of an error
-    public function prepare(Request req) returns Request|AuthenticationError;
+    public isolated function prepare(Request req) returns Request|AuthenticationError;
 
     # Inspects the request and response and evaluates what is to be done.
     #
@@ -29,5 +29,5 @@ public type OutboundAuthHandler object {
     # + resp - The `http:Response` instance
     # + return - The updated `http:Request` instance, an `http:AuthenticationError` in case of an error,
     #                 or else `()` if nothing is to be returned
-    public function inspect(Request req, Response resp) returns Request|AuthenticationError?;
+    public isolated function inspect(Request req, Response resp) returns Request|AuthenticationError?;
 };

--- a/http-ballerina/src/http/auth/utils.bal
+++ b/http-ballerina/src/http/auth/utils.bal
@@ -52,7 +52,7 @@ public type Scopes string[]|string[][];
 #
 # + req - The `Request` instance
 # + return - Value of the Authorization header
-public function extractAuthorizationHeaderValue(Request req) returns @tainted string {
+public isolated function extractAuthorizationHeaderValue(Request req) returns @tainted string {
     // extract authorization header
     return req.getHeader(AUTH_HEADER);
 }
@@ -61,7 +61,7 @@ public function extractAuthorizationHeaderValue(Request req) returns @tainted st
 #
 # + context - The `FilterContext` instance
 # + return - The status of calling resource is secured or not
-public function isResourceSecured(FilterContext context) returns boolean {
+public isolated function isResourceSecured(FilterContext context) returns boolean {
     ResourceAuth? resourceLevelAuthAnn = getResourceAuthConfig(context);
     ServiceAuth? serviceLevelAuthAnn = getServiceAuthConfig(context);
 
@@ -80,7 +80,7 @@ public function isResourceSecured(FilterContext context) returns boolean {
 #
 # + context - The `FilterContext` instance
 # + return - The authentication handlers or a boolean value indicating whether it is needed to engage listener-level handlers or not
-function getAuthHandlers(FilterContext context) returns InboundAuthHandlers|boolean {
+isolated function getAuthHandlers(FilterContext context) returns InboundAuthHandlers|boolean {
     ResourceAuth? resourceLevelAuthAnn = getResourceAuthConfig(context);
     ServiceAuth? serviceLevelAuthAnn = getServiceAuthConfig(context);
 
@@ -91,7 +91,7 @@ function getAuthHandlers(FilterContext context) returns InboundAuthHandlers|bool
     if (resourceSecured is boolean) {
         // if resource is not secured, no need to check further.
         if (!resourceSecured) {
-            log:printDebug(function () returns string {
+            log:printDebug(isolated function () returns string {
                 return "Resource is not secured. `enabled: false`.";
             });
             return false;
@@ -135,7 +135,7 @@ function getAuthHandlers(FilterContext context) returns InboundAuthHandlers|bool
         }
         // if service is not secured, no need to check further.
         if (!serviceSecured) {
-            log:printDebug(function () returns string {
+            log:printDebug(isolated function () returns string {
                 return "Service is not secured. `enabled: false`.";
             });
             return false;
@@ -156,7 +156,7 @@ function getAuthHandlers(FilterContext context) returns InboundAuthHandlers|bool
 #
 # + context - `FilterContext` instance
 # + return - Authorization scopes or whether it is needed to engage listener level scopes or not
-function getScopes(FilterContext context) returns Scopes|boolean {
+isolated function getScopes(FilterContext context) returns Scopes|boolean {
     ResourceAuth? resourceLevelAuthAnn = getResourceAuthConfig(context);
     ServiceAuth? serviceLevelAuthAnn = getServiceAuthConfig(context);
 
@@ -167,7 +167,7 @@ function getScopes(FilterContext context) returns Scopes|boolean {
     if (resourceSecured is boolean) {
         // if resource is not secured, no need to check further.
         if (!resourceSecured) {
-            log:printDebug(function () returns string {
+            log:printDebug(isolated function () returns string {
                 return "Resource is not secured. `enabled: false`.";
             });
             return false;
@@ -211,7 +211,7 @@ function getScopes(FilterContext context) returns Scopes|boolean {
         }
         // if service is not secured, no need to check further.
         if (!serviceSecured) {
-            log:printDebug(function () returns string {
+            log:printDebug(isolated function () returns string {
                 return "Service is not secured. `enabled: false`.";
             });
             return false;
@@ -231,7 +231,7 @@ function getScopes(FilterContext context) returns Scopes|boolean {
 #
 # + context - The `FilterContext` instance
 # + return - The service-level authentication annotations or else `()`
-function getServiceAuthConfig(FilterContext context) returns ServiceAuth? {
+isolated function getServiceAuthConfig(FilterContext context) returns ServiceAuth? {
     any annData = reflect:getServiceAnnotations(context.getService(), SERVICE_ANN_NAME, ANN_MODULE);
     if (!(annData is ())) {
         HttpServiceConfig serviceConfig = <HttpServiceConfig> annData;
@@ -243,7 +243,7 @@ function getServiceAuthConfig(FilterContext context) returns ServiceAuth? {
 #
 # + context - The `FilterContext` instance
 # + return - The resource-level and service-level authentication annotations
-function getResourceAuthConfig(FilterContext context) returns ResourceAuth? {
+isolated function getResourceAuthConfig(FilterContext context) returns ResourceAuth? {
     any annData = reflect:getResourceAnnotations(context.getService(), context.getResourceName(), RESOURCE_ANN_NAME,
                                                  ANN_MODULE);
     if (!(annData is ())) {
@@ -256,7 +256,7 @@ function getResourceAuthConfig(FilterContext context) returns ResourceAuth? {
 #
 # + context - The `FilterContext` instance
 # + return - Whether the `http:ResourceConfig` has `http:WebSocketUpgradeConfig` or not
-function isWebSocketUpgradeRequest(FilterContext context) returns boolean {
+isolated function isWebSocketUpgradeRequest(FilterContext context) returns boolean {
     any annData = reflect:getResourceAnnotations(context.getService(), context.getResourceName(), RESOURCE_ANN_NAME,
                                                  ANN_MODULE);
     if (annData is ()) {
@@ -273,7 +273,7 @@ function isWebSocketUpgradeRequest(FilterContext context) returns boolean {
 #
 # + serviceAuth - Service auth annotation
 # + return - Whether the service is secured or not
-function isServiceAuthEnabled(ServiceAuth? serviceAuth) returns boolean {
+isolated function isServiceAuthEnabled(ServiceAuth? serviceAuth) returns boolean {
     if (serviceAuth is ServiceAuth) {
         return serviceAuth.enabled;
     }
@@ -284,7 +284,7 @@ function isServiceAuthEnabled(ServiceAuth? serviceAuth) returns boolean {
 #
 # + resourceAuth - Resource auth annotation
 # + return - Whether the resource is secured or not
-function isResourceAuthEnabled(ResourceAuth? resourceAuth) returns boolean? {
+isolated function isResourceAuthEnabled(ResourceAuth? resourceAuth) returns boolean? {
     if (resourceAuth is ResourceAuth) {
         return resourceAuth?.enabled;
     }
@@ -294,7 +294,7 @@ function isResourceAuthEnabled(ResourceAuth? resourceAuth) returns boolean? {
 #
 # + resp - The `Response` instance
 # + return - The map of the response headers
-function createResponseHeaderMap(Response resp) returns @tainted map<anydata> {
+isolated function createResponseHeaderMap(Response resp) returns @tainted map<anydata> {
     map<anydata> headerMap = { STATUS_CODE: resp.statusCode };
     string[] headerNames = resp.getHeaderNames();
     foreach string header in headerNames {
@@ -309,8 +309,9 @@ function createResponseHeaderMap(Response resp) returns @tainted map<anydata> {
 # + message -The error message
 # + err - The `error` instance
 # + return - The prepared `http:AuthenticationError` instance
-function prepareAuthenticationError(string message, error? err = ()) returns AuthenticationError {
-    log:printDebug(function () returns string { return message; });
+isolated function prepareAuthenticationError(string message, error? err = ()) returns AuthenticationError {
+    final string messageValue = message;
+    log:printDebug(isolated function () returns string { return messageValue; });
     if (err is error) {
         return AuthenticationError(message, err);
     }
@@ -322,8 +323,9 @@ function prepareAuthenticationError(string message, error? err = ()) returns Aut
 # + message -The error message
 # + err - The `error` instance
 # + return - The prepared `http:AuthorizationError` instance
-function prepareAuthorizationError(string message, error? err = ()) returns AuthorizationError {
-    log:printDebug(function () returns string { return message; });
+isolated function prepareAuthorizationError(string message, error? err = ()) returns AuthorizationError {
+    final string messageValue = message;
+    log:printDebug(isolated function () returns string { return messageValue; });
     if (err is error) {
         return AuthorizationError(message, err);
     }

--- a/http-ballerina/src/http/caching/cache_control_utils.bal
+++ b/http-ballerina/src/http/caching/cache_control_utils.bal
@@ -17,14 +17,14 @@
 import ballerina/lang.'int;
 import ballerina/stringutils;
 
-function appendFields (string[] fields) returns string {
+isolated function appendFields (string[] fields) returns string {
     if (fields.length() > 0) {
         return "=\"" + buildCommaSeparatedString(fields) + "\"";
     }
     return "";
 }
 
-function buildCommaSeparatedString (string[] values) returns string {
+isolated function buildCommaSeparatedString (string[] values) returns string {
     string delimitedValues = values[0];
     int arrLength = values.length();
 
@@ -37,7 +37,7 @@ function buildCommaSeparatedString (string[] values) returns string {
     return delimitedValues;
 }
 
-function getDirectiveValue (string directive) returns int {
+isolated function getDirectiveValue (string directive) returns int {
     string[] directiveParts = stringutils:split(directive, "=");
 
     // Disregarding the directive if a value isn't provided

--- a/http-ballerina/src/http/caching/cached_response_validation.bal
+++ b/http-ballerina/src/http/caching/cached_response_validation.bal
@@ -17,7 +17,7 @@
 import ballerina/log;
 import ballerina/time;
 
-function getValidationResponse(HttpClient httpClient, Request req, Response cachedResponse, HttpCache cache,
+isolated function getValidationResponse(HttpClient httpClient, Request req, Response cachedResponse, HttpCache cache,
                                time:Time currentT, string path, string httpMethod, boolean isFreshResponse)
                                                                                 returns @tainted Response|ClientError {
     // If the no-cache directive is set, always validate the response before serving
@@ -74,7 +74,7 @@ function getValidationResponse(HttpClient httpClient, Request req, Response cach
 }
 
 // Based https://tools.ietf.org/html/rfc7234#section-4.3.1
-function sendValidationRequest(HttpClient httpClient, string path, Request originalRequest, Response cachedResponse)
+isolated function sendValidationRequest(HttpClient httpClient, string path, Request originalRequest, Response cachedResponse)
                                 returns Response|ClientError {
     // Set the precondition headers only if the user hasn't explicitly set them.
     boolean userProvidedINMHeader = originalRequest.hasHeader(IF_NONE_MATCH);
@@ -104,7 +104,7 @@ function sendValidationRequest(HttpClient httpClient, string path, Request origi
 }
 
 // Based on https://tools.ietf.org/html/rfc7234#section-4.3.4
-function handle304Response(Response validationResponse, Response cachedResponse, HttpCache cache, string path,
+isolated function handle304Response(Response validationResponse, Response cachedResponse, HttpCache cache, string path,
                            string httpMethod) returns @tainted Response|ClientError {
     if (validationResponse.hasHeader(ETAG)) {
         string etag = validationResponse.getHeader(ETAG);
@@ -144,12 +144,12 @@ function handle304Response(Response validationResponse, Response cachedResponse,
 }
 
 // Based on https://tools.ietf.org/html/rfc7234#section-4.3.4
-function hasAWeakValidator(Response validationResponse, string etag) returns boolean {
+isolated function hasAWeakValidator(Response validationResponse, string etag) returns boolean {
     return (validationResponse.hasHeader(LAST_MODIFIED) || !isAStrongValidator(etag));
 }
 
 // Based on https://tools.ietf.org/html/rfc7234#section-4.3.4
-function isAStrongValidator(string etag) returns boolean {
+isolated function isAStrongValidator(string etag) returns boolean {
     // TODO: Consider cases where Last-Modified can also be treated as a strong validator as per
     // https://tools.ietf.org/html/rfc7232#section-2.2.2
     if (!etag.startsWith(WEAK_VALIDATOR_TAG)) {

--- a/http-ballerina/src/http/caching/cached_response_validation.bal
+++ b/http-ballerina/src/http/caching/cached_response_validation.bal
@@ -17,7 +17,7 @@
 import ballerina/log;
 import ballerina/time;
 
-isolated function getValidationResponse(HttpClient httpClient, Request req, Response cachedResponse, HttpCache cache,
+function getValidationResponse(HttpClient httpClient, Request req, Response cachedResponse, HttpCache cache,
                                time:Time currentT, string path, string httpMethod, boolean isFreshResponse)
                                                                                 returns @tainted Response|ClientError {
     // If the no-cache directive is set, always validate the response before serving
@@ -74,7 +74,7 @@ isolated function getValidationResponse(HttpClient httpClient, Request req, Resp
 }
 
 // Based https://tools.ietf.org/html/rfc7234#section-4.3.1
-isolated function sendValidationRequest(HttpClient httpClient, string path, Request originalRequest, Response cachedResponse)
+function sendValidationRequest(HttpClient httpClient, string path, Request originalRequest, Response cachedResponse)
                                 returns Response|ClientError {
     // Set the precondition headers only if the user hasn't explicitly set them.
     boolean userProvidedINMHeader = originalRequest.hasHeader(IF_NONE_MATCH);

--- a/http-ballerina/src/http/caching/constants.bal
+++ b/http-ballerina/src/http/caching/constants.bal
@@ -77,12 +77,12 @@ final string WARNING_111_REVALIDATION_FAILED = "111 " + WARNING_AGENT + " \"Reva
 const string WEAK_VALIDATOR_TAG = "W/";
 const int STALE = 0;
 
-function getWarningAgent() returns string {
+isolated function getWarningAgent() returns string {
     string ballerinaVersion = getProperty("ballerina.version");
     return "ballerina-http-caching-client/" + ballerinaVersion;
 }
 
-function getProperty(@untainted string name) returns string = @java:Method {
+isolated function getProperty(@untainted string name) returns string = @java:Method {
     name: "getProperty",
     'class: "org.ballerinalang.net.http.util.CacheUtils"
 } external;

--- a/http-ballerina/src/http/caching/freshness_lifetime_calculation.bal
+++ b/http-ballerina/src/http/caching/freshness_lifetime_calculation.bal
@@ -16,14 +16,14 @@
 
 import ballerina/time;
 
-function isFreshResponse(Response cachedResponse, boolean isSharedCache) returns @tainted boolean {
+isolated function isFreshResponse(Response cachedResponse, boolean isSharedCache) returns @tainted boolean {
     int currentAge = getResponseAge(cachedResponse);
     int freshnessLifetime = getFreshnessLifetime(cachedResponse, isSharedCache);
     return freshnessLifetime > currentAge;
 }
 
 // Based on https://tools.ietf.org/html/rfc7234#section-4.2.1
-function getFreshnessLifetime(Response cachedResponse, boolean isSharedCache) returns int {
+isolated function getFreshnessLifetime(Response cachedResponse, boolean isSharedCache) returns int {
     // TODO: Ensure that duplicate directives are not counted towards freshness lifetime.
     var responseCacheControl = cachedResponse.cacheControl;
     if (responseCacheControl is ResponseCacheControl) {

--- a/http-ballerina/src/http/caching/http_cache.bal
+++ b/http-ballerina/src/http/caching/http_cache.bal
@@ -34,7 +34,7 @@ public class HttpCache {
     # Creates the HTTP cache.
     #
     # + cacheConfig - The configurations for the HTTP cache
-    public function init(CacheConfig cacheConfig) {
+    public isolated function init(CacheConfig cacheConfig) {
         cache:CacheConfig config = {
             capacity: cacheConfig.capacity,
             evictionFactor: cacheConfig.evictionFactor
@@ -44,7 +44,7 @@ public class HttpCache {
         self.isShared = cacheConfig.isShared;
     }
 
-    function isAllowedToCache(Response response) returns boolean {
+    isolated function isAllowedToCache(Response response) returns boolean {
         if (self.policy == CACHE_CONTROL_AND_VALIDATORS) {
             return response.hasHeader(CACHE_CONTROL) && (response.hasHeader(ETAG) || response.hasHeader(LAST_MODIFIED));
         }
@@ -52,7 +52,7 @@ public class HttpCache {
         return true;
     }
 
-    function put(string key, RequestCacheControl? requestCacheControl, Response inboundResponse) {
+    isolated function put(string key, RequestCacheControl? requestCacheControl, Response inboundResponse) {
         if (self.isNonCacheableResponse(requestCacheControl, inboundResponse.cacheControl)) {
             return;
         }
@@ -67,7 +67,7 @@ public class HttpCache {
     }
 
     // TODO: Need to consider https://tools.ietf.org/html/rfc7234#section-3.2 as well here
-    private function isNonCacheableResponse(RequestCacheControl? reqCC, ResponseCacheControl? resCC) returns boolean {
+    private isolated function isNonCacheableResponse(RequestCacheControl? reqCC, ResponseCacheControl? resCC) returns boolean {
         if (resCC is ResponseCacheControl) {
             if (resCC.noStore || (self.isShared && resCC.isPrivate)) {
                 return true;
@@ -79,7 +79,7 @@ public class HttpCache {
 
     // Based on https://tools.ietf.org/html/rfc7234#page-6
     // TODO: Consider cache control extensions as well here
-    private function isCacheableResponse(Response inboundResp) returns boolean {
+    private isolated function isCacheableResponse(Response inboundResp) returns boolean {
         ResponseCacheControl? respCC = inboundResp.cacheControl;
         boolean allowedByCacheControl = false;
 
@@ -92,16 +92,16 @@ public class HttpCache {
         return allowedByCacheControl || inboundResp.hasHeader(EXPIRES) || isCacheableStatusCode(inboundResp.statusCode);
     }
 
-    function hasKey(string key) returns boolean {
+    isolated function hasKey(string key) returns boolean {
         return self.cache.hasKey(key);
     }
 
-    function get(string key) returns Response {
+    isolated function get(string key) returns Response {
         Response[] cacheEntry = <Response[]> self.cache.get(key);
         return cacheEntry[cacheEntry.length() - 1];
     }
 
-    function getAll(string key) returns Response[]|() {
+    isolated function getAll(string key) returns Response[]|() {
         var cacheEntry = trap <Response[]> self.cache.get(key);
         if (cacheEntry is Response[]) {
             return cacheEntry;
@@ -109,7 +109,7 @@ public class HttpCache {
         return ();
     }
 
-    function getAllByETag(string key, string etag) returns Response[] {
+    isolated function getAllByETag(string key, string etag) returns Response[] {
         Response[] cachedResponses = [];
         Response[] matchingResponses = [];
         int i = 0;
@@ -129,7 +129,7 @@ public class HttpCache {
         return matchingResponses;
     }
 
-    function getAllByWeakETag(string key, string etag) returns Response[] {
+    isolated function getAllByWeakETag(string key, string etag) returns Response[] {
         Response[] cachedResponses = [];
         Response[] matchingResponses = [];
         int i = 0;
@@ -149,7 +149,7 @@ public class HttpCache {
         return matchingResponses;
     }
 
-    function remove(string key) {
+    isolated function remove(string key) {
         cache:Error? result = self.cache.invalidate(key);
         if (result is cache:Error) {
             log:printDebug(() => "Failed to remove the key: " + key + " from the HTTP cache.");
@@ -157,7 +157,7 @@ public class HttpCache {
     }
 }
 
-function isCacheableStatusCode(int statusCode) returns boolean {
+isolated function isCacheableStatusCode(int statusCode) returns boolean {
     return statusCode == STATUS_OK || statusCode == STATUS_NON_AUTHORITATIVE_INFORMATION ||
            statusCode == STATUS_NO_CONTENT || statusCode == STATUS_PARTIAL_CONTENT ||
            statusCode == STATUS_MULTIPLE_CHOICES || statusCode == STATUS_MOVED_PERMANENTLY ||
@@ -166,7 +166,7 @@ function isCacheableStatusCode(int statusCode) returns boolean {
            statusCode == STATUS_NOT_IMPLEMENTED;
 }
 
-function addEntry(cache:Cache cache, string key, Response inboundResponse) {
+isolated function addEntry(cache:Cache cache, string key, Response inboundResponse) {
     if (cache.hasKey(key)) {
         Response[] existingResponses = <Response[]>cache.get(key);
         existingResponses.push(inboundResponse);
@@ -179,13 +179,13 @@ function addEntry(cache:Cache cache, string key, Response inboundResponse) {
     }
 }
 
-function weakValidatorEquals(string etag1, string etag2) returns boolean {
+isolated function weakValidatorEquals(string etag1, string etag2) returns boolean {
     string validatorPortion1 = etag1.startsWith(WEAK_VALIDATOR_TAG) ? etag1.substring(2, etag1.length()) : etag1;
     string validatorPortion2 = etag2.startsWith(WEAK_VALIDATOR_TAG) ? etag2.substring(2, etag2.length()) : etag2;
 
     return validatorPortion1 == validatorPortion2;
 }
 
-function getCacheKey(string httpMethod, string url) returns string {
+isolated function getCacheKey(string httpMethod, string url) returns string {
     return string `${httpMethod} ${url}`;
 }

--- a/http-ballerina/src/http/caching/http_caching_client.bal
+++ b/http-ballerina/src/http/caching/http_caching_client.bal
@@ -41,7 +41,7 @@ public client class HttpCachingClient {
     # + url - The URL of the HTTP endpoint to connect to
     # + config - The configurations for the client endpoint associated with the caching client
     # + cacheConfig - The configurations for the HTTP cache to be used with the caching client
-    public function init(string url, ClientConfiguration config, CacheConfig cacheConfig) {
+    public isolated function init(string url, ClientConfiguration config, CacheConfig cacheConfig) {
         self.url = url;
         var httpSecureClient = createHttpSecureClient(url, config);
         if (httpSecureClient is HttpClient) {
@@ -60,7 +60,7 @@ public client class HttpCachingClient {
     # + message - HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function post(string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function post(string path, RequestMessage message) returns Response|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -78,7 +78,7 @@ public client class HttpCachingClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function head(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
+    public remote isolated function head(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
         return getCachedResponse(self.cache, self.httpClient, req, HTTP_HEAD, path, self.cacheConfig.isShared, false);
@@ -91,7 +91,7 @@ public client class HttpCachingClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function put(string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function put(string path, RequestMessage message) returns Response|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -110,7 +110,7 @@ public client class HttpCachingClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function execute(string httpMethod, string path, RequestMessage message)
+    public remote isolated function execute(string httpMethod, string path, RequestMessage message)
                                                             returns @tainted Response|ClientError {
         Request request = <Request>message;
         setRequestCacheControlHeader(request);
@@ -134,7 +134,7 @@ public client class HttpCachingClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function patch(string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function patch(string path, RequestMessage message) returns Response|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -152,7 +152,7 @@ public client class HttpCachingClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function delete(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function delete(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -170,7 +170,7 @@ public client class HttpCachingClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function get(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
+    public remote isolated function get(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
         return getCachedResponse(self.cache, self.httpClient, req, HTTP_GET, path, self.cacheConfig.isShared, false);
@@ -183,7 +183,7 @@ public client class HttpCachingClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function options(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function options(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -194,13 +194,13 @@ public client class HttpCachingClient {
         return inboundResponse;
     }
 
-    # Forward remote function can be used to invoke an HTTP call with inbound request's HTTP method. Only inbound requests of
+    # Forward remote isolated function can be used to invoke an HTTP call with inbound request's HTTP method. Only inbound requests of
     # GET and HEAD HTTP method types are cacheable.
     #
     # + path - Request path
     # + request - The HTTP request to be forwarded
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function forward(string path, @tainted Request request) returns @tainted Response|ClientError {
+    public remote isolated function forward(string path, @tainted Request request) returns @tainted Response|ClientError {
         if (request.method == HTTP_GET || request.method == HTTP_HEAD) {
             return getCachedResponse(self.cache, self.httpClient, request, request.method, path,
                                      self.cacheConfig.isShared, true);
@@ -220,7 +220,7 @@ public client class HttpCachingClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - An `HttpFuture` that represents an asynchronous service invocation, or an error if the submission fails
-    public remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         return self.httpClient->submit(httpVerb, path, <Request>message);
     }
 
@@ -228,7 +228,7 @@ public client class HttpCachingClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - A `http:Response` message, or else an `http:ClientError` if the invocation fails
-    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         return self.httpClient->getResponse(httpFuture);
     }
 
@@ -236,7 +236,7 @@ public client class HttpCachingClient {
     #
     # + httpFuture - The `http:HttpFuture` relates to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote function hasPromise(HttpFuture httpFuture) returns boolean {
+    public remote isolated function hasPromise(HttpFuture httpFuture) returns boolean {
         return self.httpClient->hasPromise(httpFuture);
     }
 
@@ -244,7 +244,7 @@ public client class HttpCachingClient {
     #
     # + httpFuture - The `http:HttpFuture` relates to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return self.httpClient->getNextPromise(httpFuture);
     }
 
@@ -252,7 +252,7 @@ public client class HttpCachingClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised HTTP `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return self.httpClient->getPromisedResponse(promise);
     }
 
@@ -260,7 +260,7 @@ public client class HttpCachingClient {
     # response using the rejected promise.
     #
     # + promise - The Push Promise to be rejected
-    public remote function rejectPromise(PushPromise promise) {
+    public remote isolated function rejectPromise(PushPromise promise) {
         self.httpClient->rejectPromise(promise);
     }
 }
@@ -272,14 +272,14 @@ public client class HttpCachingClient {
 # + cacheConfig - The configurations for the HTTP cache to be used with the caching client
 # + return - An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer 
 #            or else an `http:ClientError`
-public function createHttpCachingClient(string url, ClientConfiguration config, CacheConfig cacheConfig)
+public isolated function createHttpCachingClient(string url, ClientConfiguration config, CacheConfig cacheConfig)
                                                                                       returns HttpClient|ClientError {
     HttpCachingClient httpCachingClient = new(url, config, cacheConfig);
     log:printDebug(() => "Created HTTP caching client: " + io:sprintf("%s", httpCachingClient));
     return httpCachingClient;
 }
 
-function getCachedResponse(HttpCache cache, HttpClient httpClient, @tainted Request req, string httpMethod, string path,
+isolated function getCachedResponse(HttpCache cache, HttpClient httpClient, @tainted Request req, string httpMethod, string path,
                            boolean isShared, boolean forwardRequest) returns @tainted Response|ClientError {
     time:Time currentT = time:currentTime();
     req.parseCacheControlHeader();
@@ -345,7 +345,7 @@ function getCachedResponse(HttpCache cache, HttpClient httpClient, @tainted Requ
 }
 
 // Based on https://tools.ietf.org/html/rfc7234#section-4.4
-function invalidateResponses(HttpCache httpCache, Response inboundResponse, string path) {
+isolated function invalidateResponses(HttpCache httpCache, Response inboundResponse, string path) {
     // TODO: Improve this logic in accordance with the spec
     if (isCacheableStatusCode(inboundResponse.statusCode) &&
                     inboundResponse.statusCode >= 200 && inboundResponse.statusCode < 400) {
@@ -367,7 +367,7 @@ function invalidateResponses(HttpCache httpCache, Response inboundResponse, stri
     }
 }
 
-function sendNewRequest(HttpClient httpClient, Request request, string path, string httpMethod, boolean forwardRequest)
+isolated function sendNewRequest(HttpClient httpClient, Request request, string path, string httpMethod, boolean forwardRequest)
                                                                                 returns Response|ClientError {
     if (forwardRequest) {
         return httpClient->forward(path, request);

--- a/http-ballerina/src/http/caching/http_caching_client.bal
+++ b/http-ballerina/src/http/caching/http_caching_client.bal
@@ -41,7 +41,7 @@ public client class HttpCachingClient {
     # + url - The URL of the HTTP endpoint to connect to
     # + config - The configurations for the client endpoint associated with the caching client
     # + cacheConfig - The configurations for the HTTP cache to be used with the caching client
-    public isolated function init(string url, ClientConfiguration config, CacheConfig cacheConfig) {
+    public function init(string url, ClientConfiguration config, CacheConfig cacheConfig) {
         self.url = url;
         var httpSecureClient = createHttpSecureClient(url, config);
         if (httpSecureClient is HttpClient) {
@@ -60,7 +60,7 @@ public client class HttpCachingClient {
     # + message - HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function post(string path, RequestMessage message) returns Response|ClientError {
+    public remote function post(string path, RequestMessage message) returns Response|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -78,7 +78,7 @@ public client class HttpCachingClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function head(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
+    public remote function head(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
         return getCachedResponse(self.cache, self.httpClient, req, HTTP_HEAD, path, self.cacheConfig.isShared, false);
@@ -91,7 +91,7 @@ public client class HttpCachingClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function put(string path, RequestMessage message) returns Response|ClientError {
+    public remote function put(string path, RequestMessage message) returns Response|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -110,7 +110,7 @@ public client class HttpCachingClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function execute(string httpMethod, string path, RequestMessage message)
+    public remote function execute(string httpMethod, string path, RequestMessage message)
                                                             returns @tainted Response|ClientError {
         Request request = <Request>message;
         setRequestCacheControlHeader(request);
@@ -134,7 +134,7 @@ public client class HttpCachingClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function patch(string path, RequestMessage message) returns Response|ClientError {
+    public remote function patch(string path, RequestMessage message) returns Response|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -152,7 +152,7 @@ public client class HttpCachingClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function delete(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function delete(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -170,7 +170,7 @@ public client class HttpCachingClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function get(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
+    public remote function get(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
         return getCachedResponse(self.cache, self.httpClient, req, HTTP_GET, path, self.cacheConfig.isShared, false);
@@ -183,7 +183,7 @@ public client class HttpCachingClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function options(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function options(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -194,13 +194,13 @@ public client class HttpCachingClient {
         return inboundResponse;
     }
 
-    # Forward remote isolated function can be used to invoke an HTTP call with inbound request's HTTP method. Only inbound requests of
+    # Forward remote function can be used to invoke an HTTP call with inbound request's HTTP method. Only inbound requests of
     # GET and HEAD HTTP method types are cacheable.
     #
     # + path - Request path
     # + request - The HTTP request to be forwarded
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function forward(string path, @tainted Request request) returns @tainted Response|ClientError {
+    public remote function forward(string path, @tainted Request request) returns @tainted Response|ClientError {
         if (request.method == HTTP_GET || request.method == HTTP_HEAD) {
             return getCachedResponse(self.cache, self.httpClient, request, request.method, path,
                                      self.cacheConfig.isShared, true);
@@ -220,7 +220,7 @@ public client class HttpCachingClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - An `HttpFuture` that represents an asynchronous service invocation, or an error if the submission fails
-    public remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         return self.httpClient->submit(httpVerb, path, <Request>message);
     }
 
@@ -228,7 +228,7 @@ public client class HttpCachingClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - A `http:Response` message, or else an `http:ClientError` if the invocation fails
-    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         return self.httpClient->getResponse(httpFuture);
     }
 
@@ -236,7 +236,7 @@ public client class HttpCachingClient {
     #
     # + httpFuture - The `http:HttpFuture` relates to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote isolated function hasPromise(HttpFuture httpFuture) returns boolean {
+    public remote function hasPromise(HttpFuture httpFuture) returns boolean {
         return self.httpClient->hasPromise(httpFuture);
     }
 
@@ -244,7 +244,7 @@ public client class HttpCachingClient {
     #
     # + httpFuture - The `http:HttpFuture` relates to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return self.httpClient->getNextPromise(httpFuture);
     }
 
@@ -252,7 +252,7 @@ public client class HttpCachingClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised HTTP `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return self.httpClient->getPromisedResponse(promise);
     }
 
@@ -260,7 +260,7 @@ public client class HttpCachingClient {
     # response using the rejected promise.
     #
     # + promise - The Push Promise to be rejected
-    public remote isolated function rejectPromise(PushPromise promise) {
+    public remote function rejectPromise(PushPromise promise) {
         self.httpClient->rejectPromise(promise);
     }
 }
@@ -272,14 +272,14 @@ public client class HttpCachingClient {
 # + cacheConfig - The configurations for the HTTP cache to be used with the caching client
 # + return - An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer 
 #            or else an `http:ClientError`
-public isolated function createHttpCachingClient(string url, ClientConfiguration config, CacheConfig cacheConfig)
+public function createHttpCachingClient(string url, ClientConfiguration config, CacheConfig cacheConfig)
                                                                                       returns HttpClient|ClientError {
     HttpCachingClient httpCachingClient = new(url, config, cacheConfig);
     log:printDebug(() => "Created HTTP caching client: " + io:sprintf("%s", httpCachingClient));
     return httpCachingClient;
 }
 
-isolated function getCachedResponse(HttpCache cache, HttpClient httpClient, @tainted Request req, string httpMethod, string path,
+function getCachedResponse(HttpCache cache, HttpClient httpClient, @tainted Request req, string httpMethod, string path,
                            boolean isShared, boolean forwardRequest) returns @tainted Response|ClientError {
     time:Time currentT = time:currentTime();
     req.parseCacheControlHeader();
@@ -367,7 +367,7 @@ isolated function invalidateResponses(HttpCache httpCache, Response inboundRespo
     }
 }
 
-isolated function sendNewRequest(HttpClient httpClient, Request request, string path, string httpMethod, boolean forwardRequest)
+function sendNewRequest(HttpClient httpClient, Request request, string path, string httpMethod, boolean forwardRequest)
                                                                                 returns Response|ClientError {
     if (forwardRequest) {
         return httpClient->forward(path, request);

--- a/http-ballerina/src/http/caching/request_cache_control.bal
+++ b/http-ballerina/src/http/caching/request_cache_control.bal
@@ -36,7 +36,7 @@ public class RequestCacheControl {
     # Builds the cache control directives string from the current `http:RequestCacheControl` configurations.
     #
     # + return - The cache control directives string to be used in the `cache-control` header
-    public function buildCacheControlDirectives () returns string {
+    public isolated function buildCacheControlDirectives () returns string {
         string[] directives = [];
         int i = 0;
 
@@ -82,7 +82,7 @@ public class RequestCacheControl {
     }
 }
 
-function setRequestCacheControlHeader(Request request) {
+isolated function setRequestCacheControlHeader(Request request) {
     var requestCacheControl = request.cacheControl;
     if (requestCacheControl is RequestCacheControl) {
         if (!request.hasHeader(CACHE_CONTROL)) {

--- a/http-ballerina/src/http/caching/response_age_calculation.bal
+++ b/http-ballerina/src/http/caching/response_age_calculation.bal
@@ -19,7 +19,7 @@ import ballerina/log;
 import ballerina/time;
 
 // Based on https://tools.ietf.org/html/rfc7234#section-4.2.3
-function calculateCurrentResponseAge(Response cachedResponse) returns @tainted int {
+isolated function calculateCurrentResponseAge(Response cachedResponse) returns @tainted int {
     int ageValue = getResponseAge(cachedResponse);
     int dateValue = getDateValue(cachedResponse);
     int now = time:currentTime().time;
@@ -37,7 +37,7 @@ function calculateCurrentResponseAge(Response cachedResponse) returns @tainted i
     return (correctedInitialAge + residentTime) / 1000;
 }
 
-function getResponseAge(Response cachedResponse) returns @tainted int {
+isolated function getResponseAge(Response cachedResponse) returns @tainted int {
     if (!cachedResponse.hasHeader(AGE)) {
         return 0;
     }
@@ -48,7 +48,7 @@ function getResponseAge(Response cachedResponse) returns @tainted int {
     return (ageValue is int) ? ageValue : 0;
 }
 
-function getDateValue(Response inboundResponse) returns int {
+isolated function getDateValue(Response inboundResponse) returns int {
     if (inboundResponse.hasHeader(DATE)) {
         string dateHeader = inboundResponse.getHeader(DATE); // TODO: May need to handle invalid date headers
         var dateHeaderTime = time:parse(dateHeader, time:TIME_FORMAT_RFC_1123);

--- a/http-ballerina/src/http/caching/response_cache_control.bal
+++ b/http-ballerina/src/http/caching/response_cache_control.bal
@@ -44,7 +44,7 @@ public class ResponseCacheControl {
     # Builds the cache control directives string from the current `http:ResponseCacheControl` configurations.
     #
     # + return - The cache control directives string to be used in the `cache-control` header
-    public function buildCacheControlDirectives () returns string {
+    public isolated function buildCacheControlDirectives () returns string {
         string[] directives = [];
         int i = 0;
 
@@ -94,7 +94,7 @@ public class ResponseCacheControl {
     }
 }
 
-function setResponseCacheControlHeader(Response response) {
+isolated function setResponseCacheControlHeader(Response response) {
     var responseCacheControl = response.cacheControl;
     if (responseCacheControl is ResponseCacheControl) {
         if (!response.hasHeader(CACHE_CONTROL)) {

--- a/http-ballerina/src/http/caching/stale_response_checks.bal
+++ b/http-ballerina/src/http/caching/stale_response_checks.bal
@@ -16,7 +16,7 @@
 
 // All the functions in this file are based on https://tools.ietf.org/html/rfc7234#section-4.2.4
 
-function isAllowedToBeServedStale(RequestCacheControl? requestCacheControl, Response cachedResponse,
+isolated function isAllowedToBeServedStale(RequestCacheControl? requestCacheControl, Response cachedResponse,
                                   boolean isSharedCache) returns boolean {
     // A cache MUST NOT generate a stale response if it is prohibited by an explicit in-protocol directive
     if (isServingStaleProhibitedInRequestCC(requestCacheControl)) {
@@ -30,7 +30,7 @@ function isAllowedToBeServedStale(RequestCacheControl? requestCacheControl, Resp
     return isStaleResponseAccepted(requestCacheControl, cachedResponse, isSharedCache);
 }
 
-function isServingStaleProhibitedInRequestCC(RequestCacheControl? cacheControl) returns boolean {
+isolated function isServingStaleProhibitedInRequestCC(RequestCacheControl? cacheControl) returns boolean {
     // A cache MUST NOT generate a stale response if it is prohibited by an explicit in-protocol directive
     if (cacheControl is ()) {
         return false;
@@ -40,7 +40,7 @@ function isServingStaleProhibitedInRequestCC(RequestCacheControl? cacheControl) 
     return reqCC.noCache || reqCC.noStore;
 }
 
-function isServingStaleProhibitedInResponseCC(ResponseCacheControl? cacheControl) returns boolean {
+isolated function isServingStaleProhibitedInResponseCC(ResponseCacheControl? cacheControl) returns boolean {
     // A cache MUST NOT generate a stale response if it is prohibited by an explicit in-protocol directive
     if (cacheControl is ()) {
         return false;
@@ -52,7 +52,7 @@ function isServingStaleProhibitedInResponseCC(ResponseCacheControl? cacheControl
     return resCC.noCache || resCC.mustRevalidate || resCC.proxyRevalidate || (resCC.sMaxAge >= 0);
 }
 
-function isStaleResponseAccepted(RequestCacheControl? requestCacheControl, Response cachedResponse,
+isolated function isStaleResponseAccepted(RequestCacheControl? requestCacheControl, Response cachedResponse,
                                  boolean isSharedCache) returns boolean {
     if (requestCacheControl is RequestCacheControl) {
         if (requestCacheControl.maxStale == MAX_STALE_ANY_AGE) {

--- a/http-ballerina/src/http/caching/utils.bal
+++ b/http-ballerina/src/http/caching/utils.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 
-function isNoCacheSet(RequestCacheControl? reqCC, ResponseCacheControl? resCC) returns boolean {
+isolated function isNoCacheSet(RequestCacheControl? reqCC, ResponseCacheControl? resCC) returns boolean {
     if (reqCC is RequestCacheControl && reqCC.noCache) {
         return true;
     }
@@ -28,17 +28,17 @@ function isNoCacheSet(RequestCacheControl? reqCC, ResponseCacheControl? resCC) r
     return false;
 }
 
-function updateResponseTimestamps(Response response, int requestedTime, int receivedTime) {
+isolated function updateResponseTimestamps(Response response, int requestedTime, int receivedTime) {
     response.requestTime = requestedTime;
     response.receivedTime = receivedTime;
 }
 
-function setAgeHeader(Response cachedResponse) {
+isolated function setAgeHeader(Response cachedResponse) {
     cachedResponse.setHeader(AGE, <@untainted>calculateCurrentResponseAge(cachedResponse).toString());
 }
 
 // Based on https://tools.ietf.org/html/rfc7234#section-4.3.4
-function updateResponse(Response cachedResponse, Response validationResponse) {
+isolated function updateResponse(Response cachedResponse, Response validationResponse) {
     // 1 - delete warning headers with warn codes 1xx
     // 2 - retain warning headers with warn codes 2xx
     // 3 - use other headers in validation response to replace corresponding headers in cached response
@@ -46,7 +46,7 @@ function updateResponse(Response cachedResponse, Response validationResponse) {
     replaceHeaders(cachedResponse, validationResponse);
 }
 
-function retain2xxWarnings(Response cachedResponse) {
+isolated function retain2xxWarnings(Response cachedResponse) {
     if (cachedResponse.hasHeader(WARNING)) {
         string[] warningHeaders = <@untainted>cachedResponse.getHeaders(WARNING);
         cachedResponse.removeHeader(WARNING);
@@ -62,7 +62,7 @@ function retain2xxWarnings(Response cachedResponse) {
 }
 
 // Based on https://tools.ietf.org/html/rfc7234#section-4.3.4
-function replaceHeaders(Response cachedResponse, Response validationResponse) {
+isolated function replaceHeaders(Response cachedResponse, Response validationResponse) {
     string[] headerNames = <@untainted>validationResponse.getHeaderNames();
 
     log:printDebug("Updating response headers using validation response.");

--- a/http-ballerina/src/http/client_endpoint.bal
+++ b/http-ballerina/src/http/client_endpoint.bal
@@ -17,7 +17,7 @@
 import ballerina/java;
 import ballerina/crypto;
 import ballerina/time;
-import ballerina/observe;
+// import ballerina/observe;
 
 ////////////////////////////////
 ///// HTTP Client Endpoint /////
@@ -45,7 +45,7 @@ public client class Client {
     #
     # + url - URL of the target service
     # + config - The configurations to be used when initializing the `client`
-    public function init(string url, ClientConfiguration? config = ()) {
+    public isolated function init(string url, ClientConfiguration? config = ()) {
         self.config = config ?: {};
         self.url = url;
         var cookieConfigVal = self.config.cookieConfig;
@@ -68,7 +68,7 @@ public client class Client {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function post(@untainted string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function post(@untainted string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         Response|ClientError response = self.httpClient->post(path, req);
         if (observabilityEnabled && response is Response) {
@@ -83,7 +83,7 @@ public client class Client {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function head(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function head(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         Response|ClientError response = self.httpClient->head(path, message = req);
         if (observabilityEnabled && response is Response) {
@@ -98,7 +98,7 @@ public client class Client {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function put(@untainted string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function put(@untainted string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         Response|ClientError response = self.httpClient->put(path, req);
         if (observabilityEnabled && response is Response) {
@@ -114,7 +114,7 @@ public client class Client {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function execute(@untainted string httpVerb, @untainted string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function execute(@untainted string httpVerb, @untainted string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         Response|ClientError response = self.httpClient->execute(httpVerb, path, req);
         if (observabilityEnabled && response is Response) {
@@ -129,7 +129,7 @@ public client class Client {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function patch(@untainted string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function patch(@untainted string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         Response|ClientError response = self.httpClient->patch(path, req);
         if (observabilityEnabled && response is Response) {
@@ -144,7 +144,7 @@ public client class Client {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function delete(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function delete(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         Response|ClientError response = self.httpClient->delete(path, req);
         if (observabilityEnabled && response is Response) {
@@ -159,7 +159,7 @@ public client class Client {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function get(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function get(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         Response|ClientError response = self.httpClient->get(path, message = req);
         if (observabilityEnabled && response is Response) {
@@ -174,7 +174,7 @@ public client class Client {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function options(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function options(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         Response|ClientError response = self.httpClient->options(path, message = req);
         if (observabilityEnabled && response is Response) {
@@ -188,7 +188,7 @@ public client class Client {
     # + path - Request path
     # + request - An HTTP inbound request message
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function forward(@untainted string path, Request request) returns Response|ClientError {
+    public remote isolated function forward(@untainted string path, Request request) returns Response|ClientError {
         Response|ClientError response = self.httpClient->forward(path, request);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, request.method, response.statusCode, self.url);
@@ -205,7 +205,7 @@ public client class Client {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission fails
-    public remote function submit(@untainted string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote isolated function submit(@untainted string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         Request req = buildRequest(message);
         return self.httpClient->submit(httpVerb, path, req);
 
@@ -215,10 +215,10 @@ public client class Client {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:Response` message or else an `http: ClientError` if the invocation fails
-    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         Response|ClientError response = self.httpClient->getResponse(httpFuture);
         if (response is Response) {
-            error? err = observe:addTagToSpan(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(response.statusCode));
+            // error? err = observe:addTagToSpan(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(response.statusCode));
         }
         return response;
     }
@@ -227,7 +227,7 @@ public client class Client {
     #
     # + httpFuture - The `http:HttpFuture` relates to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote function hasPromise(HttpFuture httpFuture) returns boolean {
+    public remote isolated function hasPromise(HttpFuture httpFuture) returns boolean {
         return self.httpClient->hasPromise(httpFuture);
     }
 
@@ -235,7 +235,7 @@ public client class Client {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return self.httpClient->getNextPromise(httpFuture);
     }
 
@@ -243,10 +243,10 @@ public client class Client {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         Response|ClientError response = self.httpClient->getPromisedResponse(promise);
         if (observabilityEnabled && response is Response) {
-            addObservabilityInformation(promise.path, promise.method, response.statusCode, self.url);
+            //addObservabilityInformation(promise.path, promise.method, response.statusCode, self.url);
         }
         return response;
     }
@@ -254,14 +254,14 @@ public client class Client {
     # This just pass the request to actual network call.
     #
     # + promise - The Push Promise to be rejected
-    public remote function rejectPromise(PushPromise promise) {
+    public remote isolated function rejectPromise(PushPromise promise) {
         return self.httpClient->rejectPromise(promise);
     }
 
     # Retrieves the cookie store of the client.
     #
     # + return - The cookie store related to the client
-    public function getCookieStore() returns CookieStore? {
+    public isolated function getCookieStore() returns CookieStore? {
         return self.cookieStore;
     }
 }
@@ -311,7 +311,7 @@ public type ClientHttp1Settings record {|
     ProxyConfig? proxy = ();
 |};
 
-function createSimpleHttpClient(HttpClient caller, PoolConfiguration globalPoolConfig) = @java:Method {
+isolated function createSimpleHttpClient(HttpClient caller, PoolConfiguration globalPoolConfig) = @java:Method {
    'class: "org.ballerinalang.net.http.clientendpoint.CreateSimpleHttpClient",
    name: "createSimpleHttpClient"
 } external;
@@ -424,7 +424,7 @@ public type CookieConfig record {|
      PersistentCookieHandler persistentCookieHandler?;
 |};
 
-function initialize(string serviceUrl, ClientConfiguration config, CookieStore? cookieStore) returns HttpClient|error {
+isolated function initialize(string serviceUrl, ClientConfiguration config, CookieStore? cookieStore) returns HttpClient|error {
     boolean httpClientRequired = false;
     string url = serviceUrl;
     if (url.endsWith("/")) {
@@ -452,7 +452,7 @@ function initialize(string serviceUrl, ClientConfiguration config, CookieStore? 
     }
 }
 
-function createRedirectClient(string url, ClientConfiguration configuration, CookieStore? cookieStore) returns HttpClient|ClientError {
+isolated function createRedirectClient(string url, ClientConfiguration configuration, CookieStore? cookieStore) returns HttpClient|ClientError {
     var redirectConfig = configuration.followRedirects;
     if (redirectConfig is FollowRedirects) {
         if (redirectConfig.enabled) {
@@ -470,7 +470,7 @@ function createRedirectClient(string url, ClientConfiguration configuration, Coo
     }
 }
 
-function checkForRetry(string url, ClientConfiguration config, CookieStore? cookieStore) returns HttpClient|ClientError {
+isolated function checkForRetry(string url, ClientConfiguration config, CookieStore? cookieStore) returns HttpClient|ClientError {
     var retryConfigVal = config.retryConfig;
     if (retryConfigVal is RetryConfig) {
         return createRetryClient(url, config, cookieStore);
@@ -479,7 +479,7 @@ function checkForRetry(string url, ClientConfiguration config, CookieStore? cook
     }
 }
 
-function createCircuitBreakerClient(string uri, ClientConfiguration configuration, CookieStore? cookieStore) returns HttpClient|ClientError {
+isolated function createCircuitBreakerClient(string uri, ClientConfiguration configuration, CookieStore? cookieStore) returns HttpClient|ClientError {
     HttpClient cbHttpClient;
     var cbConfig = configuration.circuitBreaker;
     if (cbConfig is CircuitBreakerConfig) {
@@ -531,7 +531,7 @@ function createCircuitBreakerClient(string uri, ClientConfiguration configuratio
     }
 }
 
-function createRetryClient(string url, ClientConfiguration configuration, CookieStore? cookieStore) returns HttpClient|ClientError {
+isolated function createRetryClient(string url, ClientConfiguration configuration, CookieStore? cookieStore) returns HttpClient|ClientError {
     var retryConfig = configuration.retryConfig;
     if (retryConfig is RetryConfig) {
         boolean[] statusCodes = populateErrorCodeIndex(retryConfig.statusCodes);
@@ -551,7 +551,7 @@ function createRetryClient(string url, ClientConfiguration configuration, Cookie
     return createCookieClient(url, configuration, cookieStore);
 }
 
-function createCookieClient(string url, ClientConfiguration configuration, CookieStore? cookieStore) returns HttpClient|ClientError {
+isolated function createCookieClient(string url, ClientConfiguration configuration, CookieStore? cookieStore) returns HttpClient|ClientError {
     var cookieConfigVal = configuration.cookieConfig;
     if (cookieConfigVal is CookieConfig) {
         if (!cookieConfigVal.enabled) {
@@ -573,7 +573,7 @@ function createCookieClient(string url, ClientConfiguration configuration, Cooki
     return createDefaultClient(url, configuration);
 }
 
-function createDefaultClient(string url, ClientConfiguration configuration) returns HttpClient|ClientError {
+isolated function createDefaultClient(string url, ClientConfiguration configuration) returns HttpClient|ClientError {
     if (configuration.cache.enabled) {
         return createHttpCachingClient(url, configuration, configuration.cache);
     }

--- a/http-ballerina/src/http/client_endpoint.bal
+++ b/http-ballerina/src/http/client_endpoint.bal
@@ -17,7 +17,7 @@
 import ballerina/java;
 import ballerina/crypto;
 import ballerina/time;
-// import ballerina/observe;
+import ballerina/observe;
 
 ////////////////////////////////
 ///// HTTP Client Endpoint /////
@@ -218,7 +218,7 @@ public client class Client {
     public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         Response|ClientError response = self.httpClient->getResponse(httpFuture);
         if (response is Response) {
-            // error? err = observe:addTagToSpan(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(response.statusCode));
+            error? err = observe:addTagToSpan(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(response.statusCode));
         }
         return response;
     }
@@ -246,7 +246,7 @@ public client class Client {
     public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         Response|ClientError response = self.httpClient->getPromisedResponse(promise);
         if (observabilityEnabled && response is Response) {
-            //addObservabilityInformation(promise.path, promise.method, response.statusCode, self.url);
+            addObservabilityInformation(promise.path, promise.method, response.statusCode, self.url);
         }
         return response;
     }

--- a/http-ballerina/src/http/client_endpoint.bal
+++ b/http-ballerina/src/http/client_endpoint.bal
@@ -68,7 +68,7 @@ public client class Client {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function post(@untainted string path, RequestMessage message) returns Response|ClientError {
+    public remote function post(@untainted string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         Response|ClientError response = self.httpClient->post(path, req);
         if (observabilityEnabled && response is Response) {
@@ -83,7 +83,7 @@ public client class Client {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function head(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function head(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         Response|ClientError response = self.httpClient->head(path, message = req);
         if (observabilityEnabled && response is Response) {
@@ -98,7 +98,7 @@ public client class Client {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function put(@untainted string path, RequestMessage message) returns Response|ClientError {
+    public remote function put(@untainted string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         Response|ClientError response = self.httpClient->put(path, req);
         if (observabilityEnabled && response is Response) {
@@ -114,7 +114,7 @@ public client class Client {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function execute(@untainted string httpVerb, @untainted string path, RequestMessage message) returns Response|ClientError {
+    public remote function execute(@untainted string httpVerb, @untainted string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         Response|ClientError response = self.httpClient->execute(httpVerb, path, req);
         if (observabilityEnabled && response is Response) {
@@ -129,7 +129,7 @@ public client class Client {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function patch(@untainted string path, RequestMessage message) returns Response|ClientError {
+    public remote function patch(@untainted string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         Response|ClientError response = self.httpClient->patch(path, req);
         if (observabilityEnabled && response is Response) {
@@ -144,7 +144,7 @@ public client class Client {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function delete(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function delete(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         Response|ClientError response = self.httpClient->delete(path, req);
         if (observabilityEnabled && response is Response) {
@@ -159,7 +159,7 @@ public client class Client {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function get(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function get(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         Response|ClientError response = self.httpClient->get(path, message = req);
         if (observabilityEnabled && response is Response) {
@@ -174,7 +174,7 @@ public client class Client {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function options(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function options(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         Response|ClientError response = self.httpClient->options(path, message = req);
         if (observabilityEnabled && response is Response) {
@@ -188,7 +188,7 @@ public client class Client {
     # + path - Request path
     # + request - An HTTP inbound request message
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function forward(@untainted string path, Request request) returns Response|ClientError {
+    public remote function forward(@untainted string path, Request request) returns Response|ClientError {
         Response|ClientError response = self.httpClient->forward(path, request);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, request.method, response.statusCode, self.url);

--- a/http-ballerina/src/http/client_endpoint.bal
+++ b/http-ballerina/src/http/client_endpoint.bal
@@ -45,7 +45,7 @@ public client class Client {
     #
     # + url - URL of the target service
     # + config - The configurations to be used when initializing the `client`
-    public isolated function init(string url, ClientConfiguration? config = ()) {
+    public function init(string url, ClientConfiguration? config = ()) {
         self.config = config ?: {};
         self.url = url;
         var cookieConfigVal = self.config.cookieConfig;
@@ -205,7 +205,7 @@ public client class Client {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission fails
-    public remote isolated function submit(@untainted string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote function submit(@untainted string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         Request req = buildRequest(message);
         return self.httpClient->submit(httpVerb, path, req);
 
@@ -215,7 +215,7 @@ public client class Client {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:Response` message or else an `http: ClientError` if the invocation fails
-    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         Response|ClientError response = self.httpClient->getResponse(httpFuture);
         if (response is Response) {
             // error? err = observe:addTagToSpan(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(response.statusCode));
@@ -227,7 +227,7 @@ public client class Client {
     #
     # + httpFuture - The `http:HttpFuture` relates to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote isolated function hasPromise(HttpFuture httpFuture) returns boolean {
+    public remote function hasPromise(HttpFuture httpFuture) returns boolean {
         return self.httpClient->hasPromise(httpFuture);
     }
 
@@ -235,7 +235,7 @@ public client class Client {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return self.httpClient->getNextPromise(httpFuture);
     }
 
@@ -243,7 +243,7 @@ public client class Client {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         Response|ClientError response = self.httpClient->getPromisedResponse(promise);
         if (observabilityEnabled && response is Response) {
             //addObservabilityInformation(promise.path, promise.method, response.statusCode, self.url);
@@ -254,14 +254,14 @@ public client class Client {
     # This just pass the request to actual network call.
     #
     # + promise - The Push Promise to be rejected
-    public remote isolated function rejectPromise(PushPromise promise) {
+    public remote function rejectPromise(PushPromise promise) {
         return self.httpClient->rejectPromise(promise);
     }
 
     # Retrieves the cookie store of the client.
     #
     # + return - The cookie store related to the client
-    public isolated function getCookieStore() returns CookieStore? {
+    public function getCookieStore() returns CookieStore? {
         return self.cookieStore;
     }
 }
@@ -424,7 +424,7 @@ public type CookieConfig record {|
      PersistentCookieHandler persistentCookieHandler?;
 |};
 
-isolated function initialize(string serviceUrl, ClientConfiguration config, CookieStore? cookieStore) returns HttpClient|error {
+function initialize(string serviceUrl, ClientConfiguration config, CookieStore? cookieStore) returns HttpClient|error {
     boolean httpClientRequired = false;
     string url = serviceUrl;
     if (url.endsWith("/")) {
@@ -452,7 +452,7 @@ isolated function initialize(string serviceUrl, ClientConfiguration config, Cook
     }
 }
 
-isolated function createRedirectClient(string url, ClientConfiguration configuration, CookieStore? cookieStore) returns HttpClient|ClientError {
+function createRedirectClient(string url, ClientConfiguration configuration, CookieStore? cookieStore) returns HttpClient|ClientError {
     var redirectConfig = configuration.followRedirects;
     if (redirectConfig is FollowRedirects) {
         if (redirectConfig.enabled) {
@@ -470,7 +470,7 @@ isolated function createRedirectClient(string url, ClientConfiguration configura
     }
 }
 
-isolated function checkForRetry(string url, ClientConfiguration config, CookieStore? cookieStore) returns HttpClient|ClientError {
+function checkForRetry(string url, ClientConfiguration config, CookieStore? cookieStore) returns HttpClient|ClientError {
     var retryConfigVal = config.retryConfig;
     if (retryConfigVal is RetryConfig) {
         return createRetryClient(url, config, cookieStore);
@@ -479,7 +479,7 @@ isolated function checkForRetry(string url, ClientConfiguration config, CookieSt
     }
 }
 
-isolated function createCircuitBreakerClient(string uri, ClientConfiguration configuration, CookieStore? cookieStore) returns HttpClient|ClientError {
+function createCircuitBreakerClient(string uri, ClientConfiguration configuration, CookieStore? cookieStore) returns HttpClient|ClientError {
     HttpClient cbHttpClient;
     var cbConfig = configuration.circuitBreaker;
     if (cbConfig is CircuitBreakerConfig) {
@@ -531,7 +531,7 @@ isolated function createCircuitBreakerClient(string uri, ClientConfiguration con
     }
 }
 
-isolated function createRetryClient(string url, ClientConfiguration configuration, CookieStore? cookieStore) returns HttpClient|ClientError {
+function createRetryClient(string url, ClientConfiguration configuration, CookieStore? cookieStore) returns HttpClient|ClientError {
     var retryConfig = configuration.retryConfig;
     if (retryConfig is RetryConfig) {
         boolean[] statusCodes = populateErrorCodeIndex(retryConfig.statusCodes);
@@ -551,7 +551,7 @@ isolated function createRetryClient(string url, ClientConfiguration configuratio
     return createCookieClient(url, configuration, cookieStore);
 }
 
-isolated function createCookieClient(string url, ClientConfiguration configuration, CookieStore? cookieStore) returns HttpClient|ClientError {
+function createCookieClient(string url, ClientConfiguration configuration, CookieStore? cookieStore) returns HttpClient|ClientError {
     var cookieConfigVal = configuration.cookieConfig;
     if (cookieConfigVal is CookieConfig) {
         if (!cookieConfigVal.enabled) {
@@ -573,7 +573,7 @@ isolated function createCookieClient(string url, ClientConfiguration configurati
     return createDefaultClient(url, configuration);
 }
 
-isolated function createDefaultClient(string url, ClientConfiguration configuration) returns HttpClient|ClientError {
+function createDefaultClient(string url, ClientConfiguration configuration) returns HttpClient|ClientError {
     if (configuration.cache.enabled) {
         return createHttpCachingClient(url, configuration, configuration.cache);
     }

--- a/http-ballerina/src/http/cookie/cookieStore.bal
+++ b/http-ballerina/src/http/cookie/cookieStore.bal
@@ -26,7 +26,7 @@ public class CookieStore {
     Cookie[] allSessionCookies = [];
     PersistentCookieHandler? persistentCookieHandler;
 
-    public function init(PersistentCookieHandler? persistentCookieHandler = ()) {
+    public isolated function init(PersistentCookieHandler? persistentCookieHandler = ()) {
         self.persistentCookieHandler = persistentCookieHandler;
     }
 

--- a/http-ballerina/src/http/cookie/http_cookie_client.bal
+++ b/http-ballerina/src/http/cookie/http_cookie_client.bal
@@ -36,7 +36,7 @@ public client class CookieClient {
     # + cookieConfig - Configurations associated with the cookies
     # + httpClient - HTTP client for outbound HTTP requests
     # + cookieStore - Stores the cookies of the client
-     public function init(string url, ClientConfiguration config, CookieConfig cookieConfig, HttpClient httpClient, CookieStore? cookieStore) {
+     public isolated function init(string url, ClientConfiguration config, CookieConfig cookieConfig, HttpClient httpClient, CookieStore? cookieStore) {
          self.url = url;
          self.config = config;
          self.cookieConfig = cookieConfig;
@@ -53,7 +53,8 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function get(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
+    public remote isolated function get(string path, RequestMessage message = ()) returns @tainted Response|ClientError
+    {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->get(path, message = request);
@@ -67,7 +68,7 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function post(string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function post(string path, RequestMessage message) returns Response|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->post(path, request);
@@ -81,7 +82,7 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function head(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
+    public remote isolated function head(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->head(path, message = request);
@@ -95,7 +96,7 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function put(string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function put(string path, RequestMessage message) returns Response|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->put(path, request);
@@ -108,7 +109,7 @@ public client class CookieClient {
     # + path - Request path
     # + request - An HTTP inbound request message
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function forward(string path, Request request) returns Response|ClientError{
+    public remote isolated function forward(string path, Request request) returns Response|ClientError{
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->forward(path, request);
         return addCookiesInResponseToStore(inboundResponse, self.cookieStore, self.cookieConfig, self.url, path);
@@ -122,7 +123,7 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->execute(httpVerb, path, request);
@@ -136,7 +137,7 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function patch(string path, RequestMessage message) returns Response|ClientError  {
+    public remote isolated function patch(string path, RequestMessage message) returns Response|ClientError  {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse =  self.httpClient->patch(path, request);
@@ -150,7 +151,7 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function delete(string path, RequestMessage message = ()) returns Response|ClientError  {
+    public remote isolated function delete(string path, RequestMessage message = ()) returns Response|ClientError  {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse =  self.httpClient->delete(path, request);
@@ -164,7 +165,7 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function options(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function options(string path, RequestMessage message = ()) returns Response|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse =  self.httpClient->options(path, message = request);
@@ -180,7 +181,7 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `HttpFuture`, which represents an asynchronous service invocation or else an `http:ClientError` if the submission fails
-    public remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         Request request = <Request>message;
         return self.httpClient->submit(httpVerb, path, request);
     }
@@ -189,7 +190,7 @@ public client class CookieClient {
     #
     # + httpFuture - The `http:HttpFuture` relates to a previous asynchronous invocation
     # + return - An HTTP response message or else an `http:ClientError` if the invocation fails
-    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         return self.httpClient->getResponse(httpFuture);
     }
 
@@ -197,7 +198,7 @@ public client class CookieClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote function hasPromise(HttpFuture httpFuture) returns boolean {
+    public remote isolated function hasPromise(HttpFuture httpFuture) returns boolean {
         return self.httpClient->hasPromise(httpFuture);
     }
 
@@ -205,7 +206,7 @@ public client class CookieClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An HTTP Push Promise message or else an `http:ClientError` if the invocation fails
-    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError{
+    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError{
         return self.httpClient->getNextPromise(httpFuture);
     }
 
@@ -213,7 +214,7 @@ public client class CookieClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised HTTP `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return self.httpClient->getPromisedResponse(promise);
     }
 
@@ -221,13 +222,13 @@ public client class CookieClient {
     # response using the rejected promise.
     #
     # + promise - The Push Promise to be rejected
-    public remote function rejectPromise(PushPromise promise) {
+    public remote isolated function rejectPromise(PushPromise promise) {
         self.httpClient->rejectPromise(promise);
     }
 }
 
 // Gets the relevant cookies from the cookieStore and adds them to the request.
-function addStoredCookiesToRequest(string url, string path, CookieStore? cookieStore, Request request) {
+isolated function addStoredCookiesToRequest(string url, string path, CookieStore? cookieStore, Request request) {
     Cookie[] cookiesToSend = [];
     if (cookieStore is CookieStore) {
         cookiesToSend = cookieStore.getCookies(url, path);
@@ -239,7 +240,7 @@ function addStoredCookiesToRequest(string url, string path, CookieStore? cookieS
 }
 
 // Gets the cookies from the inbound response, adds them to the cookies store, and returns the response.
-function addCookiesInResponseToStore(Response|ClientError inboundResponse, @tainted CookieStore? cookieStore, CookieConfig cookieConfig, string url, string path) returns Response|ClientError {
+isolated function addCookiesInResponseToStore(Response|ClientError inboundResponse, @tainted CookieStore? cookieStore, CookieConfig cookieConfig, string url, string path) returns Response|ClientError {
     if (cookieStore is CookieStore && inboundResponse is Response) {
         Cookie[] cookiesInResponse = inboundResponse.getCookies();
         cookieStore.addCookies(cookiesInResponse, cookieConfig, url, path );

--- a/http-ballerina/src/http/cookie/http_cookie_client.bal
+++ b/http-ballerina/src/http/cookie/http_cookie_client.bal
@@ -36,7 +36,7 @@ public client class CookieClient {
     # + cookieConfig - Configurations associated with the cookies
     # + httpClient - HTTP client for outbound HTTP requests
     # + cookieStore - Stores the cookies of the client
-     public isolated function init(string url, ClientConfiguration config, CookieConfig cookieConfig, HttpClient httpClient, CookieStore? cookieStore) {
+     public function init(string url, ClientConfiguration config, CookieConfig cookieConfig, HttpClient httpClient, CookieStore? cookieStore) {
          self.url = url;
          self.config = config;
          self.cookieConfig = cookieConfig;
@@ -181,7 +181,7 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `HttpFuture`, which represents an asynchronous service invocation or else an `http:ClientError` if the submission fails
-    public remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         Request request = <Request>message;
         return self.httpClient->submit(httpVerb, path, request);
     }
@@ -190,7 +190,7 @@ public client class CookieClient {
     #
     # + httpFuture - The `http:HttpFuture` relates to a previous asynchronous invocation
     # + return - An HTTP response message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         return self.httpClient->getResponse(httpFuture);
     }
 
@@ -198,7 +198,7 @@ public client class CookieClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote isolated function hasPromise(HttpFuture httpFuture) returns boolean {
+    public remote function hasPromise(HttpFuture httpFuture) returns boolean {
         return self.httpClient->hasPromise(httpFuture);
     }
 
@@ -206,7 +206,7 @@ public client class CookieClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An HTTP Push Promise message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError{
+    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError{
         return self.httpClient->getNextPromise(httpFuture);
     }
 
@@ -214,7 +214,7 @@ public client class CookieClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised HTTP `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return self.httpClient->getPromisedResponse(promise);
     }
 
@@ -222,7 +222,7 @@ public client class CookieClient {
     # response using the rejected promise.
     #
     # + promise - The Push Promise to be rejected
-    public remote isolated function rejectPromise(PushPromise promise) {
+    public remote function rejectPromise(PushPromise promise) {
         self.httpClient->rejectPromise(promise);
     }
 }

--- a/http-ballerina/src/http/cookie/http_cookie_client.bal
+++ b/http-ballerina/src/http/cookie/http_cookie_client.bal
@@ -53,7 +53,7 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function get(string path, RequestMessage message = ()) returns @tainted Response|ClientError
+    public remote function get(string path, RequestMessage message = ()) returns @tainted Response|ClientError
     {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
@@ -68,7 +68,7 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function post(string path, RequestMessage message) returns Response|ClientError {
+    public remote function post(string path, RequestMessage message) returns Response|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->post(path, request);
@@ -82,7 +82,7 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function head(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
+    public remote function head(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->head(path, message = request);
@@ -96,7 +96,7 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function put(string path, RequestMessage message) returns Response|ClientError {
+    public remote function put(string path, RequestMessage message) returns Response|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->put(path, request);
@@ -109,7 +109,7 @@ public client class CookieClient {
     # + path - Request path
     # + request - An HTTP inbound request message
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function forward(string path, Request request) returns Response|ClientError{
+    public remote function forward(string path, Request request) returns Response|ClientError{
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->forward(path, request);
         return addCookiesInResponseToStore(inboundResponse, self.cookieStore, self.cookieConfig, self.url, path);
@@ -123,7 +123,7 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
+    public remote function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->execute(httpVerb, path, request);
@@ -137,7 +137,7 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function patch(string path, RequestMessage message) returns Response|ClientError  {
+    public remote function patch(string path, RequestMessage message) returns Response|ClientError  {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse =  self.httpClient->patch(path, request);
@@ -151,7 +151,7 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function delete(string path, RequestMessage message = ()) returns Response|ClientError  {
+    public remote function delete(string path, RequestMessage message = ()) returns Response|ClientError  {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse =  self.httpClient->delete(path, request);
@@ -165,7 +165,7 @@ public client class CookieClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function options(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function options(string path, RequestMessage message = ()) returns Response|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse =  self.httpClient->options(path, message = request);
@@ -228,7 +228,7 @@ public client class CookieClient {
 }
 
 // Gets the relevant cookies from the cookieStore and adds them to the request.
-isolated function addStoredCookiesToRequest(string url, string path, CookieStore? cookieStore, Request request) {
+function addStoredCookiesToRequest(string url, string path, CookieStore? cookieStore, Request request) {
     Cookie[] cookiesToSend = [];
     if (cookieStore is CookieStore) {
         cookiesToSend = cookieStore.getCookies(url, path);
@@ -240,7 +240,7 @@ isolated function addStoredCookiesToRequest(string url, string path, CookieStore
 }
 
 // Gets the cookies from the inbound response, adds them to the cookies store, and returns the response.
-isolated function addCookiesInResponseToStore(Response|ClientError inboundResponse, @tainted CookieStore? cookieStore, CookieConfig cookieConfig, string url, string path) returns Response|ClientError {
+function addCookiesInResponseToStore(Response|ClientError inboundResponse, @tainted CookieStore? cookieStore, CookieConfig cookieConfig, string url, string path) returns Response|ClientError {
     if (cookieStore is CookieStore && inboundResponse is Response) {
         Cookie[] cookiesInResponse = inboundResponse.getCookies();
         cookieStore.addCookies(cookiesInResponse, cookieConfig, url, path );

--- a/http-ballerina/src/http/http2/http_push_promise.bal
+++ b/http-ballerina/src/http/http2/http_push_promise.bal
@@ -29,7 +29,7 @@ public class PushPromise {
     #
     # + path - The resource path
     # + method - The HTTP method
-    public function init(string path = "/", string method = "GET") {
+    public isolated function init(string path = "/", string method = "GET") {
         self.path = path;
         self.method = method;
     }
@@ -38,7 +38,7 @@ public class PushPromise {
     #
     # + headerName - The header name
     # + return - A `boolean` representing the existence of a given header
-    public function hasHeader(string headerName) returns boolean {
+    public isolated function hasHeader(string headerName) returns boolean {
         return externPromiseHasHeader(self, headerName);
     }
 
@@ -47,7 +47,7 @@ public class PushPromise {
     #
     # + headerName - The header name
     # + return - The header value, or null if there is no such header
-    public function getHeader(string headerName) returns string {
+    public isolated function getHeader(string headerName) returns string {
         return externPromiseGetHeader(self, headerName);
     }
 
@@ -55,7 +55,7 @@ public class PushPromise {
     #
     # + headerName - The header name
     # + return - The array of header values
-    public function getHeaders(string headerName) returns string[] {
+    public isolated function getHeaders(string headerName) returns string[] {
         return externPromiseGetHeaders(self, headerName);
     }
 
@@ -63,7 +63,7 @@ public class PushPromise {
     #
     # + headerName - The header name
     # + headerValue - The header value
-    public function addHeader(string headerName, string headerValue) {
+    public isolated function addHeader(string headerName, string headerValue) {
         return externPromiseAddHeader(self, headerName, headerValue);
     }
 
@@ -71,73 +71,73 @@ public class PushPromise {
     #
     # + headerName - The header name
     # + headerValue - The header value
-    public function setHeader(string headerName, string headerValue) {
+    public isolated function setHeader(string headerName, string headerValue) {
         return externPromiseSetHeader(self, headerName, headerValue);
     }
 
     # Removes a transport header from the `http:PushPromise`.
     #
     # + headerName - The header name
-    public function removeHeader(string headerName) {
+    public isolated function removeHeader(string headerName) {
         return externPromiseRemoveHeader(self, headerName);
     }
 
     # Removes all transport headers from the `http:PushPromise`.
-    public function removeAllHeaders() {
+    public isolated function removeAllHeaders() {
         return externPromiseRemoveAllHeaders(self);
     }
 
     # Gets all transport header names from the `http:PushPromise`.
     #
     # + return - An array of all transport header names
-    public function getHeaderNames() returns string[] {
+    public isolated function getHeaderNames() returns string[] {
         return externPromiseGetHeaderNames(self);
     }
 }
 
-function externPromiseHasHeader(PushPromise promise, string headerName) returns boolean =
+isolated function externPromiseHasHeader(PushPromise promise, string headerName) returns boolean =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternPushPromise",
     name: "hasHeader"
 } external;
 
-function externPromiseGetHeader(PushPromise promise, string headerName) returns string =
+isolated function externPromiseGetHeader(PushPromise promise, string headerName) returns string =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternPushPromise",
     name: "getHeader"
 } external;
 
-function externPromiseGetHeaders(PushPromise promise, string headerName) returns string[] =
+isolated function externPromiseGetHeaders(PushPromise promise, string headerName) returns string[] =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternPushPromise",
     name: "getHeaders"
 } external;
 
-function externPromiseAddHeader(PushPromise promise, string headerName, string headerValue) =
+isolated function externPromiseAddHeader(PushPromise promise, string headerName, string headerValue) =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternPushPromise",
     name: "addHeader"
 } external;
 
-function externPromiseSetHeader(PushPromise promise, string headerName, string headerValue) =
+isolated function externPromiseSetHeader(PushPromise promise, string headerName, string headerValue) =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternPushPromise",
     name: "setHeader"
 } external;
 
-function externPromiseRemoveHeader(PushPromise promise, string headerName) =
+isolated function externPromiseRemoveHeader(PushPromise promise, string headerName) =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternPushPromise",
     name: "removeHeader"
 } external;
 
-function externPromiseRemoveAllHeaders(PushPromise promise) =
+isolated function externPromiseRemoveAllHeaders(PushPromise promise) =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternPushPromise",
     name: "removeAllHeaders"
 } external;
 
-function externPromiseGetHeaderNames(PushPromise promise) returns string[] =
+isolated function externPromiseGetHeaderNames(PushPromise promise) returns string[] =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternPushPromise",
     name: "getHeaderNames"

--- a/http-ballerina/src/http/http_client.bal
+++ b/http-ballerina/src/http/http_client.bal
@@ -32,7 +32,7 @@ public client class HttpClient {
     #
     # + url - URL of the target service
     # + config - The configurations to be used when initializing the `client`
-    public function init(string url, ClientConfiguration? config = ()) {
+    public isolated function init(string url, ClientConfiguration? config = ()) {
         self.config = config ?: {};
         self.url = url;
         createSimpleHttpClient(self, globalHttpClientConnPool);
@@ -44,7 +44,7 @@ public client class HttpClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function post(@untainted string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function post(@untainted string path, RequestMessage message) returns Response|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_POST);
     }
 
@@ -54,7 +54,7 @@ public client class HttpClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` for the request or else an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function head(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function head(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_HEAD);
     }
 
@@ -64,7 +64,7 @@ public client class HttpClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` for the request or else an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function put(@untainted string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function put(@untainted string path, RequestMessage message) returns Response|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_PUT);
     }
 
@@ -75,7 +75,7 @@ public client class HttpClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` for the request or else an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function execute(@untainted string httpVerb, @untainted string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function execute(@untainted string httpVerb, @untainted string path, RequestMessage message) returns Response|ClientError {
         return externExecute(self, httpVerb, path, <Request>message);
     }
 
@@ -85,7 +85,7 @@ public client class HttpClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or else an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function patch(@untainted string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function patch(@untainted string path, RequestMessage message) returns Response|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_PATCH);
     }
 
@@ -95,7 +95,7 @@ public client class HttpClient {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` for the request or else an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function delete(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function delete(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_DELETE);
     }
 
@@ -105,7 +105,7 @@ public client class HttpClient {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` for the request or else an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function get(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function get(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_GET);
     }
 
@@ -115,7 +115,7 @@ public client class HttpClient {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or else an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function options(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function options(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_OPTIONS);
     }
 
@@ -124,7 +124,7 @@ public client class HttpClient {
     # + path - Request path
     # + request - An HTTP inbound request message
     # + return - An `http:Response` for the request or else an `http:ClientError` if failed to establish communication with the upstream server
-    public remote function forward(@untainted string path, Request request) returns Response|ClientError {
+    public remote isolated function forward(@untainted string path, Request request) returns Response|ClientError {
         return externForward(self, path, request);
     }
 
@@ -137,7 +137,7 @@ public client class HttpClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation, or else an `http:ClientError` if the submission fails
-    public remote function submit(@untainted string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote isolated function submit(@untainted string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         return externSubmit(self, httpVerb, path, <Request>message);
     }
 
@@ -145,7 +145,7 @@ public client class HttpClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         return externGetResponse(self, httpFuture);
     }
 
@@ -153,7 +153,7 @@ public client class HttpClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote function hasPromise(HttpFuture httpFuture) returns boolean {
+    public remote isolated function hasPromise(HttpFuture httpFuture) returns boolean {
         return externHasPromise(self, httpFuture);
     }
 
@@ -161,7 +161,7 @@ public client class HttpClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return externGetNextPromise(self, httpFuture);
     }
 
@@ -169,7 +169,7 @@ public client class HttpClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return externGetPromisedResponse(self, promise);
     }
 
@@ -177,60 +177,60 @@ public client class HttpClient {
     # response using the rejected promise.
     #
     # + promise - The Push Promise to be rejected
-    public remote function rejectPromise(PushPromise promise) {
+    public remote isolated function rejectPromise(PushPromise promise) {
         return externRejectPromise(self, promise);
     }
 }
 
-function externGetResponse(HttpClient httpClient, HttpFuture httpFuture) returns Response|ClientError =
+isolated function externGetResponse(HttpClient httpClient, HttpFuture httpFuture) returns Response|ClientError =
 @java:Method {
     'class: "org.ballerinalang.net.http.actions.httpclient.GetResponse",
     name: "getResponse"
 } external;
 
-function externHasPromise(HttpClient httpClient, HttpFuture httpFuture) returns boolean =
+isolated function externHasPromise(HttpClient httpClient, HttpFuture httpFuture) returns boolean =
 @java:Method {
     'class: "org.ballerinalang.net.http.actions.httpclient.HasPromise",
     name: "hasPromise"
 } external;
 
-function externGetNextPromise(HttpClient httpClient, HttpFuture httpFuture) returns PushPromise|ClientError =
+isolated function externGetNextPromise(HttpClient httpClient, HttpFuture httpFuture) returns PushPromise|ClientError =
 @java:Method {
     'class: "org.ballerinalang.net.http.actions.httpclient.GetNextPromise",
     name: "getNextPromise"
 } external;
 
-function externGetPromisedResponse(HttpClient httpClient, PushPromise promise) returns Response|ClientError =
+isolated function externGetPromisedResponse(HttpClient httpClient, PushPromise promise) returns Response|ClientError =
 @java:Method {
     'class: "org.ballerinalang.net.http.actions.httpclient.GetPromisedResponse",
     name: "getPromisedResponse"
 } external;
 
-function externRejectPromise(HttpClient httpClient, PushPromise promise) =
+isolated function externRejectPromise(HttpClient httpClient, PushPromise promise) =
 @java:Method {
     'class: "org.ballerinalang.net.http.actions.httpclient.HttpClientAction",
     name: "rejectPromise"
 } external;
 
-function externExecute(HttpClient caller, string httpVerb, string path, Request req) returns Response|ClientError =
+isolated function externExecute(HttpClient caller, string httpVerb, string path, Request req) returns Response|ClientError =
 @java:Method {
     'class: "org.ballerinalang.net.http.actions.httpclient.Execute",
     name: "execute"
 } external;
 
-function externSubmit(HttpClient caller, string httpVerb, string path, Request req) returns HttpFuture|ClientError =
+isolated function externSubmit(HttpClient caller, string httpVerb, string path, Request req) returns HttpFuture|ClientError =
 @java:Method {
     'class: "org.ballerinalang.net.http.actions.httpclient.Submit",
     name: "submit"
 } external;
 
-function externForward(HttpClient caller, string path, Request req) returns Response|ClientError =
+isolated function externForward(HttpClient caller, string path, Request req) returns Response|ClientError =
 @java:Method {
     'class: "org.ballerinalang.net.http.actions.httpclient.Forward",
     name: "forward"
 } external;
 
-function externExecuteClientAction(HttpClient caller, string path, Request req, string httpMethod)
+isolated function externExecuteClientAction(HttpClient caller, string path, Request req, string httpMethod)
                                   returns Response|ClientError =
 @java:Method {
     'class: "org.ballerinalang.net.http.actions.httpclient.HttpClientAction",
@@ -248,7 +248,7 @@ public type HttpTimeoutError record {|
     int statusCode = 0;
 |};
 
-function createClient(string url, ClientConfiguration config) returns HttpClient|ClientError {
+isolated function createClient(string url, ClientConfiguration config) returns HttpClient|ClientError {
     HttpClient simpleClient = new(url, config);
     return simpleClient;
 }

--- a/http-ballerina/src/http/http_client.bal
+++ b/http-ballerina/src/http/http_client.bal
@@ -32,7 +32,7 @@ public client class HttpClient {
     #
     # + url - URL of the target service
     # + config - The configurations to be used when initializing the `client`
-    public isolated function init(string url, ClientConfiguration? config = ()) {
+    public function init(string url, ClientConfiguration? config = ()) {
         self.config = config ?: {};
         self.url = url;
         createSimpleHttpClient(self, globalHttpClientConnPool);
@@ -137,7 +137,7 @@ public client class HttpClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation, or else an `http:ClientError` if the submission fails
-    public remote isolated function submit(@untainted string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote function submit(@untainted string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         return externSubmit(self, httpVerb, path, <Request>message);
     }
 
@@ -145,7 +145,7 @@ public client class HttpClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         return externGetResponse(self, httpFuture);
     }
 
@@ -153,7 +153,7 @@ public client class HttpClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote isolated function hasPromise(HttpFuture httpFuture) returns boolean {
+    public remote function hasPromise(HttpFuture httpFuture) returns boolean {
         return externHasPromise(self, httpFuture);
     }
 
@@ -161,7 +161,7 @@ public client class HttpClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return externGetNextPromise(self, httpFuture);
     }
 
@@ -169,7 +169,7 @@ public client class HttpClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return externGetPromisedResponse(self, promise);
     }
 
@@ -177,7 +177,7 @@ public client class HttpClient {
     # response using the rejected promise.
     #
     # + promise - The Push Promise to be rejected
-    public remote isolated function rejectPromise(PushPromise promise) {
+    public remote function rejectPromise(PushPromise promise) {
         return externRejectPromise(self, promise);
     }
 }
@@ -248,7 +248,7 @@ public type HttpTimeoutError record {|
     int statusCode = 0;
 |};
 
-isolated function createClient(string url, ClientConfiguration config) returns HttpClient|ClientError {
+function createClient(string url, ClientConfiguration config) returns HttpClient|ClientError {
     HttpClient simpleClient = new(url, config);
     return simpleClient;
 }

--- a/http-ballerina/src/http/http_client.bal
+++ b/http-ballerina/src/http/http_client.bal
@@ -44,7 +44,7 @@ public client class HttpClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function post(@untainted string path, RequestMessage message) returns Response|ClientError {
+    public remote function post(@untainted string path, RequestMessage message) returns Response|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_POST);
     }
 
@@ -54,7 +54,7 @@ public client class HttpClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` for the request or else an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function head(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function head(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_HEAD);
     }
 
@@ -64,7 +64,7 @@ public client class HttpClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` for the request or else an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function put(@untainted string path, RequestMessage message) returns Response|ClientError {
+    public remote function put(@untainted string path, RequestMessage message) returns Response|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_PUT);
     }
 
@@ -75,7 +75,7 @@ public client class HttpClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` for the request or else an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function execute(@untainted string httpVerb, @untainted string path, RequestMessage message) returns Response|ClientError {
+    public remote function execute(@untainted string httpVerb, @untainted string path, RequestMessage message) returns Response|ClientError {
         return externExecute(self, httpVerb, path, <Request>message);
     }
 
@@ -85,7 +85,7 @@ public client class HttpClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or else an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function patch(@untainted string path, RequestMessage message) returns Response|ClientError {
+    public remote function patch(@untainted string path, RequestMessage message) returns Response|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_PATCH);
     }
 
@@ -95,7 +95,7 @@ public client class HttpClient {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` for the request or else an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function delete(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function delete(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_DELETE);
     }
 
@@ -105,7 +105,7 @@ public client class HttpClient {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` for the request or else an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function get(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function get(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_GET);
     }
 
@@ -115,7 +115,7 @@ public client class HttpClient {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or else an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function options(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function options(@untainted string path, RequestMessage message = ()) returns Response|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_OPTIONS);
     }
 
@@ -124,7 +124,7 @@ public client class HttpClient {
     # + path - Request path
     # + request - An HTTP inbound request message
     # + return - An `http:Response` for the request or else an `http:ClientError` if failed to establish communication with the upstream server
-    public remote isolated function forward(@untainted string path, Request request) returns Response|ClientError {
+    public remote function forward(@untainted string path, Request request) returns Response|ClientError {
         return externForward(self, path, request);
     }
 

--- a/http-ballerina/src/http/http_client_connection_pool.bal
+++ b/http-ballerina/src/http/http_client_connection_pool.bal
@@ -32,20 +32,21 @@ public type PoolConfiguration record {
 
 //This is a hack to get the global map initialized, without involving locking.
 class ConnectionManager {
-    public PoolConfiguration poolConfig = {};
-    public function init() {
+    public PoolConfiguration & readonly poolConfig = {};
+    public isolated function init() {
         self.initGlobalPool(self.poolConfig);
     }
-    function initGlobalPool(PoolConfiguration poolConfig) {
+
+    isolated function initGlobalPool(PoolConfiguration poolConfig) {
         return externInitGlobalPool(poolConfig);
     }
 }
 
-function externInitGlobalPool(PoolConfiguration poolConfig) =
+isolated function externInitGlobalPool(PoolConfiguration poolConfig) =
 @java:Method {
     'class: "org.ballerinalang.net.http.clientendpoint.InitGlobalPool",
     name: "initGlobalPool"
 } external;
 
 ConnectionManager connectionManager = new;
-PoolConfiguration globalHttpClientConnPool = connectionManager.poolConfig;
+final PoolConfiguration & readonly globalHttpClientConnPool = connectionManager.poolConfig;

--- a/http-ballerina/src/http/http_commons.bal
+++ b/http-ballerina/src/http/http_commons.bal
@@ -191,7 +191,7 @@ isolated function buildResponse(ResponseMessage message) returns Response {
 # + httpClient - HTTP client which uses to call the relevant functions
 # + verb - HTTP verb used for submit method
 # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-public isolated function invokeEndpoint (string path, Request outRequest, HttpOperation requestAction, HttpClient httpClient,
+public function invokeEndpoint (string path, Request outRequest, HttpOperation requestAction, HttpClient httpClient,
                                                                     string verb = "") returns HttpResponse|ClientError {
 
     if (HTTP_GET == requestAction) {

--- a/http-ballerina/src/http/http_commons.bal
+++ b/http-ballerina/src/http/http_commons.bal
@@ -19,7 +19,7 @@ import ballerina/mime;
 import ballerina/io;
 import ballerina/observe;
 
-boolean observabilityEnabled = observe:isObservabilityEnabled();
+final boolean observabilityEnabled = observe:isObservabilityEnabled();
 
 # The types of messages that are accepted by HTTP `client` when sending out the outbound request.
 public type RequestMessage Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|();
@@ -131,12 +131,12 @@ public type CommonClientConfiguration record {|
 # + headerValue - The header value
 # + return - A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails
 //TODO: Make the error nillable
-public function parseHeader(string headerValue) returns [string, map<any>]|ClientError = @java:Method {
+public isolated function parseHeader(string headerValue) returns [string, map<any>]|ClientError = @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ParseHeader",
     name: "parseHeader"
 } external;
 
-function buildRequest(RequestMessage message) returns Request {
+isolated function buildRequest(RequestMessage message) returns Request {
     Request request = new;
     if (message is ()) {
         request.noEntityBody = true;
@@ -160,7 +160,7 @@ function buildRequest(RequestMessage message) returns Request {
     return request;
 }
 
-function buildResponse(ResponseMessage message) returns Response {
+isolated function buildResponse(ResponseMessage message) returns Response {
     Response response = new;
     if (message is ()) {
         return response;
@@ -191,7 +191,7 @@ function buildResponse(ResponseMessage message) returns Response {
 # + httpClient - HTTP client which uses to call the relevant functions
 # + verb - HTTP verb used for submit method
 # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-public function invokeEndpoint (string path, Request outRequest, HttpOperation requestAction, HttpClient httpClient,
+public isolated function invokeEndpoint (string path, Request outRequest, HttpOperation requestAction, HttpClient httpClient,
                                                                     string verb = "") returns HttpResponse|ClientError {
 
     if (HTTP_GET == requestAction) {
@@ -226,7 +226,7 @@ public function invokeEndpoint (string path, Request outRequest, HttpOperation r
 }
 
 // Extracts HttpOperation from the Http verb passed in.
-function extractHttpOperation (string httpVerb) returns HttpOperation {
+isolated function extractHttpOperation (string httpVerb) returns HttpOperation {
     HttpOperation inferredConnectorAction = HTTP_NONE;
     if ("GET" == httpVerb) {
         inferredConnectorAction = HTTP_GET;
@@ -252,7 +252,7 @@ function extractHttpOperation (string httpVerb) returns HttpOperation {
 
 // Populate boolean index array by looking at the configured Http status codes to get better performance
 // at runtime.
-function populateErrorCodeIndex (int[] errorCode) returns boolean[] {
+isolated function populateErrorCodeIndex (int[] errorCode) returns boolean[] {
     boolean[] result = [];
     foreach var i in errorCode {
         result[i] = true;
@@ -260,11 +260,11 @@ function populateErrorCodeIndex (int[] errorCode) returns boolean[] {
     return result;
 }
 
-function getError() returns UnsupportedActionError {
+isolated function getError() returns UnsupportedActionError {
     return UnsupportedActionError("Unsupported connector action received.");
 }
 
-function populateRequestFields (Request originalRequest, Request newRequest)  {
+isolated function populateRequestFields (Request originalRequest, Request newRequest)  {
     newRequest.rawPath = originalRequest.rawPath;
     newRequest.method = originalRequest.method;
     newRequest.httpVersion = originalRequest.httpVersion;
@@ -273,7 +273,7 @@ function populateRequestFields (Request originalRequest, Request newRequest)  {
     newRequest.extraPathInfo = originalRequest.extraPathInfo;
 }
 
-function populateMultipartRequest(Request inRequest) returns Request|ClientError {
+isolated function populateMultipartRequest(Request inRequest) returns Request|ClientError {
     if (isMultipartRequest(inRequest)) {
         mime:Entity[] bodyParts = check inRequest.getBodyParts();
         foreach var bodyPart in bodyParts {
@@ -301,17 +301,17 @@ function populateMultipartRequest(Request inRequest) returns Request|ClientError
     return inRequest;
 }
 
-function isMultipartRequest(Request request) returns @tainted boolean {
+isolated function isMultipartRequest(Request request) returns @tainted boolean {
     return request.hasHeader(mime:CONTENT_TYPE) &&
         request.getHeader(mime:CONTENT_TYPE).startsWith(MULTIPART_AS_PRIMARY_TYPE);
 }
 
-function isNestedEntity(mime:Entity entity) returns @tainted boolean {
+isolated function isNestedEntity(mime:Entity entity) returns @tainted boolean {
     return entity.hasHeader(mime:CONTENT_TYPE) &&
         entity.getHeader(mime:CONTENT_TYPE).startsWith(MULTIPART_AS_PRIMARY_TYPE);
 }
 
-function createFailoverRequest(Request request, mime:Entity requestEntity) returns Request|ClientError {
+isolated function createFailoverRequest(Request request, mime:Entity requestEntity) returns Request|ClientError {
     if (isMultipartRequest(request)) {
         return populateMultipartRequest(request);
     } else {
@@ -322,23 +322,23 @@ function createFailoverRequest(Request request, mime:Entity requestEntity) retur
     }
 }
 
-function getInvalidTypeError() returns ClientError {
+isolated function getInvalidTypeError() returns ClientError {
     return GenericClientError("Invalid return type found for the HTTP operation");
 }
 
-function createErrorForNoPayload(mime:Error err) returns GenericClientError {
+isolated function createErrorForNoPayload(mime:Error err) returns GenericClientError {
     string message = "No payload";
     return GenericClientError(message, err);
 }
 
-function getStatusCodeRange(int statusCode) returns string {
+isolated function getStatusCodeRange(int statusCode) returns string {
     return statusCode.toString().substring(0,1) + STATUS_CODE_GROUP_SUFFIX;
 }
 
 # Returns a random UUID string.
 #
 # + return - The random string
-function uuid() returns string {
+isolated function uuid() returns string {
     var result = java:toString(nativeUuid());
     if (result is string) {
         return result;
@@ -352,47 +352,47 @@ function uuid() returns string {
 # + path - Resource path
 # + method - http method of the request
 # + statusCode - status code of the response
-function addObservabilityInformation(string path, string method, int statusCode, string url) {
-    error? err = observe:addTagToSpan(HTTP_URL, path);
-    err = observe:addTagToSpan(HTTP_METHOD, method);
-    err = observe:addTagToSpan(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(statusCode));
-    err = observe:addTagToSpan(HTTP_BASE_URL, url);
+isolated function addObservabilityInformation(string path, string method, int statusCode, string url) {
+    // error? err = observe:addTagToSpan(HTTP_URL, path);
+    // err = observe:addTagToSpan(HTTP_METHOD, method);
+    // err = observe:addTagToSpan(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(statusCode));
+    // err = observe:addTagToSpan(HTTP_BASE_URL, url);
 }
 
 //Resolve a given path against a given URI.
-function resolve(string baseUrl, string path) returns string|ClientError = @java:Method {
+isolated function resolve(string baseUrl, string path) returns string|ClientError = @java:Method {
     'class: "org.ballerinalang.net.uri.nativeimpl.Resolve",
     name: "resolve"
 } external;
 
 //Returns a random UUID string.
-function nativeUuid() returns handle = @java:Method {
+isolated function nativeUuid() returns handle = @java:Method {
     name: "randomUUID",
     'class: "java.util.UUID"
 } external;
 
-// Non-blocking payload retrieval common external functions
-function externGetJson(mime:Entity entity) returns @tainted json|mime:ParserError = @java:Method {
+// Non-blocking payload retrieval common external isolated functions
+isolated function externGetJson(mime:Entity entity) returns @tainted json|mime:ParserError = @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHttpDataSourceBuilder",
     name: "getNonBlockingJson"
 } external;
 
-function externGetXml(mime:Entity entity) returns @tainted xml|mime:ParserError = @java:Method {
+isolated function externGetXml(mime:Entity entity) returns @tainted xml|mime:ParserError = @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHttpDataSourceBuilder",
     name: "getNonBlockingXml"
 } external;
 
-function externGetText(mime:Entity entity) returns @tainted string|mime:ParserError = @java:Method {
+isolated function externGetText(mime:Entity entity) returns @tainted string|mime:ParserError = @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHttpDataSourceBuilder",
     name: "getNonBlockingText"
 } external;
 
-function externGetByteArray(mime:Entity entity) returns @tainted byte[]|mime:ParserError = @java:Method {
+isolated function externGetByteArray(mime:Entity entity) returns @tainted byte[]|mime:ParserError = @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHttpDataSourceBuilder",
     name: "getNonBlockingByteArray"
 } external;
 
-function externGetByteChannel(mime:Entity entity) returns @tainted io:ReadableByteChannel|mime:ParserError =
+isolated function externGetByteChannel(mime:Entity entity) returns @tainted io:ReadableByteChannel|mime:ParserError =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHttpDataSourceBuilder",
     name: "getByteChannel"

--- a/http-ballerina/src/http/http_commons.bal
+++ b/http-ballerina/src/http/http_commons.bal
@@ -353,10 +353,10 @@ isolated function uuid() returns string {
 # + method - http method of the request
 # + statusCode - status code of the response
 isolated function addObservabilityInformation(string path, string method, int statusCode, string url) {
-    // error? err = observe:addTagToSpan(HTTP_URL, path);
-    // err = observe:addTagToSpan(HTTP_METHOD, method);
-    // err = observe:addTagToSpan(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(statusCode));
-    // err = observe:addTagToSpan(HTTP_BASE_URL, url);
+    error? err = observe:addTagToSpan(HTTP_URL, path);
+    err = observe:addTagToSpan(HTTP_METHOD, method);
+    err = observe:addTagToSpan(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(statusCode));
+    err = observe:addTagToSpan(HTTP_BASE_URL, url);
 }
 
 //Resolve a given path against a given URI.

--- a/http-ballerina/src/http/http_connection.bal
+++ b/http-ballerina/src/http/http_connection.bal
@@ -36,7 +36,7 @@ public client class Caller {
     # + message - The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:ListenerError` if failed to respond or else `()`
-    public remote function respond(ResponseMessage message = ()) returns ListenerError? {
+    public remote isolated function respond(ResponseMessage message = ()) returns ListenerError? {
         Response response = buildResponse(message);
         FilterContext? filterContext = self.filterContext;
         (RequestFilter | ResponseFilter)[] filters = self.config.filters;
@@ -60,7 +60,7 @@ public client class Caller {
     #
     # + promise - Push promise message
     # + return - An `http:ListenerError` in case of failures
-    public remote function promise(PushPromise promise) returns ListenerError? {
+    public remote isolated function promise(PushPromise promise) returns ListenerError? {
         return externPromise(self, promise);
     }
 
@@ -69,7 +69,7 @@ public client class Caller {
     # + promise - Push promise message
     # + response - The outbound response
     # + return - An `http:ListenerError` in case of failures while responding with the promised response
-    public remote function pushPromisedResponse(PushPromise promise, Response response)
+    public remote isolated function pushPromisedResponse(PushPromise promise, Response response)
                                                                 returns ListenerError? {
         return externPushPromisedResponse(self, promise, response);
     }
@@ -78,7 +78,7 @@ public client class Caller {
     #
     # + headers - A `map` of custom headers for handshake
     # + return - An `http:WebSocketCaller` instance or else an `http:WebSocketError` on failure to upgrade
-    public remote function acceptWebSocketUpgrade(map<string> headers) 
+    public remote isolated function acceptWebSocketUpgrade(map<string> headers) 
                                                 returns WebSocketCaller | WebSocketError {
         return externAcceptWebSocketUpgrade(self, headers);
     }
@@ -89,14 +89,14 @@ public client class Caller {
     #            This error status code need to be 4xx or 5xx else the default status code would be 400.
     # + reason - Reason for cancelling the upgrade
     # + return - An `error` if an error occurs during cancelling the upgrade or nil
-    public remote function cancelWebSocketUpgrade(int status, string reason) returns WebSocketError? {
+    public remote isolated function cancelWebSocketUpgrade(int status, string reason) returns WebSocketError? {
         return externCancelWebSocketUpgrade(self, status, reason);
     }
 
     # Sends a `100-continue` response to the caller.
     #
     # + return - An `http:ListenerError` if failed to send the `100-continue` response or else `()`
-    public remote function 'continue() returns ListenerError? {
+    public remote isolated function 'continue() returns ListenerError? {
         Response res = new;
         res.statusCode = STATUS_CONTINUE;
         return self->respond(res);
@@ -108,7 +108,7 @@ public client class Caller {
     # + code - The redirect status code to be sent
     # + locations - An array of URLs to which the caller can redirect to
     # + return - An `http:ListenerError` if failed to send the redirect response or else `()`
-    public remote function redirect(Response response, RedirectCode code, string[] locations) returns ListenerError? {
+    public remote isolated function redirect(Response response, RedirectCode code, string[] locations) returns ListenerError? {
         if (code == REDIRECT_MULTIPLE_CHOICES_300) {
             response.statusCode = STATUS_MULTIPLE_CHOICES;
         } else if (code == REDIRECT_MOVED_PERMANENTLY_301) {
@@ -141,7 +141,7 @@ public client class Caller {
     # + message - The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - An `http:ListenerError` if failed to respond or else `()`
-    public remote function ok(ResponseMessage message = ()) returns ListenerError? {
+    public remote isolated function ok(ResponseMessage message = ()) returns ListenerError? {
         Response response = buildResponse(message);
         response.statusCode = STATUS_OK;
         return self->respond(response);
@@ -153,7 +153,7 @@ public client class Caller {
     # + message - The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`. This message is optional.
     # + return - An `http:ListenerError` if failed to respond or else `()`
-    public remote function created(string uri, ResponseMessage message = ()) returns ListenerError? {
+    public remote isolated function created(string uri, ResponseMessage message = ()) returns ListenerError? {
         Response response = buildResponse(message);
         response.statusCode = STATUS_CREATED;
         if (uri.length() > 0) {
@@ -167,7 +167,7 @@ public client class Caller {
     # + message - The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`. This message is optional.
     # + return - An `http:ListenerError` if failed to respond or else `()`
-    public remote function accepted(ResponseMessage message = ()) returns ListenerError? {
+    public remote isolated function accepted(ResponseMessage message = ()) returns ListenerError? {
         Response response = buildResponse(message);
         response.statusCode = STATUS_ACCEPTED;
         return self->respond(response);
@@ -181,7 +181,7 @@ public client class Caller {
     #
     # + message - The outbound response, which is optional
     # + return - An `http:ListenerError` if failed to respond or else `()`
-    public remote function noContent(Response? message = ()) returns ListenerError? {
+    public remote isolated function noContent(Response? message = ()) returns ListenerError? {
         Response newResponse = new;
         if message is Response {
             newResponse = message;
@@ -198,7 +198,7 @@ public client class Caller {
     # + message - The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ByteChannel`,
     #             or `mime:Entity[]`
     # + return - An `http:ListenerError` if failed to respond or else `()`
-    public remote function badRequest(ResponseMessage message = ()) returns ListenerError? {
+    public remote isolated function badRequest(ResponseMessage message = ()) returns ListenerError? {
         Response response = buildResponse(message);
         response.statusCode = STATUS_BAD_REQUEST;
         return self->respond(response);
@@ -212,7 +212,7 @@ public client class Caller {
     # + message - The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ByteChannel`,
     #             or `mime:Entity[]`
     # + return - An `http:ListenerError` if failed to respond or else `()`
-    public remote function notFound(ResponseMessage message = ()) returns ListenerError? {
+    public remote isolated function notFound(ResponseMessage message = ()) returns ListenerError? {
         Response response = buildResponse(message);
         response.statusCode = STATUS_NOT_FOUND;
         return self->respond(response);
@@ -226,7 +226,7 @@ public client class Caller {
     # + message - The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ByteChannel`,
     #             or `mime:Entity[]`
     # + return - An `http:ListenerError` if failed to respond or else `()`
-    public remote function internalServerError(ResponseMessage message = ()) returns ListenerError? {
+    public remote isolated function internalServerError(ResponseMessage message = ()) returns ListenerError? {
         Response response = buildResponse(message);
         response.statusCode = STATUS_INTERNAL_SERVER_ERROR;
         return self->respond(response);
@@ -239,17 +239,17 @@ public client class Caller {
     # ```
     #
     # + return - The hostname of the address or else `()` if it is unresolved
-    public function getRemoteHostName() returns string? {
+    public isolated function getRemoteHostName() returns string? {
         return nativeGetRemoteHostName(self);
     }
 }
 
-function nativeRespond(Caller caller, Response response) returns ListenerError? = @java:Method {
+isolated function nativeRespond(Caller caller, Response response) returns ListenerError? = @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.connection.Respond",
     name: "nativeRespond"
 } external;
 
-function nativeGetRemoteHostName(Caller caller) returns string = @java:Method {
+isolated function nativeGetRemoteHostName(Caller caller) returns string = @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.connection.GetRemoteHostName",
     name: "nativeGetRemoteHostName"
 } external;
@@ -279,25 +279,25 @@ public const REDIRECT_TEMPORARY_REDIRECT_307 = 307;
 # Represents the HTTP redirect status code `308 - Permanent Redirect`.
 public const REDIRECT_PERMANENT_REDIRECT_308 = 308;
 
-function externPromise(Caller caller, PushPromise promise) returns ListenerError? =
+isolated function externPromise(Caller caller, PushPromise promise) returns ListenerError? =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.connection.Promise",
     name: "promise"
 } external;
 
-function externPushPromisedResponse(Caller caller, PushPromise promise, Response response) returns ListenerError? =
+isolated function externPushPromisedResponse(Caller caller, PushPromise promise, Response response) returns ListenerError? =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.connection.PushPromisedResponse",
     name: "pushPromisedResponse"
 } external;
 
-function externAcceptWebSocketUpgrade(Caller caller, map<string> headers) returns WebSocketCaller | WebSocketError =
+isolated function externAcceptWebSocketUpgrade(Caller caller, map<string> headers) returns WebSocketCaller | WebSocketError =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.connection.AcceptWebSocketUpgrade",
     name: "acceptWebSocketUpgrade"
 } external;
 
-function externCancelWebSocketUpgrade(Caller caller, int status, string reason) returns WebSocketError? =
+isolated function externCancelWebSocketUpgrade(Caller caller, int status, string reason) returns WebSocketError? =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.connection.CancelWebSocketUpgrade",
     name: "cancelWebSocketUpgrade",

--- a/http-ballerina/src/http/http_filter.bal
+++ b/http-ballerina/src/http/http_filter.bal
@@ -25,7 +25,7 @@ public type RequestFilter object {
     # + request - An inbound HTTP request message
     # + context - A filter context
     # + return - True if the filter succeeds
-    public function filterRequest(Caller caller, Request request, FilterContext context) returns boolean;
+    public isolated function filterRequest(Caller caller, Request request, FilterContext context) returns boolean;
 };
 
 # Abstract Representation of a HTTP Response Filter.
@@ -37,7 +37,7 @@ public type ResponseFilter object {
     # + response - An outbound HTTP response message
     # + context - A filter context
     # + return - True if the filter succeeds
-    public function filterResponse(Response response, FilterContext context) returns boolean;
+    public isolated function filterResponse(Response response, FilterContext context) returns boolean;
 };
 
 # Representation of request filter Context.
@@ -58,7 +58,7 @@ public class FilterContext {
     # + serviceRef - The service to which the context is applied
     # + serviceName - Name of the service
     # + resourceName - Name of the resource function
-    public function init(service serviceRef, string serviceName, string resourceName) {
+    public isolated function init(service serviceRef, string serviceName, string resourceName) {
         self.serviceRef = serviceRef;
         self.serviceName = serviceName;
         self.resourceName = resourceName;
@@ -67,21 +67,21 @@ public class FilterContext {
     # Gets the service to which the `http:FilerContext` is applied.
     #
     # + return  - `service` of the context
-    public function getService() returns service {
+    public isolated function getService() returns service {
         return self.serviceRef;
     }
 
     # Gets the service name to which the `http:FilerContext` is applied.
     #
     # + return  - Name of the `service`
-    public function getServiceName() returns string {
+    public isolated function getServiceName() returns string {
         return self.serviceName;
     }
 
     # Gets the resource function name to which the `http:FilerContext` is applied.
     #
     # + return  - Name of the resource function
-    public function getResourceName() returns string {
+    public isolated function getResourceName() returns string {
         return self.resourceName;
     }
 }

--- a/http-ballerina/src/http/http_request.bal
+++ b/http-ballerina/src/http/http_request.bal
@@ -45,7 +45,7 @@ public class Request {
     private boolean dirtyRequest;
     boolean noEntityBody;
 
-    public function init() {
+    public isolated function init() {
         self.dirtyRequest = false;
         self.noEntityBody = false;
         self.entity = self.createNewEntity();
@@ -54,28 +54,28 @@ public class Request {
     # Create a new `Entity` and link it with the request.
     #
     # + return - Newly created `Entity` that has been set to the request
-    function createNewEntity() returns mime:Entity {
+    isolated function createNewEntity() returns mime:Entity {
         return externCreateNewReqEntity(self);
     }
 
     # Sets the provided `Entity` to the request.
     #
     # + e - The `Entity` to be set to the request
-    public function setEntity(mime:Entity e) {
+    public isolated function setEntity(mime:Entity e) {
         return externSetReqEntity(self, e);
     }
 
     # Sets the provided `Entity` to the request and update only the content type header in the transport message.
     #
     # + e - The `Entity` to be set to the request
-    function setEntityAndUpdateContentTypeHeader(mime:Entity e) {
+    isolated function setEntityAndUpdateContentTypeHeader(mime:Entity e) {
         return externSetReqEntityAndUpdateContentTypeHeader(self, e);
     }
 
     # Gets the query parameters of the request as a map consisting of a string array.
     #
     # + return - String array map of the query params
-    public function getQueryParams() returns map<string[]> {
+    public isolated function getQueryParams() returns map<string[]> {
         return externGetQueryParams(self);
     }
 
@@ -84,7 +84,7 @@ public class Request {
     # + key - Represents the query param key
     # + return - The query param value associated with the given key as a string. If multiple param values are
     #            present, then the first value is returned. `()` is returned if no key is found.
-    public function getQueryParamValue(@untainted string key) returns @tainted string? {
+    public isolated function getQueryParamValue(@untainted string key) returns @tainted string? {
         map<string[]> params = self.getQueryParams();
         var result = params[key];
         return result is () ? () : result[0];
@@ -95,7 +95,7 @@ public class Request {
     # + key - Represents the query param key
     # + return - All the query param values associated with the given key as a `string[]`. `()` is returned if no key
     #            is found.
-    public function getQueryParamValues(@untainted string key) returns @tainted string[]? {
+    public isolated function getQueryParamValues(@untainted string key) returns @tainted string[]? {
         map<string[]> params = self.getQueryParams();
         return params[key];
     }
@@ -104,26 +104,26 @@ public class Request {
     #
     # + path - Path to the location of matrix parameters
     # + return - A map of matrix parameters which can be found for the given path
-    public function getMatrixParams(string path) returns map<any> {
+    public isolated function getMatrixParams(string path) returns map<any> {
         return externGetMatrixParams(self, path);
     }
 
     # Gets the `Entity` associated with the request.
     #
     # + return - The `Entity` of the request. An `http:ClientError` is returned, if entity construction fails
-    public function getEntity() returns mime:Entity|ClientError {
+    public isolated function getEntity() returns mime:Entity|ClientError {
         return externGetReqEntity(self);
     }
 
     // Gets the `Entity` from the request without the body and headers. This function is exposed only to be used
     // internally.
-    function getEntityWithoutBodyAndHeaders() returns mime:Entity {
+    isolated function getEntityWithoutBodyAndHeaders() returns mime:Entity {
         return externGetEntityWithoutBodyAndHeaders(self);
     }
 
     // Gets the `Entity` from the request with the body, but without headers. This function is used for Http level
     // functions.
-    function getEntityWithBodyAndWithoutHeaders() returns mime:Entity|ClientError {
+    isolated function getEntityWithBodyAndWithoutHeaders() returns mime:Entity|ClientError {
         return externGetEntityWithBodyAndWithoutHeaders(self);
     }
 
@@ -131,7 +131,7 @@ public class Request {
     #
     # + headerName - The header name
     # + return - Returns true if the specified header key exists
-    public function hasHeader(string headerName) returns boolean {
+    public isolated function hasHeader(string headerName) returns boolean {
         return externRequestHasHeader(self, headerName);
     }
 
@@ -141,7 +141,7 @@ public class Request {
     # + headerName - The header name
     # + return - The first header value for the specified header name. Panic if the header is not found. Use the
     #            `Request.hasHeader()` beforehand to check the existence of a header.
-    public function getHeader(string headerName) returns @tainted string {
+    public isolated function getHeader(string headerName) returns @tainted string {
         return externRequestGetHeader(self, headerName);
     }
 
@@ -150,7 +150,7 @@ public class Request {
     # + headerName - The header name
     # + return - The header values the specified header key maps to. Panic if the header is not found. Use the
     #            `Request.hasHeader()` beforehand to check the existence of a header.
-    public function getHeaders(string headerName) returns @tainted string[] {
+    public isolated function getHeaders(string headerName) returns @tainted string[] {
         return externRequestGetHeaders(self, headerName);
     }
 
@@ -159,7 +159,7 @@ public class Request {
     #
     # + headerName - The header name
     # + headerValue - The header value
-    public function setHeader(string headerName, string headerValue) {
+    public isolated function setHeader(string headerName, string headerValue) {
         externRequestSetHeader(self, headerName, headerValue);
     }
 
@@ -167,33 +167,33 @@ public class Request {
     #
     # + headerName - The header name
     # + headerValue - The header value
-    public function addHeader(string headerName, string headerValue) {
+    public isolated function addHeader(string headerName, string headerValue) {
         externRequestAddHeader(self, headerName, headerValue);
     }
 
     # Removes the specified header from the request.
     #
     # + headerName - The header name
-    public function removeHeader(string headerName) {
+    public isolated function removeHeader(string headerName) {
         externRequestRemoveHeader(self, headerName);
     }
 
     # Removes all the headers from the request.
-    public function removeAllHeaders() {
+    public isolated function removeAllHeaders() {
         return externRequestRemoveAllHeaders(self);
     }
 
     # Gets all the names of the headers of the request.
     #
     # + return - An array of all the header names
-    public function getHeaderNames() returns @tainted string[] {
+    public isolated function getHeaderNames() returns @tainted string[] {
         return externRequestGetHeaderNames(self);
     }
 
     # Checks whether the client expects a `100-continue` response.
     #
     # + return - Returns true if the client expects a `100-continue` response
-    public function expects100Continue() returns boolean {
+    public isolated function expects100Continue() returns boolean {
         return <@untainted> (self.hasHeader(EXPECT) ? self.getHeader(EXPECT) == "100-continue" : false);
     }
 
@@ -201,21 +201,21 @@ public class Request {
     #
     # + contentType - Content type value to be set as the `content-type` header
     # + return - Nil if successful, error in case of invalid content-type
-    public function setContentType(string contentType) returns error? {
+    public isolated function setContentType(string contentType) returns error? {
         return trap self.setHeader(mime:CONTENT_TYPE, contentType);
     }
 
     # Gets the type of the payload of the request (i.e: the `content-type` header value).
     #
     # + return - The `content-type` header value as a string
-    public function getContentType() returns @tainted string {
+    public isolated function getContentType() returns @tainted string {
         return self.getHeader(mime:CONTENT_TYPE);
     }
 
     # Extracts `json` payload from the request. If the content type is not JSON, an `http:ClientError` is returned.
     #
     # + return - The `json` payload or `http:ClientError` in case of errors
-    public function getJsonPayload() returns @tainted json|ClientError {
+    public isolated function getJsonPayload() returns @tainted json|ClientError {
         var result = self.getEntityWithBodyAndWithoutHeaders();
         if (result is error) {
             return result;
@@ -237,7 +237,7 @@ public class Request {
     # Extracts `xml` payload from the request. If the content type is not XML, an `http:ClientError` is returned.
     #
     # + return - The `xml` payload or `http:ClientError` in case of errors
-    public function getXmlPayload() returns @tainted xml|ClientError {
+    public isolated function getXmlPayload() returns @tainted xml|ClientError {
         var result = self.getEntityWithBodyAndWithoutHeaders();
         if (result is error) {
             return result;
@@ -259,7 +259,7 @@ public class Request {
     # Extracts `text` payload from the request. If the content type is not of type text, an `http:ClientError` is returned.
     #
     # + return - The `text` payload or `http:ClientError` in case of errors
-    public function getTextPayload() returns @tainted string|ClientError {
+    public isolated function getTextPayload() returns @tainted string|ClientError {
         var result = self.getEntityWithBodyAndWithoutHeaders();
         if (result is error) {
             return result;
@@ -282,7 +282,7 @@ public class Request {
     # `Request.getBodyParts()`.
     #
     # + return - A byte channel from which the message payload can be read or `http:ClientError` in case of errors
-    public function getByteChannel() returns @tainted io:ReadableByteChannel|ClientError {
+    public isolated function getByteChannel() returns @tainted io:ReadableByteChannel|ClientError {
         var result = self.getEntityWithBodyAndWithoutHeaders();
         if (result is error) {
             return result;
@@ -300,7 +300,7 @@ public class Request {
     # Gets the request payload as a `byte[]`.
     #
     # + return - The byte[] representation of the message payload or `http:ClientError` in case of errors
-    public function getBinaryPayload() returns @tainted byte[]|ClientError {
+    public isolated function getBinaryPayload() returns @tainted byte[]|ClientError {
         var result = self.getEntityWithBodyAndWithoutHeaders();
         if (result is error) {
             return result;
@@ -318,7 +318,7 @@ public class Request {
     # Gets the form parameters from the HTTP request as a `map` when content type is application/x-www-form-urlencoded.
     #
     # + return - The map of form params or `http:ClientError` in case of errors
-    public function getFormParams() returns @tainted map<string>|ClientError {
+    public isolated function getFormParams() returns @tainted map<string>|ClientError {
         var mimeEntity = self.getEntityWithBodyAndWithoutHeaders();
         if (mimeEntity is error) {
             return mimeEntity;
@@ -374,7 +374,7 @@ public class Request {
 
     # + return - The body parts as an array of entities or else an `http:ClientError` if there were any errors
     #            constructing the body parts from the request
-    public function getBodyParts() returns mime:Entity[]|ClientError {
+    public isolated function getBodyParts() returns mime:Entity[]|ClientError {
         var result = self.getEntity();
         if (result is ClientError) {
             return result;
@@ -394,7 +394,7 @@ public class Request {
     # + payload - The `json` payload
     # + contentType - The content type of the payload. Set this to override the default `content-type` header value
     #                 for `json`
-    public function setJsonPayload(json payload, string contentType = "application/json") {
+    public isolated function setJsonPayload(json payload, string contentType = "application/json") {
         mime:Entity entity = self.getEntityWithoutBodyAndHeaders();
         entity.setJson(payload, contentType);
         self.setEntityAndUpdateContentTypeHeader(entity);
@@ -405,7 +405,7 @@ public class Request {
     # + payload - The `xml` payload
     # + contentType - The content type of the payload. Set this to override the default `content-type` header value
     #                 for `xml`
-    public function setXmlPayload(xml payload, string contentType = "application/xml") {
+    public isolated function setXmlPayload(xml payload, string contentType = "application/xml") {
         mime:Entity entity = self.getEntityWithoutBodyAndHeaders();
         entity.setXml(payload, contentType);
         self.setEntityAndUpdateContentTypeHeader(entity);
@@ -416,7 +416,7 @@ public class Request {
     # + payload - The `string` payload
     # + contentType - The content type of the payload. Set this to override the default `content-type` header value
     #                 for `string`
-    public function setTextPayload(string payload, string contentType = "text/plain") {
+    public isolated function setTextPayload(string payload, string contentType = "text/plain") {
         mime:Entity entity = self.getEntityWithoutBodyAndHeaders();
         entity.setText(payload, contentType);
         self.setEntityAndUpdateContentTypeHeader(entity);
@@ -427,7 +427,7 @@ public class Request {
     # + payload - The `byte[]` payload
     # + contentType - The content type of the payload. Set this to override the default `content-type` header value
     #                 for `byte[]`
-    public function setBinaryPayload(byte[] payload, string contentType = "application/octet-stream") {
+    public isolated function setBinaryPayload(byte[] payload, string contentType = "application/octet-stream") {
         mime:Entity entity = self.getEntityWithoutBodyAndHeaders();
         entity.setByteArray(payload, contentType);
         self.setEntityAndUpdateContentTypeHeader(entity);
@@ -438,7 +438,7 @@ public class Request {
     # + bodyParts - The entities which make up the message body
     # + contentType - The content type of the top level message. Set this to override the default
     #                 `content-type` header value
-    public function setBodyParts(mime:Entity[] bodyParts, string contentType = "multipart/form-data") {
+    public isolated function setBodyParts(mime:Entity[] bodyParts, string contentType = "multipart/form-data") {
         mime:Entity entity = self.getEntityWithoutBodyAndHeaders();
         entity.setBodyParts(bodyParts, contentType);
         self.setEntityAndUpdateContentTypeHeader(entity);
@@ -460,7 +460,7 @@ public class Request {
     # + payload - A `ByteChannel` through which the message payload can be read
     # + contentType - The content type of the payload. Set this to override the default `content-type`
     #                 header value
-    public function setByteChannel(io:ReadableByteChannel payload, string contentType = "application/octet-stream") {
+    public isolated function setByteChannel(io:ReadableByteChannel payload, string contentType = "application/octet-stream") {
         mime:Entity entity = self.getEntityWithoutBodyAndHeaders();
         entity.setByteChannel(payload, contentType);
         self.setEntityAndUpdateContentTypeHeader(entity);
@@ -471,7 +471,7 @@ public class Request {
     #
     # + payload - Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel`, or `Entity[]` (i.e., a set
     # of body parts).
-    public function setPayload(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[] payload) {
+    public isolated function setPayload(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[] payload) {
         if (payload is string) {
             self.setTextPayload(payload);
         } else if (payload is xml) {
@@ -488,7 +488,7 @@ public class Request {
     }
 
     // For use within the module. Takes the Cache-Control header and parses it to a RequestCacheControl object.
-    function parseCacheControlHeader() {
+    isolated function parseCacheControlHeader() {
         // If the request doesn't contain a cache-control header, resort to default cache control settings
         if (!self.hasHeader(CACHE_CONTROL)) {
             return;
@@ -526,16 +526,16 @@ public class Request {
     # Check whether the entity body is present.
     #
     # + return - A boolean indicating the availability of the entity body
-    function checkEntityBodyAvailability() returns boolean {
+    isolated function checkEntityBodyAvailability() returns boolean {
         return externCheckReqEntityBodyAvailability(self);
     }
 
     # Adds cookies to the request.
     #
     # + cookiesToAdd - Represents the cookies to be added
-    public function addCookies(Cookie[] cookiesToAdd) {
+    public isolated function addCookies(Cookie[] cookiesToAdd) {
         string cookieheader = "";
-        Cookie[] sortedCookies = cookiesToAdd.sort(array:ASCENDING, function(Cookie c) returns int {
+        Cookie[] sortedCookies = cookiesToAdd.sort(array:ASCENDING, isolated function(Cookie c) returns int {
             var cookiePath = c.path;
             int l = 0;
             if (cookiePath is string) {
@@ -574,55 +574,55 @@ public class Request {
     }
 }
 
-function externCreateNewReqEntity(Request request) returns mime:Entity =
+isolated function externCreateNewReqEntity(Request request) returns mime:Entity =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternRequest",
     name: "createNewEntity"
 } external;
 
-function externSetReqEntity(Request request, mime:Entity entity) =
+isolated function externSetReqEntity(Request request, mime:Entity entity) =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternRequest",
     name: "setEntity"
 } external;
 
-function externSetReqEntityAndUpdateContentTypeHeader(Request request, mime:Entity entity) =
+isolated function externSetReqEntityAndUpdateContentTypeHeader(Request request, mime:Entity entity) =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternRequest",
     name: "setEntityAndUpdateContentTypeHeader"
 } external;
 
-function externGetQueryParams(Request request) returns map<string[]> =
+isolated function externGetQueryParams(Request request) returns map<string[]> =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternRequest",
     name: "getQueryParams"
 } external;
 
-function externGetMatrixParams(Request request, string path) returns map<any> =
+isolated function externGetMatrixParams(Request request, string path) returns map<any> =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternRequest",
     name: "getMatrixParams"
 } external;
 
-function externGetReqEntity(Request request) returns mime:Entity|ClientError =
+isolated function externGetReqEntity(Request request) returns mime:Entity|ClientError =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternRequest",
     name: "getEntity"
 } external;
 
-function externGetEntityWithoutBodyAndHeaders(Request request) returns mime:Entity =
+isolated function externGetEntityWithoutBodyAndHeaders(Request request) returns mime:Entity =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternRequest",
     name: "getEntityWithoutBodyAndHeaders"
 } external;
 
-function externGetEntityWithBodyAndWithoutHeaders(Request request) returns mime:Entity =
+isolated function externGetEntityWithBodyAndWithoutHeaders(Request request) returns mime:Entity =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternRequest",
     name: "getEntityWithBodyAndWithoutHeaders"
 } external;
 
-function externCheckReqEntityBodyAvailability(Request request) returns boolean =
+isolated function externCheckReqEntityBodyAvailability(Request request) returns boolean =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternRequest",
     name: "checkEntityBodyAvailability"
@@ -653,47 +653,47 @@ public const FAILED = "failed";
 public const NONE = ();
 
 // HTTP header related external functions
-function externRequestGetHeader(Request request, string headerName, HeaderPosition position = LEADING)
+isolated function externRequestGetHeader(Request request, string headerName, HeaderPosition position = LEADING)
                          returns @tainted string = @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHeaders",
     name: "getHeader"
 } external;
 
-function externRequestGetHeaders(Request request, string headerName, HeaderPosition position = LEADING)
+isolated function externRequestGetHeaders(Request request, string headerName, HeaderPosition position = LEADING)
                           returns @tainted string[] = @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHeaders",
     name: "getHeaders"
 } external;
 
-function externRequestGetHeaderNames(Request request, HeaderPosition position = LEADING) returns @tainted string[] =
+isolated function externRequestGetHeaderNames(Request request, HeaderPosition position = LEADING) returns @tainted string[] =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHeaders",
     name: "getHeaderNames"
 } external;
 
-function externRequestAddHeader(Request request, string headerName, string headerValue, HeaderPosition position = LEADING) =
+isolated function externRequestAddHeader(Request request, string headerName, string headerValue, HeaderPosition position = LEADING) =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHeaders",
     name: "addHeader"
 } external;
 
-function externRequestSetHeader(Request request, string headerName, string headerValue, HeaderPosition position = LEADING) =
+isolated function externRequestSetHeader(Request request, string headerName, string headerValue, HeaderPosition position = LEADING) =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHeaders",
     name: "setHeader"
 } external;
 
-function externRequestRemoveHeader(Request request, string headerName, HeaderPosition position = LEADING) = @java:Method {
+isolated function externRequestRemoveHeader(Request request, string headerName, HeaderPosition position = LEADING) = @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHeaders",
     name: "removeHeader"
 } external;
 
-function externRequestRemoveAllHeaders(Request request, HeaderPosition position = LEADING) = @java:Method {
+isolated function externRequestRemoveAllHeaders(Request request, HeaderPosition position = LEADING) = @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHeaders",
     name: "removeAllHeaders"
 } external;
 
-function externRequestHasHeader(Request request, string headerName, HeaderPosition position = LEADING) returns boolean =
+isolated function externRequestHasHeader(Request request, string headerName, HeaderPosition position = LEADING) returns boolean =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHeaders",
     name: "hasHeader"

--- a/http-ballerina/src/http/http_request.bal
+++ b/http-ballerina/src/http/http_request.bal
@@ -533,7 +533,7 @@ public class Request {
     # Adds cookies to the request.
     #
     # + cookiesToAdd - Represents the cookies to be added
-    public isolated function addCookies(Cookie[] cookiesToAdd) {
+    public function addCookies(Cookie[] cookiesToAdd) {
         string cookieheader = "";
         Cookie[] sortedCookies = cookiesToAdd.sort(array:ASCENDING, isolated function(Cookie c) returns int {
             var cookiePath = c.path;

--- a/http-ballerina/src/http/http_response.bal
+++ b/http-ballerina/src/http/http_response.bal
@@ -43,47 +43,47 @@ public class Response {
     int requestTime = 0;
     private mime:Entity? entity = ();
 
-    public function init() {
+    public isolated function init() {
         self.entity = self.createNewEntity();
     }
 
     # Create a new `Entity` and link it with the response.
     #
     # + return - Newly created `Entity` that has been set to the response
-    function createNewEntity() returns mime:Entity {
+    isolated function createNewEntity() returns mime:Entity {
         return externCreateNewResEntity(self);
     }
 
     # Gets the `Entity` associated with the response.
     #
     # + return - The `Entity` of the response. An `http:ClientError` is returned, if entity construction fails
-    public function getEntity() returns mime:Entity|ClientError {
+    public isolated function getEntity() returns mime:Entity|ClientError {
         return externGetResEntity(self);
     }
 
     // Gets the `Entity` from the response without the entity body. This function is exposed only to be used
     // internally.
-    function getEntityWithoutBodyAndHeaders() returns mime:Entity {
+    isolated function getEntityWithoutBodyAndHeaders() returns mime:Entity {
         return externGetResEntityWithoutBodyAndHeaders(self);
     }
 
     // Gets the `Entity` from the response with the body, but without headers. This function is used for Http level
     // functions.
-    function getEntityWithBodyAndWithoutHeaders() returns mime:Entity|ClientError {
+    isolated function getEntityWithBodyAndWithoutHeaders() returns mime:Entity|ClientError {
         return externGetResEntityWithBodyAndWithoutHeaders(self);
     }
 
     # Sets the provided `Entity` to the response.
     #
     # + e - The `Entity` to be set to the response
-    public function setEntity(mime:Entity e) {
+    public isolated function setEntity(mime:Entity e) {
         return externSetResEntity(self, e);
     }
 
     # Sets the provided `Entity` to the request and update only the content type header in the transport message.
     #
     # + e - The `Entity` to be set to the request
-    function setEntityAndUpdateContentTypeHeader(mime:Entity e) {
+    isolated function setEntityAndUpdateContentTypeHeader(mime:Entity e) {
         return externSetResEntityAndUpdateContentTypeHeader(self, e);
     }
 
@@ -92,7 +92,7 @@ public class Response {
     # + headerName - The header name
     # + position - Represents the position of the header as an optional parameter
     # + return - `true` if the specified header key exists
-    public function hasHeader(string headerName, HeaderPosition position = LEADING) returns boolean {
+    public isolated function hasHeader(string headerName, HeaderPosition position = LEADING) returns boolean {
         return externResponseHasHeader(self, headerName, position);
     }
 
@@ -104,7 +104,7 @@ public class Response {
     #              the entity-body of the `Response` must be accessed initially.
     # + return - The first header value for the specified header name. Panic if the header is not found. Use the
     #            `Response.hasHeader()` beforehand to check the existence of a header.
-    public function getHeader(string headerName, HeaderPosition position = LEADING) returns @tainted string {
+    public isolated function getHeader(string headerName, HeaderPosition position = LEADING) returns @tainted string {
         return externResponseGetHeader(self, headerName, position);
     }
 
@@ -114,7 +114,7 @@ public class Response {
     # + headerValue - The header value
     # + position - Represents the position of the header as an optional parameter. If the position is `http:TRAILING`,
     #              the entity-body of the `Response` must be accessed initially.
-    public function addHeader(string headerName, string headerValue, HeaderPosition position = LEADING) {
+    public isolated function addHeader(string headerName, string headerValue, HeaderPosition position = LEADING) {
         return externResponseAddHeader(self, headerName, headerValue, position);
     }
 
@@ -125,7 +125,7 @@ public class Response {
     #              the entity-body of the `Response` must be accessed initially.
     # + return - The header values the specified header key maps to. Panic if the header is not found. Use the
     #            `Response.hasHeader()` beforehand to check the existence of a header.
-    public function getHeaders(string headerName, HeaderPosition position = LEADING) returns @tainted string[] {
+    public isolated function getHeaders(string headerName, HeaderPosition position = LEADING) returns @tainted string[] {
         return externResponseGetHeaders(self, headerName, position);
     }
 
@@ -136,7 +136,7 @@ public class Response {
     # + headerValue - The header value
     # + position - Represents the position of the header as an optional parameter. If the position is `http:TRAILING`,
     #              the entity-body of the `Response` must be accessed initially.
-    public function setHeader(string headerName, string headerValue, HeaderPosition position = LEADING) {
+    public isolated function setHeader(string headerName, string headerValue, HeaderPosition position = LEADING) {
         externResponseSetHeader(self, headerName, headerValue, position);
 
 
@@ -151,7 +151,7 @@ public class Response {
     # + headerName - The header name
     # + position - Represents the position of the header as an optional parameter. If the position is `http:TRAILING`,
     #              the entity-body of the `Response` must be accessed initially.
-    public function removeHeader(string headerName, HeaderPosition position = LEADING) {
+    public isolated function removeHeader(string headerName, HeaderPosition position = LEADING) {
         externResponseRemoveHeader(self, headerName, position);
     }
 
@@ -159,7 +159,7 @@ public class Response {
     #
     # + position - Represents the position of the header as an optional parameter. If the position is `http:TRAILING`,
     #              the entity-body of the `Response` must be accessed initially.
-    public function removeAllHeaders(HeaderPosition position = LEADING) {
+    public isolated function removeAllHeaders(HeaderPosition position = LEADING) {
         externResponseRemoveAllHeaders(self, position);
     }
 
@@ -168,7 +168,7 @@ public class Response {
     # + position - Represents the position of the header as an optional parameter. If the position is `http:TRAILING`,
     #              the entity-body of the `Response` must be accessed initially.
     # + return - An array of all the header names
-    public function getHeaderNames(HeaderPosition position = LEADING) returns @tainted string[] {
+    public isolated function getHeaderNames(HeaderPosition position = LEADING) returns @tainted string[] {
         return externResponseGetHeaderNames(self, position);
     }
 
@@ -176,21 +176,21 @@ public class Response {
     #
     # + contentType - Content type value to be set as the `content-type` header
     # + return - Nil if successful, error in case of invalid content-type
-   public function setContentType(string contentType) returns error? {
+   public isolated function setContentType(string contentType) returns error? {
         return trap self.setHeader(mime:CONTENT_TYPE, contentType);
     }
 
     # Gets the type of the payload of the response (i.e: the `content-type` header value).
     #
     # + return - Returns the `content-type` header value as a string
-    public function getContentType() returns @tainted string {
+    public isolated function getContentType() returns @tainted string {
         return self.getHeader(mime:CONTENT_TYPE);
     }
 
     # Extract `json` payload from the response. If the content type is not JSON, an `http:ClientError` is returned.
     #
     # + return - The `json` payload or `http:ClientError` in case of errors
-    public function getJsonPayload() returns @tainted json|ClientError {
+    public isolated function getJsonPayload() returns @tainted json|ClientError {
         var result = self.getEntityWithBodyAndWithoutHeaders();
         if (result is error) {
             return result;
@@ -212,7 +212,7 @@ public class Response {
     # Extracts `xml` payload from the response.
     #
     # + return - The `xml` payload or `http:ClientError` in case of errors
-    public function getXmlPayload() returns @tainted xml|ClientError {
+    public isolated function getXmlPayload() returns @tainted xml|ClientError {
         var result = self.getEntityWithBodyAndWithoutHeaders();
         if (result is error) {
             return result;
@@ -234,7 +234,7 @@ public class Response {
     # Extracts `text` payload from the response.
     #
     # + return - The string representation of the message payload or `http:ClientError` in case of errors
-    public function getTextPayload() returns @tainted string|ClientError {
+    public isolated function getTextPayload() returns @tainted string|ClientError {
         var result = self.getEntityWithBodyAndWithoutHeaders();
         if (result is error) {
             return result;
@@ -257,7 +257,7 @@ public class Response {
     # `Response.getBodyParts()`.
     #
     # + return - A byte channel from which the message payload can be read or `http:ClientError` in case of errors
-    public function getByteChannel() returns @tainted io:ReadableByteChannel|ClientError {
+    public isolated function getByteChannel() returns @tainted io:ReadableByteChannel|ClientError {
         var result = self.getEntityWithBodyAndWithoutHeaders();
         if (result is error) {
             return result;
@@ -275,7 +275,7 @@ public class Response {
     # Gets the response payload as a `byte[]`.
     #
     # + return - The byte[] representation of the message payload or `http:ClientError` in case of errors
-    public function getBinaryPayload() returns @tainted byte[]|ClientError {
+    public isolated function getBinaryPayload() returns @tainted byte[]|ClientError {
         var result = self.getEntityWithBodyAndWithoutHeaders();
         if (result is error) {
             return result;
@@ -294,7 +294,7 @@ public class Response {
     #
     # + return - The body parts as an array of entities or else an `http:ClientError` if there were any errors in
     #            constructing the body parts from the response
-    public function getBodyParts() returns mime:Entity[]|ClientError {
+    public isolated function getBodyParts() returns mime:Entity[]|ClientError {
         var result = self.getEntity();
         if (result is ClientError) {
             // TODO: Confirm whether this is actually a ClientError or not.
@@ -310,16 +310,16 @@ public class Response {
         }
     }
 
-    # Sets the `etag` header for the given payload. The ETag is generated using a CRC32 hash function.
+    # Sets the `etag` header for the given payload. The ETag is generated using a CRC32 hash isolated function.
     #
     # + payload - The payload for which the ETag should be set
-    public function setETag(json|xml|string|byte[] payload) {
+    public isolated function setETag(json|xml|string|byte[] payload) {
         string etag = crypto:crc32b(payload.toString().toBytes());
         self.setHeader(ETAG, etag);
     }
 
     # Sets the current time as the `last-modified` header.
-    public function setLastModified() {
+    public isolated function setLastModified() {
         time:Time currentT = time:currentTime();
         var lastModified = time:format(currentT, time:TIME_FORMAT_RFC_1123);
         if (lastModified is string) {
@@ -336,7 +336,7 @@ public class Response {
     # + payload - The `json` payload
     # + contentType - The content type of the payload. Set this to override the default `content-type` header value
     #                 for `json`
-    public function setJsonPayload(json payload, string contentType = "application/json") {
+    public isolated function setJsonPayload(json payload, string contentType = "application/json") {
         mime:Entity entity = self.getEntityWithoutBodyAndHeaders();
         entity.setJson(payload, contentType);
         self.setEntityAndUpdateContentTypeHeader(entity);
@@ -347,7 +347,7 @@ public class Response {
     # + payload - The `xml` payload
     # + contentType - The content type of the payload. Set this to override the default `content-type` header value
     #                 for `xml`
-    public function setXmlPayload(xml payload, string contentType = "application/xml") {
+    public isolated function setXmlPayload(xml payload, string contentType = "application/xml") {
         mime:Entity entity = self.getEntityWithoutBodyAndHeaders();
         entity.setXml(payload, contentType);
         self.setEntityAndUpdateContentTypeHeader(entity);
@@ -358,7 +358,7 @@ public class Response {
     # + payload - The `string` payload
     # + contentType - The content type of the payload. Set this to override the default `content-type` header value
     #                 for `string`
-    public function setTextPayload(string payload, string contentType = "text/plain") {
+    public isolated function setTextPayload(string payload, string contentType = "text/plain") {
         mime:Entity entity = self.getEntityWithoutBodyAndHeaders();
         entity.setText(payload, contentType);
         self.setEntityAndUpdateContentTypeHeader(entity);
@@ -369,7 +369,7 @@ public class Response {
     # + payload - The `byte[]` payload
     # + contentType - The content type of the payload. Set this to override the default `content-type` header value
     #                 for `byte[]`
-    public function setBinaryPayload(byte[] payload, string contentType = "application/octet-stream") {
+    public isolated function setBinaryPayload(byte[] payload, string contentType = "application/octet-stream") {
         mime:Entity entity = self.getEntityWithoutBodyAndHeaders();
         entity.setByteArray(payload, contentType);
         self.setEntityAndUpdateContentTypeHeader(entity);
@@ -380,7 +380,7 @@ public class Response {
     # + bodyParts - The entities which make up the message body
     # + contentType - The content type of the top level message. Set this to override the default
     #                 `content-type` header value
-    public function setBodyParts(mime:Entity[] bodyParts, string contentType = "multipart/form-data") {
+    public isolated function setBodyParts(mime:Entity[] bodyParts, string contentType = "multipart/form-data") {
         mime:Entity entity = self.getEntityWithoutBodyAndHeaders();
         entity.setBodyParts(bodyParts, contentType);
         self.setEntityAndUpdateContentTypeHeader(entity);
@@ -402,7 +402,7 @@ public class Response {
     # + payload - A `ByteChannel` through which the message payload can be read
     # + contentType - The content type of the payload. Set this to override the default `content-type`
     #                 header value
-    public function setByteChannel(io:ReadableByteChannel payload, string contentType = "application/octet-stream") {
+    public isolated function setByteChannel(io:ReadableByteChannel payload, string contentType = "application/octet-stream") {
         mime:Entity entity = self.getEntityWithoutBodyAndHeaders();
         entity.setByteChannel(payload, contentType);
         self.setEntityAndUpdateContentTypeHeader(entity);
@@ -412,7 +412,7 @@ public class Response {
     #
     # + payload - Payload can be of type `string`, `xml`, `json`, `byte[]`, `ByteChannel` or `Entity[]` (i.e: a set
     #             of body parts)
-    public function setPayload(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[] payload) {
+    public isolated function setPayload(string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[] payload) {
         if (payload is string) {
             self.setTextPayload(payload);
         } else if (payload is xml) {
@@ -464,84 +464,84 @@ public class Response {
     }
 }
 
-function externCreateNewResEntity(Response response) returns mime:Entity =
+isolated function externCreateNewResEntity(Response response) returns mime:Entity =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternResponse",
     name: "createNewEntity"
 } external;
 
-function externSetResEntity(Response response, mime:Entity entity) =
+isolated function externSetResEntity(Response response, mime:Entity entity) =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternResponse",
     name: "setEntity"
 } external;
 
-function externSetResEntityAndUpdateContentTypeHeader(Response response, mime:Entity entity) =
+isolated function externSetResEntityAndUpdateContentTypeHeader(Response response, mime:Entity entity) =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternResponse",
     name: "setEntityAndUpdateContentTypeHeader"
 } external;
 
-function externGetResEntity(Response response) returns mime:Entity|ClientError =
+isolated function externGetResEntity(Response response) returns mime:Entity|ClientError =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternResponse",
     name: "getEntity"
 } external;
 
-function externGetResEntityWithoutBodyAndHeaders(Response response) returns mime:Entity =
+isolated function externGetResEntityWithoutBodyAndHeaders(Response response) returns mime:Entity =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternResponse",
     name: "getEntityWithoutBodyAndHeaders"
 } external;
 
-function externGetResEntityWithBodyAndWithoutHeaders(Response response) returns mime:Entity =
+isolated function externGetResEntityWithBodyAndWithoutHeaders(Response response) returns mime:Entity =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternResponse",
     name: "getEntityWithBodyAndWithoutHeaders"
 } external;
 
 // HTTP header related external functions
-function externResponseGetHeader(Response response, string headerName, HeaderPosition position)
+isolated function externResponseGetHeader(Response response, string headerName, HeaderPosition position)
                          returns @tainted string = @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHeaders",
     name: "getHeader"
 } external;
 
-function externResponseGetHeaders(Response response, string headerName, HeaderPosition position)
+isolated function externResponseGetHeaders(Response response, string headerName, HeaderPosition position)
                           returns @tainted string[] = @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHeaders",
     name: "getHeaders"
 } external;
 
-function externResponseGetHeaderNames(Response response, HeaderPosition position) returns @tainted string[] =
+isolated function externResponseGetHeaderNames(Response response, HeaderPosition position) returns @tainted string[] =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHeaders",
     name: "getHeaderNames"
 } external;
 
-function externResponseAddHeader(Response response, string headerName, string headerValue, HeaderPosition position) =
+isolated function externResponseAddHeader(Response response, string headerName, string headerValue, HeaderPosition position) =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHeaders",
     name: "addHeader"
 } external;
 
-function externResponseSetHeader(Response response, string headerName, string headerValue, HeaderPosition position) =
+isolated function externResponseSetHeader(Response response, string headerName, string headerValue, HeaderPosition position) =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHeaders",
     name: "setHeader"
 } external;
 
-function externResponseRemoveHeader(Response response, string headerName, HeaderPosition position) = @java:Method {
+isolated function externResponseRemoveHeader(Response response, string headerName, HeaderPosition position) = @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHeaders",
     name: "removeHeader"
 } external;
 
-function externResponseRemoveAllHeaders(Response response, HeaderPosition position) = @java:Method {
+isolated function externResponseRemoveAllHeaders(Response response, HeaderPosition position) = @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHeaders",
     name: "removeAllHeaders"
 } external;
 
-function externResponseHasHeader(Response response, string headerName, HeaderPosition position) returns boolean =
+isolated function externResponseHasHeader(Response response, string headerName, HeaderPosition position) returns boolean =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHeaders",
     name: "hasHeader"

--- a/http-ballerina/src/http/http_secure_client.bal
+++ b/http-ballerina/src/http/http_secure_client.bal
@@ -34,7 +34,7 @@ public client class HttpSecureClient {
     #
     # + url - URL of the target service
     # + config - The configurations to be used when initializing the `client`
-    public isolated function init(string url, ClientConfiguration config) {
+    public function init(string url, ClientConfiguration config) {
         self.url = url;
         self.config = config;
         HttpClient|ClientError simpleClient = createClient(url, self.config);
@@ -215,7 +215,7 @@ public client class HttpSecureClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation, or else an `http:ClientError` if the submission fails
-    public remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         return self.httpClient->submit(httpVerb, path, req);
@@ -225,7 +225,7 @@ public client class HttpSecureClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         return self.httpClient->getResponse(httpFuture);
     }
 
@@ -233,7 +233,7 @@ public client class HttpSecureClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote isolated function hasPromise(HttpFuture httpFuture) returns boolean {
+    public remote function hasPromise(HttpFuture httpFuture) returns boolean {
         return self.httpClient->hasPromise(httpFuture);
     }
 
@@ -241,7 +241,7 @@ public client class HttpSecureClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return self.httpClient->getNextPromise(httpFuture);
     }
 
@@ -249,14 +249,14 @@ public client class HttpSecureClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return self.httpClient->getPromisedResponse(promise);
     }
 
     # Passes the request to an actual network call.
     #
     # + promise - The Push Promise to be rejected
-    public remote isolated function rejectPromise(PushPromise promise) {
+    public remote function rejectPromise(PushPromise promise) {
         return self.httpClient->rejectPromise(promise);
     }
 }
@@ -266,7 +266,7 @@ public client class HttpSecureClient {
 # + url - Base URL
 # + config - Client endpoint configurations
 # + return - Created secure HTTP client
-public isolated function createHttpSecureClient(string url, ClientConfiguration config) returns HttpClient|ClientError {
+public function createHttpSecureClient(string url, ClientConfiguration config) returns HttpClient|ClientError {
     HttpSecureClient httpSecureClient;
     if (config.auth is OutboundAuthConfig) {
         httpSecureClient = new(url, config);

--- a/http-ballerina/src/http/http_secure_client.bal
+++ b/http-ballerina/src/http/http_secure_client.bal
@@ -52,7 +52,7 @@ public client class HttpSecureClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The inbound response message or the error if one occurred while attempting to fulfill the HTTP request
-    public remote isolated function post(string path, RequestMessage message) returns Response|ClientError {
+    public remote function post(string path, RequestMessage message) returns Response|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         Response res = check self.httpClient->post(path, req);
@@ -70,7 +70,7 @@ public client class HttpSecureClient {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The inbound response message or the error if one occurred while attempting to fulfill the HTTP request
-    public remote isolated function head(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function head(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         Response res = check self.httpClient->head(path, message = req);
@@ -88,7 +88,7 @@ public client class HttpSecureClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The inbound response message or an error occurred while attempting to fulfill the HTTP request
-    public remote isolated function put(string path, RequestMessage message) returns Response|ClientError {
+    public remote function put(string path, RequestMessage message) returns Response|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         Response res = check self.httpClient->put(path, req);
@@ -107,7 +107,7 @@ public client class HttpSecureClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The inbound response message or an error occurred while attempting to fulfill the HTTP request
-    public remote isolated function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
+    public remote function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         Response res = check self.httpClient->execute(httpVerb, path, req);
@@ -125,7 +125,7 @@ public client class HttpSecureClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The inbound response message or an error occurred while attempting to fulfill the HTTP request
-    public remote isolated function patch(string path, RequestMessage message) returns Response|ClientError {
+    public remote function patch(string path, RequestMessage message) returns Response|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         Response res = check self.httpClient->patch(path, req);
@@ -143,7 +143,7 @@ public client class HttpSecureClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The inbound response message or the error if one occurred while attempting to fulfill the HTTP request
-    public remote isolated function delete(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function delete(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         Response res = check self.httpClient->delete(path, req);
@@ -161,7 +161,7 @@ public client class HttpSecureClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The inbound response message or the error if one occurred while attempting to fulfill the HTTP request
-    public remote isolated function get(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function get(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         Response res = check self.httpClient->get(path, message = req);
@@ -179,7 +179,7 @@ public client class HttpSecureClient {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The inbound response message or the error if one  occurred while attempting to fulfill the HTTP request
-    public remote isolated function options(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function options(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         Response res = check self.httpClient->options(path, message = req);
@@ -196,7 +196,7 @@ public client class HttpSecureClient {
     # + path - Request path
     # + request - An HTTP inbound request message
     # + return - The inbound response message or the error if one occurred while attempting to fulfill the HTTP request
-    public remote isolated function forward(string path, Request request) returns Response|ClientError {
+    public remote function forward(string path, Request request) returns Response|ClientError {
         Request req = request;
         req = check prepareSecureRequest(request, self.config);
         Response res = check self.httpClient->forward(path, request);

--- a/http-ballerina/src/http/http_secure_client.bal
+++ b/http-ballerina/src/http/http_secure_client.bal
@@ -34,7 +34,7 @@ public client class HttpSecureClient {
     #
     # + url - URL of the target service
     # + config - The configurations to be used when initializing the `client`
-    public function init(string url, ClientConfiguration config) {
+    public isolated function init(string url, ClientConfiguration config) {
         self.url = url;
         self.config = config;
         HttpClient|ClientError simpleClient = createClient(url, self.config);
@@ -52,7 +52,7 @@ public client class HttpSecureClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The inbound response message or the error if one occurred while attempting to fulfill the HTTP request
-    public remote function post(string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function post(string path, RequestMessage message) returns Response|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         Response res = check self.httpClient->post(path, req);
@@ -70,7 +70,7 @@ public client class HttpSecureClient {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The inbound response message or the error if one occurred while attempting to fulfill the HTTP request
-    public remote function head(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function head(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         Response res = check self.httpClient->head(path, message = req);
@@ -88,7 +88,7 @@ public client class HttpSecureClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The inbound response message or an error occurred while attempting to fulfill the HTTP request
-    public remote function put(string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function put(string path, RequestMessage message) returns Response|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         Response res = check self.httpClient->put(path, req);
@@ -107,7 +107,7 @@ public client class HttpSecureClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The inbound response message or an error occurred while attempting to fulfill the HTTP request
-    public remote function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         Response res = check self.httpClient->execute(httpVerb, path, req);
@@ -125,7 +125,7 @@ public client class HttpSecureClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The inbound response message or an error occurred while attempting to fulfill the HTTP request
-    public remote function patch(string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function patch(string path, RequestMessage message) returns Response|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         Response res = check self.httpClient->patch(path, req);
@@ -143,7 +143,7 @@ public client class HttpSecureClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The inbound response message or the error if one occurred while attempting to fulfill the HTTP request
-    public remote function delete(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function delete(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         Response res = check self.httpClient->delete(path, req);
@@ -161,7 +161,7 @@ public client class HttpSecureClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The inbound response message or the error if one occurred while attempting to fulfill the HTTP request
-    public remote function get(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function get(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         Response res = check self.httpClient->get(path, message = req);
@@ -179,7 +179,7 @@ public client class HttpSecureClient {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The inbound response message or the error if one  occurred while attempting to fulfill the HTTP request
-    public remote function options(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function options(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         Response res = check self.httpClient->options(path, message = req);
@@ -196,7 +196,7 @@ public client class HttpSecureClient {
     # + path - Request path
     # + request - An HTTP inbound request message
     # + return - The inbound response message or the error if one occurred while attempting to fulfill the HTTP request
-    public remote function forward(string path, Request request) returns Response|ClientError {
+    public remote isolated function forward(string path, Request request) returns Response|ClientError {
         Request req = request;
         req = check prepareSecureRequest(request, self.config);
         Response res = check self.httpClient->forward(path, request);
@@ -215,7 +215,7 @@ public client class HttpSecureClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation, or else an `http:ClientError` if the submission fails
-    public remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         return self.httpClient->submit(httpVerb, path, req);
@@ -225,7 +225,7 @@ public client class HttpSecureClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         return self.httpClient->getResponse(httpFuture);
     }
 
@@ -233,7 +233,7 @@ public client class HttpSecureClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote function hasPromise(HttpFuture httpFuture) returns boolean {
+    public remote isolated function hasPromise(HttpFuture httpFuture) returns boolean {
         return self.httpClient->hasPromise(httpFuture);
     }
 
@@ -241,7 +241,7 @@ public client class HttpSecureClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return self.httpClient->getNextPromise(httpFuture);
     }
 
@@ -249,14 +249,14 @@ public client class HttpSecureClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return self.httpClient->getPromisedResponse(promise);
     }
 
     # Passes the request to an actual network call.
     #
     # + promise - The Push Promise to be rejected
-    public remote function rejectPromise(PushPromise promise) {
+    public remote isolated function rejectPromise(PushPromise promise) {
         return self.httpClient->rejectPromise(promise);
     }
 }
@@ -266,7 +266,7 @@ public client class HttpSecureClient {
 # + url - Base URL
 # + config - Client endpoint configurations
 # + return - Created secure HTTP client
-public function createHttpSecureClient(string url, ClientConfiguration config) returns HttpClient|ClientError {
+public isolated function createHttpSecureClient(string url, ClientConfiguration config) returns HttpClient|ClientError {
     HttpSecureClient httpSecureClient;
     if (config.auth is OutboundAuthConfig) {
         httpSecureClient = new(url, config);
@@ -281,7 +281,7 @@ public function createHttpSecureClient(string url, ClientConfiguration config) r
 # + req - An HTTP outbound request message
 # + config - Client endpoint configurations
 # + return - Prepared HTTP request or `http:ClientError` if an error occurred at auth handler invocation
-function prepareSecureRequest(Request req, ClientConfiguration config) returns Request|ClientError {
+isolated function prepareSecureRequest(Request req, ClientConfiguration config) returns Request|ClientError {
     OutboundAuthConfig? auth = config.auth;
     if (auth is OutboundAuthConfig) {
         OutboundAuthHandler authHandler = auth.authHandler;
@@ -297,13 +297,13 @@ function prepareSecureRequest(Request req, ClientConfiguration config) returns R
 # + res - An HTTP outbound response message
 # + config - Client endpoint configurations
 # + return - Prepared HTTP request or `()` if nothing to be done or `http:ClientError` if an error occurred at auth handler invocation
-function doInspection(Request req, Response res, ClientConfiguration config) returns Request|ClientError? {
+isolated function doInspection(Request req, Response res, ClientConfiguration config) returns Request|ClientError? {
     OutboundAuthConfig? auth = config.auth;
     if (auth is OutboundAuthConfig) {
         OutboundAuthHandler authHandler = auth.authHandler;
         return authHandler.inspect(req, res);
     }
-    log:printDebug(function () returns string {
+    log:printDebug(isolated function () returns string {
         return "Retry is not required for the given request after the inspection.";
     });
     return ();

--- a/http-ballerina/src/http/non_listening_service_endpoint.bal
+++ b/http-ballerina/src/http/non_listening_service_endpoint.bal
@@ -25,26 +25,26 @@ public class MockListener {
     private int port = 0;
     private ListenerConfiguration config = {};
 
-    public function __start() returns error? {
+    public isolated function __start() returns error? {
         return self.startEndpoint();
     }
 
-    public function __gracefulStop() returns error? {
+    public isolated function __gracefulStop() returns error? {
         return self.gracefulStop();
     }
 
-    public function __immediateStop() returns error? {
+    public isolated function __immediateStop() returns error? {
     }
 
-    public function __attach(service s, string? name = ()) returns error? {
+    public isolated function __attach(service s, string? name = ()) returns error? {
         return self.register(s, name);
     }
 
-    public function __detach(service s) returns error? {
+    public isolated function __detach(service s) returns error? {
         return self.detach(s);
     }
 
-    public function init(int port, ListenerConfiguration? config = ()) {
+    public isolated function init(int port, ListenerConfiguration? config = ()) {
         self.config = config ?: {};
         self.port = port;
         var err = self.initEndpoint();
@@ -53,48 +53,48 @@ public class MockListener {
         }
     }
 
-    public function initEndpoint() returns error? {
+    public isolated function initEndpoint() returns error? {
         return externMockInitEndpoint(self);
     }
 
-    public function register(service s, string? name) returns error? {
+    public isolated function register(service s, string? name) returns error? {
         return externMockRegister(self, s, name);
     }
 
-    public function startEndpoint() returns error? {
+    public isolated function startEndpoint() returns error? {
         return externMockStart(self);
     }
 
-    public function gracefulStop() returns error? {
+    public isolated function gracefulStop() returns error? {
         return externMockGracefulStop(self);
     }
 
-    public function detach(service s) returns error? {
+    public isolated function detach(service s) returns error? {
         return externMockDetach(self, s);
     }
 }
 
-function externMockInitEndpoint(MockListener mockListener) returns error? = @java:Method {
+isolated function externMockInitEndpoint(MockListener mockListener) returns error? = @java:Method {
     'class: "org.ballerinalang.net.http.mock.nonlistening.NonListeningInitEndpoint",
     name: "initEndpoint"
 } external;
 
-function externMockRegister(MockListener mockListener, service s, string? name) returns error? = @java:Method {
+isolated function externMockRegister(MockListener mockListener, service s, string? name) returns error? = @java:Method {
    'class: "org.ballerinalang.net.http.mock.nonlistening.NonListeningRegister",
    name: "register"
 } external;
 
-function externMockStart(MockListener mockListener) returns error? = @java:Method {
+isolated function externMockStart(MockListener mockListener) returns error? = @java:Method {
     'class: "org.ballerinalang.net.http.mock.nonlistening.NonListeningStart",
     name: "start"
 } external;
 
-function externMockGracefulStop(MockListener mockListener) returns error? = @java:Method {
+isolated function externMockGracefulStop(MockListener mockListener) returns error? = @java:Method {
     'class: "org.ballerinalang.net.http.mock.nonlistening.NonListeningGracefulStop",
     name: "gracefulStop"
 } external;
 
-function externMockDetach(MockListener mockListener, service s) returns error? = @java:Method {
+isolated function externMockDetach(MockListener mockListener, service s) returns error? = @java:Method {
     'class: "org.ballerinalang.net.http.mock.nonlistening.NonListeningDetachEndpoint",
     name: "detach"
 } external;

--- a/http-ballerina/src/http/redirect/redirect_client.bal
+++ b/http-ballerina/src/http/redirect/redirect_client.bal
@@ -51,7 +51,7 @@ public client class RedirectClient {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`,
     #             `byte[]`, `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function get(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
+    public remote function get(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_GET);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -67,7 +67,7 @@ public client class RedirectClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function post(string path, RequestMessage message) returns @tainted Response|ClientError {
+    public remote function post(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result =  performRedirectIfEligible(self, path, <Request>message, HTTP_POST);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -83,7 +83,7 @@ public client class RedirectClient {
     # + message - An optional HTTP outbound request message or or any payload of type `string`, `xml`, `json`,
     #             `byte[]`, `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function head(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
+    public remote function head(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_HEAD);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -99,7 +99,7 @@ public client class RedirectClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function put(string path, RequestMessage message) returns @tainted Response|ClientError {
+    public remote function put(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_PUT);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -113,7 +113,7 @@ public client class RedirectClient {
     # + path - Resource path
     # + request - An HTTP inbound request message
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function forward(string path, Request request) returns Response|ClientError {
+    public remote function forward(string path, Request request) returns Response|ClientError {
         return self.httpClient->forward(path, request);
     }
 
@@ -125,7 +125,7 @@ public client class RedirectClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function execute(string httpVerb, string path, RequestMessage message) returns @tainted
+    public remote function execute(string httpVerb, string path, RequestMessage message) returns @tainted
             Response|ClientError {
         Request request = <Request>message;
         //Redirection is performed only for HTTP methods
@@ -148,7 +148,7 @@ public client class RedirectClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function patch(string path, RequestMessage message) returns @tainted Response|ClientError {
+    public remote function patch(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_PATCH);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -164,7 +164,7 @@ public client class RedirectClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function delete(string path, RequestMessage message = ()) returns @tainted
+    public remote function delete(string path, RequestMessage message = ()) returns @tainted
             Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_DELETE);
         if (result is HttpFuture) {
@@ -181,7 +181,7 @@ public client class RedirectClient {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`,
     #             `byte[]`, `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function options(string path, RequestMessage message = ()) returns @tainted
+    public remote function options(string path, RequestMessage message = ()) returns @tainted
             Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_OPTIONS);
         if (result is HttpFuture) {

--- a/http-ballerina/src/http/redirect/redirect_client.bal
+++ b/http-ballerina/src/http/redirect/redirect_client.bal
@@ -37,7 +37,7 @@ public client class RedirectClient {
     # + config - HTTP ClientConfiguration to be used for HTTP client invocation
     # + redirectConfig - Configurations associated with redirect
     # + httpClient - HTTP client for outbound HTTP requests
-    public isolated function init(string url, ClientConfiguration config, FollowRedirects redirectConfig, HttpClient httpClient) {
+    public function init(string url, ClientConfiguration config, FollowRedirects redirectConfig, HttpClient httpClient) {
         self.url = url;
         self.config = config;
         self.redirectConfig = redirectConfig;
@@ -200,7 +200,7 @@ public client class RedirectClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission fails
-    public remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         return self.httpClient->submit(httpVerb, path, <Request>message);
     }
 
@@ -208,7 +208,7 @@ public client class RedirectClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         return self.httpClient->getResponse(httpFuture);
     }
 
@@ -216,7 +216,7 @@ public client class RedirectClient {
     #
     # + httpFuture - The `HttpFuture` relates to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote isolated function hasPromise(HttpFuture httpFuture) returns (boolean) {
+    public remote function hasPromise(HttpFuture httpFuture) returns (boolean) {
         return self.httpClient->hasPromise(httpFuture);
     }
 
@@ -224,7 +224,7 @@ public client class RedirectClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return self.httpClient->getNextPromise(httpFuture);
     }
 
@@ -232,7 +232,7 @@ public client class RedirectClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return self.httpClient->getPromisedResponse(promise);
     }
 
@@ -240,13 +240,13 @@ public client class RedirectClient {
     # When an `http:PushPromise` is rejected, there is no chance of fetching a promised response using the rejected promise.
     #
     # + promise - The Push Promise to be rejected
-    public remote isolated function rejectPromise(PushPromise promise) {
+    public remote function rejectPromise(PushPromise promise) {
         self.httpClient->rejectPromise(promise);
     }
 }
 
 //Invoke relevant HTTP client action and check the response for redirect eligibility.
-isolated function performRedirectIfEligible(RedirectClient redirectClient, string path, Request request,
+function performRedirectIfEligible(RedirectClient redirectClient, string path, Request request,
                                    HttpOperation httpOperation) returns @tainted HttpResponse|ClientError {
     final string originalUrl = redirectClient.url + path;
     log:printDebug(isolated function() returns string {
@@ -266,7 +266,7 @@ isolated function performRedirectIfEligible(RedirectClient redirectClient, strin
 }
 
 //Inspect the response for redirect eligibility.
-isolated function checkRedirectEligibility(HttpResponse|ClientError response, string resolvedRequestedURI,
+function checkRedirectEligibility(HttpResponse|ClientError response, string resolvedRequestedURI,
                                   HttpOperation httpVerb, Request request, RedirectClient redirectClient)
                                     returns @untainted HttpResponse|ClientError {
     if (response is Response) {
@@ -293,7 +293,7 @@ isolated function isRedirectResponse(int statusCode) returns boolean {
 }
 
 //If max redirect count is not reached, perform redirection.
-isolated function redirect(Response response, HttpOperation httpVerb, Request request,
+function redirect(Response response, HttpOperation httpVerb, Request request,
                   RedirectClient redirectClient, string resolvedRequestedURI) returns @untainted HttpResponse|ClientError {
     int currentCount = redirectClient.currentRedirectCount;
     int maxCount = redirectClient.redirectConfig.maxCount;
@@ -337,7 +337,7 @@ isolated function redirect(Response response, HttpOperation httpVerb, Request re
     return response;
 }
 
-isolated function performRedirection(string location, RedirectClient redirectClient, HttpOperation redirectMethod,
+function performRedirection(string location, RedirectClient redirectClient, HttpOperation redirectMethod,
                             Request request, Response response) returns @untainted HttpResponse|ClientError {
     CookieStore? cookieStore = ();
     var cookieConfigVal = redirectClient.config.cookieConfig;

--- a/http-ballerina/src/http/redirect/redirect_client.bal
+++ b/http-ballerina/src/http/redirect/redirect_client.bal
@@ -37,7 +37,7 @@ public client class RedirectClient {
     # + config - HTTP ClientConfiguration to be used for HTTP client invocation
     # + redirectConfig - Configurations associated with redirect
     # + httpClient - HTTP client for outbound HTTP requests
-    public function init(string url, ClientConfiguration config, FollowRedirects redirectConfig, HttpClient httpClient) {
+    public isolated function init(string url, ClientConfiguration config, FollowRedirects redirectConfig, HttpClient httpClient) {
         self.url = url;
         self.config = config;
         self.redirectConfig = redirectConfig;
@@ -51,7 +51,7 @@ public client class RedirectClient {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`,
     #             `byte[]`, `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function get(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
+    public remote isolated function get(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_GET);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -67,7 +67,7 @@ public client class RedirectClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function post(string path, RequestMessage message) returns @tainted Response|ClientError {
+    public remote isolated function post(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result =  performRedirectIfEligible(self, path, <Request>message, HTTP_POST);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -83,7 +83,7 @@ public client class RedirectClient {
     # + message - An optional HTTP outbound request message or or any payload of type `string`, `xml`, `json`,
     #             `byte[]`, `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function head(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
+    public remote isolated function head(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_HEAD);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -99,7 +99,7 @@ public client class RedirectClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function put(string path, RequestMessage message) returns @tainted Response|ClientError {
+    public remote isolated function put(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_PUT);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -113,7 +113,7 @@ public client class RedirectClient {
     # + path - Resource path
     # + request - An HTTP inbound request message
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function forward(string path, Request request) returns Response|ClientError {
+    public remote isolated function forward(string path, Request request) returns Response|ClientError {
         return self.httpClient->forward(path, request);
     }
 
@@ -125,7 +125,7 @@ public client class RedirectClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function execute(string httpVerb, string path, RequestMessage message) returns @tainted
+    public remote isolated function execute(string httpVerb, string path, RequestMessage message) returns @tainted
             Response|ClientError {
         Request request = <Request>message;
         //Redirection is performed only for HTTP methods
@@ -148,7 +148,7 @@ public client class RedirectClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function patch(string path, RequestMessage message) returns @tainted Response|ClientError {
+    public remote isolated function patch(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_PATCH);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -164,7 +164,7 @@ public client class RedirectClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function delete(string path, RequestMessage message = ()) returns @tainted
+    public remote isolated function delete(string path, RequestMessage message = ()) returns @tainted
             Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_DELETE);
         if (result is HttpFuture) {
@@ -181,7 +181,7 @@ public client class RedirectClient {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`,
     #             `byte[]`, `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function options(string path, RequestMessage message = ()) returns @tainted
+    public remote isolated function options(string path, RequestMessage message = ()) returns @tainted
             Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_OPTIONS);
         if (result is HttpFuture) {
@@ -200,7 +200,7 @@ public client class RedirectClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission fails
-    public remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         return self.httpClient->submit(httpVerb, path, <Request>message);
     }
 
@@ -208,7 +208,7 @@ public client class RedirectClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         return self.httpClient->getResponse(httpFuture);
     }
 
@@ -216,7 +216,7 @@ public client class RedirectClient {
     #
     # + httpFuture - The `HttpFuture` relates to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote function hasPromise(HttpFuture httpFuture) returns (boolean) {
+    public remote isolated function hasPromise(HttpFuture httpFuture) returns (boolean) {
         return self.httpClient->hasPromise(httpFuture);
     }
 
@@ -224,7 +224,7 @@ public client class RedirectClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return self.httpClient->getNextPromise(httpFuture);
     }
 
@@ -232,7 +232,7 @@ public client class RedirectClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return self.httpClient->getPromisedResponse(promise);
     }
 
@@ -240,16 +240,16 @@ public client class RedirectClient {
     # When an `http:PushPromise` is rejected, there is no chance of fetching a promised response using the rejected promise.
     #
     # + promise - The Push Promise to be rejected
-    public remote function rejectPromise(PushPromise promise) {
+    public remote isolated function rejectPromise(PushPromise promise) {
         self.httpClient->rejectPromise(promise);
     }
 }
 
 //Invoke relevant HTTP client action and check the response for redirect eligibility.
-function performRedirectIfEligible(RedirectClient redirectClient, string path, Request request,
+isolated function performRedirectIfEligible(RedirectClient redirectClient, string path, Request request,
                                    HttpOperation httpOperation) returns @tainted HttpResponse|ClientError {
-    string originalUrl = redirectClient.url + path;
-    log:printDebug(function() returns string {
+    final string originalUrl = redirectClient.url + path;
+    log:printDebug(isolated function() returns string {
         return "Checking redirect eligibility for original request " + originalUrl;
     });
 
@@ -266,7 +266,7 @@ function performRedirectIfEligible(RedirectClient redirectClient, string path, R
 }
 
 //Inspect the response for redirect eligibility.
-function checkRedirectEligibility(HttpResponse|ClientError response, string resolvedRequestedURI,
+isolated function checkRedirectEligibility(HttpResponse|ClientError response, string resolvedRequestedURI,
                                   HttpOperation httpVerb, Request request, RedirectClient redirectClient)
                                     returns @untainted HttpResponse|ClientError {
     if (response is Response) {
@@ -283,16 +283,17 @@ function checkRedirectEligibility(HttpResponse|ClientError response, string reso
 }
 
 //Check the response status for redirect eligibility.
-function isRedirectResponse(int statusCode) returns boolean {
-    log:printDebug(function() returns string {
-        return "Response Code : " + statusCode.toString();
+isolated function isRedirectResponse(int statusCode) returns boolean {
+    final string statusCodeValue = statusCode.toString();
+    log:printDebug(isolated function() returns string {
+        return "Response Code : " + statusCodeValue;
     });
     return (statusCode == 300 || statusCode == 301 || statusCode == 302 || statusCode == 303 || statusCode == 305 ||
         statusCode == 307 || statusCode == 308);
 }
 
 //If max redirect count is not reached, perform redirection.
-function redirect(Response response, HttpOperation httpVerb, Request request,
+isolated function redirect(Response response, HttpOperation httpVerb, Request request,
                   RedirectClient redirectClient, string resolvedRequestedURI) returns @untainted HttpResponse|ClientError {
     int currentCount = redirectClient.currentRedirectCount;
     int maxCount = redirectClient.redirectConfig.maxCount;
@@ -301,15 +302,16 @@ function redirect(Response response, HttpOperation httpVerb, Request request,
         setCountAndResolvedURL(redirectClient, response, resolvedRequestedURI);
     } else {
         currentCount += 1;
-        log:printDebug(function() returns string {
-            return "Redirect count : " + currentCount.toString();
+        final string currentCountValue = currentCount.toString();
+        log:printDebug(isolated function() returns string {
+            return "Redirect count : " + currentCountValue;
         });
         redirectClient.currentRedirectCount = currentCount;
         var redirectMethod = getRedirectMethod(httpVerb, response);
         if (redirectMethod is HttpOperation) {
             if (response.hasHeader(LOCATION)) {
-                string location = response.getHeader(LOCATION);
-                log:printDebug(function() returns string {
+                final string location = response.getHeader(LOCATION);
+                log:printDebug(isolated function() returns string {
                     return "Location header value: " + location;
                 });
                 if (!isAbsolute(location)) {
@@ -335,7 +337,7 @@ function redirect(Response response, HttpOperation httpVerb, Request request,
     return response;
 }
 
-function performRedirection(string location, RedirectClient redirectClient, HttpOperation redirectMethod,
+isolated function performRedirection(string location, RedirectClient redirectClient, HttpOperation redirectMethod,
                             Request request, Response response) returns @untainted HttpResponse|ClientError {
     CookieStore? cookieStore = ();
     var cookieConfigVal = redirectClient.config.cookieConfig;
@@ -346,8 +348,9 @@ function performRedirection(string location, RedirectClient redirectClient, Http
     }
     var retryClient = createRetryClient(location, createNewEndpointConfig(redirectClient.config), cookieStore);
     if (retryClient is HttpClient) {
-        log:printDebug(function() returns string {
-                return "Redirect using new clientEP : " + location;
+        final string locationValue = location;
+        log:printDebug(isolated function() returns string {
+                return "Redirect using new clientEP : " + locationValue;
             });
         HttpResponse|ClientError result = invokeEndpoint("",
             createRedirectRequest(request, redirectClient.redirectConfig.allowAuthHeaders),
@@ -359,7 +362,7 @@ function performRedirection(string location, RedirectClient redirectClient, Http
 }
 
 //Create a new HTTP client endpoint configuration with a given location as the url.
-function createNewEndpointConfig(ClientConfiguration config) returns ClientConfiguration {
+isolated function createNewEndpointConfig(ClientConfiguration config) returns ClientConfiguration {
     ClientConfiguration newEpConfig = {
         http1Settings: config.http1Settings,
         http2Settings: config.http2Settings,
@@ -388,7 +391,7 @@ function createNewEndpointConfig(ClientConfiguration config) returns ClientConfi
 // | Does not allow changing the request       | 308       | 307       |
 // | method from POST to GET                   |           |           |
 // +-------------------------------------------+-----------+-----------+
-function getRedirectMethod(HttpOperation httpVerb, Response response) returns HttpOperation|() {
+isolated function getRedirectMethod(HttpOperation httpVerb, Response response) returns HttpOperation|() {
     int statusCode = response.statusCode;
     if (statusCode == STATUS_MOVED_PERMANENTLY || statusCode == STATUS_FOUND || statusCode == STATUS_SEE_OTHER) {
         return HTTP_GET;
@@ -397,13 +400,14 @@ function getRedirectMethod(HttpOperation httpVerb, Response response) returns Ht
                statusCode == STATUS_MULTIPLE_CHOICES || statusCode == STATUS_USE_PROXY) {
         return httpVerb;
     }
-    log:printDebug(function() returns string {
-        return "unsupported redirect status code" + statusCode.toString();
+    final string statusCodeValue = statusCode.toString();
+    log:printDebug(isolated function() returns string {
+        return "unsupported redirect status code" + statusCodeValue;
     });
     return ();
 }
 
-function createRedirectRequest(Request request, boolean allowAuthHeaders) returns Request {
+isolated function createRedirectRequest(Request request, boolean allowAuthHeaders) returns Request {
     if (allowAuthHeaders) {
         return request;
     }
@@ -412,14 +416,15 @@ function createRedirectRequest(Request request, boolean allowAuthHeaders) return
     return request;
 }
 
-function isAbsolute(string locationUrl) returns boolean {
+isolated function isAbsolute(string locationUrl) returns boolean {
     return (locationUrl.startsWith(HTTP_SCHEME) || locationUrl.startsWith(HTTPS_SCHEME));
 }
 
 //Reset the current redirect count to 0 and set the resolved requested URI.
-function setCountAndResolvedURL(RedirectClient redirectClient, Response response, string resolvedRequestedURI) {
-    log:printDebug(function() returns string {
-        return "Ultimate response coming from the request: " + resolvedRequestedURI;
+isolated function setCountAndResolvedURL(RedirectClient redirectClient, Response response, string resolvedRequestedURI) {
+    final string resolvedRequestedURIValue = resolvedRequestedURI;
+    log:printDebug(isolated function() returns string {
+        return "Ultimate response coming from the request: " + resolvedRequestedURIValue;
     });
     redirectClient.currentRedirectCount = 0;
     response.resolvedRequestedURI = resolvedRequestedURI;

--- a/http-ballerina/src/http/resiliency/failover_client_endpoint.bal
+++ b/http-ballerina/src/http/resiliency/failover_client_endpoint.bal
@@ -52,7 +52,7 @@ public client class FailoverClient {
     # Failover caller actions which provides failover capabilities to an HTTP client endpoint.
     #
     # + failoverClientConfig - The configurations of the client endpoint associated with this `Failover` instance.
-    public function init(FailoverClientConfiguration failoverClientConfig) {
+    public isolated function init(FailoverClientConfiguration failoverClientConfig) {
         self.failoverClientConfig = failoverClientConfig;
         self.succeededEndpointIndex = 0;
         var failoverHttpClientArray = createFailoverHttpClientArray(failoverClientConfig);
@@ -76,7 +76,7 @@ public client class FailoverClient {
     # + message - HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function post(string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function post(string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_POST, self);
         if (result is HttpFuture) {
@@ -92,7 +92,7 @@ public client class FailoverClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function head(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function head(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_HEAD, self);
         if (result is HttpFuture) {
@@ -108,7 +108,7 @@ public client class FailoverClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function patch(string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function patch(string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_PATCH, self);
         if (result is HttpFuture) {
@@ -124,7 +124,7 @@ public client class FailoverClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function put(string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function put(string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_PUT, self);
         if (result is HttpFuture) {
@@ -140,7 +140,7 @@ public client class FailoverClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function options(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function options(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_OPTIONS, self);
         if (result is HttpFuture) {
@@ -155,7 +155,7 @@ public client class FailoverClient {
     # + path - Resource path
     # + request - An HTTP request
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function forward(string path, Request request) returns Response|ClientError {
+    public remote isolated function forward(string path, Request request) returns Response|ClientError {
         var result = performFailoverAction(path, request, HTTP_FORWARD, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -171,7 +171,7 @@ public client class FailoverClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function execute(string httpVerb, string path, RequestMessage message) returns
+    public remote isolated function execute(string httpVerb, string path, RequestMessage message) returns
                                                                                        Response|ClientError {
         Request req = buildRequest(message);
         var result = performExecuteAction(path, req, httpVerb, self);
@@ -188,7 +188,7 @@ public client class FailoverClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function delete(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function delete(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_DELETE, self);
         if (result is HttpFuture) {
@@ -204,7 +204,7 @@ public client class FailoverClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function get(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function get(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_GET, self);
         if (result is HttpFuture) {
@@ -224,7 +224,7 @@ public client class FailoverClient {
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission
     #            fails
-    public remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         Request req = buildRequest(message);
         var result = performExecuteAction(path, req, "SUBMIT", self, verb = httpVerb);
         if (result is Response) {
@@ -238,7 +238,7 @@ public client class FailoverClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         Client foClient = getLastSuceededClientEP(self);
         return foClient->getResponse(httpFuture);
     }
@@ -247,7 +247,7 @@ public client class FailoverClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote function hasPromise(HttpFuture httpFuture) returns boolean {
+    public remote isolated function hasPromise(HttpFuture httpFuture) returns boolean {
         return false;
     }
 
@@ -255,7 +255,7 @@ public client class FailoverClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return UnsupportedActionError("Failover client not supported for getNextPromise action");
     }
 
@@ -263,7 +263,7 @@ public client class FailoverClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return UnsupportedActionError("Failover client not supported for getPromisedResponse action");
     }
 
@@ -271,21 +271,21 @@ public client class FailoverClient {
     # response using the rejected promise.
     #
     # + promise - The Push Promise to be rejected
-    public remote function rejectPromise(PushPromise promise) {
+    public remote isolated function rejectPromise(PushPromise promise) {
     }
 }
 
 // Performs execute action of the Failover connector. extract the corresponding http integer value representation
 // of the http verb and invokes the perform action method.
 // `verb` is used for HTTP `submit()` method.
-function performExecuteAction (string path, Request request, string httpVerb,
+isolated function performExecuteAction (string path, Request request, string httpVerb,
                                    FailoverClient failoverClient, string verb = "") returns HttpResponse|ClientError {
     HttpOperation connectorAction = extractHttpOperation(httpVerb);
     return performFailoverAction(path, request, connectorAction, failoverClient, verb = verb);
 }
 
 // Handles all the actions exposed through the Failover connector.
-function performFailoverAction (string path, Request request, HttpOperation requestAction,
+isolated function performFailoverAction (string path, Request request, HttpOperation requestAction,
                                         FailoverClient failoverClient, string verb = "")
                                         returns HttpResponse|ClientError {
 
@@ -393,7 +393,7 @@ function performFailoverAction (string path, Request request, HttpOperation requ
 }
 
 // Populates an error specific to the Failover connector by including all the errors returned from endpoints.
-function populateGenericFailoverActionError (ClientError?[] failoverActionErr, ClientError httpActionErr, int index)
+isolated function populateGenericFailoverActionError (ClientError?[] failoverActionErr, ClientError httpActionErr, int index)
                                                                             returns FailoverAllEndpointsFailedError {
 
     failoverActionErr[index] = httpActionErr;
@@ -405,14 +405,14 @@ function populateGenericFailoverActionError (ClientError?[] failoverActionErr, C
 
 // If leaf endpoint returns a response with status code configured to retry in the failover connector, failover error
 // will be generated with last response status code and generic failover response.
-function populateFailoverErrorHttpStatusCodes (Response inResponse, ClientError?[] failoverActionErr, int index) {
+isolated function populateFailoverErrorHttpStatusCodes (Response inResponse, ClientError?[] failoverActionErr, int index) {
     string failoverMessage = "Endpoint " + index.toString() + " returned response is: " +
                                 inResponse.statusCode.toString() + " " + inResponse.reasonPhrase;
     FailoverActionFailedError httpActionErr = FailoverActionFailedError(failoverMessage);
     failoverActionErr[index] = httpActionErr;
 }
 
-function populateErrorsFromLastResponse (Response inResponse, ClientError?[] failoverActionErr, int index)
+isolated function populateErrorsFromLastResponse (Response inResponse, ClientError?[] failoverActionErr, int index)
                                                                             returns (ClientError) {
     string message = "Last endpoint returned response: " + inResponse.statusCode.toString() + " " +
                         inResponse.reasonPhrase;
@@ -454,7 +454,7 @@ public type FailoverClientConfiguration record {|
     int intervalInMillis = 0;
 |};
 
-function createClientEPConfigFromFailoverEPConfig(FailoverClientConfiguration foConfig,
+isolated function createClientEPConfigFromFailoverEPConfig(FailoverClientConfiguration foConfig,
                                                   TargetService target) returns ClientConfiguration {
     ClientConfiguration clientEPConfig = {
         http1Settings: foConfig.http1Settings,
@@ -474,7 +474,7 @@ function createClientEPConfigFromFailoverEPConfig(FailoverClientConfiguration fo
     return clientEPConfig;
 }
 
-function createFailoverHttpClientArray(FailoverClientConfiguration failoverClientConfig)
+isolated function createFailoverHttpClientArray(FailoverClientConfiguration failoverClientConfig)
                                                                             returns Client?[]|error {
 
     Client clientEp;
@@ -490,7 +490,7 @@ function createFailoverHttpClientArray(FailoverClientConfiguration failoverClien
     return httpClients;
 }
 
-function getLastSuceededClientEP(FailoverClient failoverClient) returns Client {
+isolated function getLastSuceededClientEP(FailoverClient failoverClient) returns Client {
     var lastSuccessClient = failoverClient.failoverInferredConfig
                                             .failoverClientsArray[failoverClient.succeededEndpointIndex];
     if (lastSuccessClient is Client) {
@@ -503,7 +503,7 @@ function getLastSuceededClientEP(FailoverClient failoverClient) returns Client {
     }
 }
 
-function handleResponseWithErrorCode(Response response, int initialIndex, int noOfEndpoints, int index,
+isolated function handleResponseWithErrorCode(Response response, int initialIndex, int noOfEndpoints, int index,
                                                         ClientError?[] failoverActionErrData) returns [int, ClientError?] {
 
     ClientError? resultError = ();
@@ -547,7 +547,7 @@ function handleResponseWithErrorCode(Response response, int initialIndex, int no
     return [currentIndex, resultError];
 }
 
-function handleError(ClientError err, int initialIndex, int noOfEndpoints, int index, ClientError?[] failoverActionErrData)
+isolated function handleError(ClientError err, int initialIndex, int noOfEndpoints, int index, ClientError?[] failoverActionErrData)
                                                                                         returns [int, ClientError?] {
     ClientError? httpConnectorErr = ();
 

--- a/http-ballerina/src/http/resiliency/failover_client_endpoint.bal
+++ b/http-ballerina/src/http/resiliency/failover_client_endpoint.bal
@@ -52,7 +52,7 @@ public client class FailoverClient {
     # Failover caller actions which provides failover capabilities to an HTTP client endpoint.
     #
     # + failoverClientConfig - The configurations of the client endpoint associated with this `Failover` instance.
-    public isolated function init(FailoverClientConfiguration failoverClientConfig) {
+    public function init(FailoverClientConfiguration failoverClientConfig) {
         self.failoverClientConfig = failoverClientConfig;
         self.succeededEndpointIndex = 0;
         var failoverHttpClientArray = createFailoverHttpClientArray(failoverClientConfig);
@@ -224,7 +224,7 @@ public client class FailoverClient {
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission
     #            fails
-    public remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         Request req = buildRequest(message);
         var result = performExecuteAction(path, req, "SUBMIT", self, verb = httpVerb);
         if (result is Response) {
@@ -238,7 +238,7 @@ public client class FailoverClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         Client foClient = getLastSuceededClientEP(self);
         return foClient->getResponse(httpFuture);
     }
@@ -247,7 +247,7 @@ public client class FailoverClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote isolated function hasPromise(HttpFuture httpFuture) returns boolean {
+    public remote function hasPromise(HttpFuture httpFuture) returns boolean {
         return false;
     }
 
@@ -255,7 +255,7 @@ public client class FailoverClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return UnsupportedActionError("Failover client not supported for getNextPromise action");
     }
 
@@ -263,7 +263,7 @@ public client class FailoverClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return UnsupportedActionError("Failover client not supported for getPromisedResponse action");
     }
 
@@ -271,21 +271,21 @@ public client class FailoverClient {
     # response using the rejected promise.
     #
     # + promise - The Push Promise to be rejected
-    public remote isolated function rejectPromise(PushPromise promise) {
+    public remote function rejectPromise(PushPromise promise) {
     }
 }
 
 // Performs execute action of the Failover connector. extract the corresponding http integer value representation
 // of the http verb and invokes the perform action method.
 // `verb` is used for HTTP `submit()` method.
-isolated function performExecuteAction (string path, Request request, string httpVerb,
+function performExecuteAction (string path, Request request, string httpVerb,
                                    FailoverClient failoverClient, string verb = "") returns HttpResponse|ClientError {
     HttpOperation connectorAction = extractHttpOperation(httpVerb);
     return performFailoverAction(path, request, connectorAction, failoverClient, verb = verb);
 }
 
 // Handles all the actions exposed through the Failover connector.
-isolated function performFailoverAction (string path, Request request, HttpOperation requestAction,
+function performFailoverAction (string path, Request request, HttpOperation requestAction,
                                         FailoverClient failoverClient, string verb = "")
                                         returns HttpResponse|ClientError {
 
@@ -474,7 +474,7 @@ isolated function createClientEPConfigFromFailoverEPConfig(FailoverClientConfigu
     return clientEPConfig;
 }
 
-isolated function createFailoverHttpClientArray(FailoverClientConfiguration failoverClientConfig)
+function createFailoverHttpClientArray(FailoverClientConfiguration failoverClientConfig)
                                                                             returns Client?[]|error {
 
     Client clientEp;

--- a/http-ballerina/src/http/resiliency/failover_client_endpoint.bal
+++ b/http-ballerina/src/http/resiliency/failover_client_endpoint.bal
@@ -76,7 +76,7 @@ public client class FailoverClient {
     # + message - HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function post(string path, RequestMessage message) returns Response|ClientError {
+    public remote function post(string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_POST, self);
         if (result is HttpFuture) {
@@ -92,7 +92,7 @@ public client class FailoverClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function head(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function head(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_HEAD, self);
         if (result is HttpFuture) {
@@ -108,7 +108,7 @@ public client class FailoverClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function patch(string path, RequestMessage message) returns Response|ClientError {
+    public remote function patch(string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_PATCH, self);
         if (result is HttpFuture) {
@@ -124,7 +124,7 @@ public client class FailoverClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function put(string path, RequestMessage message) returns Response|ClientError {
+    public remote function put(string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_PUT, self);
         if (result is HttpFuture) {
@@ -140,7 +140,7 @@ public client class FailoverClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function options(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function options(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_OPTIONS, self);
         if (result is HttpFuture) {
@@ -155,7 +155,7 @@ public client class FailoverClient {
     # + path - Resource path
     # + request - An HTTP request
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function forward(string path, Request request) returns Response|ClientError {
+    public remote function forward(string path, Request request) returns Response|ClientError {
         var result = performFailoverAction(path, request, HTTP_FORWARD, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -171,7 +171,7 @@ public client class FailoverClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function execute(string httpVerb, string path, RequestMessage message) returns
+    public remote function execute(string httpVerb, string path, RequestMessage message) returns
                                                                                        Response|ClientError {
         Request req = buildRequest(message);
         var result = performExecuteAction(path, req, httpVerb, self);
@@ -188,7 +188,7 @@ public client class FailoverClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function delete(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function delete(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_DELETE, self);
         if (result is HttpFuture) {
@@ -204,7 +204,7 @@ public client class FailoverClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function get(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function get(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_GET, self);
         if (result is HttpFuture) {

--- a/http-ballerina/src/http/resiliency/http_circuit_breaker.bal
+++ b/http-ballerina/src/http/resiliency/http_circuit_breaker.bal
@@ -160,7 +160,7 @@ public client class CircuitBreakerClient {
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote isolated function post(string path, RequestMessage message) returns Response|ClientError {
+    public remote function post(string path, RequestMessage message) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -181,7 +181,7 @@ public client class CircuitBreakerClient {
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote isolated function head(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function head(string path, RequestMessage message = ()) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -202,7 +202,7 @@ public client class CircuitBreakerClient {
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote isolated function put(string path, RequestMessage message) returns Response|ClientError {
+    public remote function put(string path, RequestMessage message) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -224,7 +224,7 @@ public client class CircuitBreakerClient {
     #             `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote isolated function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
+    public remote function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -245,7 +245,7 @@ public client class CircuitBreakerClient {
     #             `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote isolated function patch(string path, RequestMessage message) returns Response|ClientError {
+    public remote function patch(string path, RequestMessage message) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -266,7 +266,7 @@ public client class CircuitBreakerClient {
     #             `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote isolated function delete(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function delete(string path, RequestMessage message = ()) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -287,7 +287,7 @@ public client class CircuitBreakerClient {
     #            `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote isolated function get(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function get(string path, RequestMessage message = ()) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -308,7 +308,7 @@ public client class CircuitBreakerClient {
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote isolated function options(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function options(string path, RequestMessage message = ()) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -328,7 +328,7 @@ public client class CircuitBreakerClient {
     # + request - A Request struct
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote isolated function forward(string path, Request request) returns Response|ClientError {
+    public remote function forward(string path, Request request) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 

--- a/http-ballerina/src/http/resiliency/http_circuit_breaker.bal
+++ b/http-ballerina/src/http/resiliency/http_circuit_breaker.bal
@@ -138,7 +138,7 @@ public client class CircuitBreakerClient {
     # + circuitBreakerInferredConfig - Configurations derived from the `http:CircuitBreakerConfig`
     # + httpClient - The underlying `HttpActions` instance, which will be making the actual network calls
     # + circuitHealth - The circuit health monitor
-    public function init(string url, ClientConfiguration config, CircuitBreakerInferredConfig
+    public isolated function init(string url, ClientConfiguration config, CircuitBreakerInferredConfig
         circuitBreakerInferredConfig, HttpClient httpClient, CircuitHealth circuitHealth) {
         RollingWindow rollingWindow = circuitBreakerInferredConfig.rollingWindow;
         if (rollingWindow.timeWindowInMillis < rollingWindow.bucketSizeInMillis) {
@@ -160,7 +160,7 @@ public client class CircuitBreakerClient {
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote function post(string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function post(string path, RequestMessage message) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -181,7 +181,7 @@ public client class CircuitBreakerClient {
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote function head(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function head(string path, RequestMessage message = ()) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -202,7 +202,7 @@ public client class CircuitBreakerClient {
     #             or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote function put(string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function put(string path, RequestMessage message) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -224,7 +224,7 @@ public client class CircuitBreakerClient {
     #             `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -245,7 +245,7 @@ public client class CircuitBreakerClient {
     #             `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote function patch(string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function patch(string path, RequestMessage message) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -266,7 +266,7 @@ public client class CircuitBreakerClient {
     #             `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote function delete(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function delete(string path, RequestMessage message = ()) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -287,7 +287,7 @@ public client class CircuitBreakerClient {
     #            `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote function get(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function get(string path, RequestMessage message = ()) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -308,7 +308,7 @@ public client class CircuitBreakerClient {
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote function options(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function options(string path, RequestMessage message = ()) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -328,7 +328,7 @@ public client class CircuitBreakerClient {
     # + request - A Request struct
     # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream
     #            server
-    public remote function forward(string path, Request request) returns Response|ClientError {
+    public remote isolated function forward(string path, Request request) returns Response|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -351,7 +351,7 @@ public client class CircuitBreakerClient {
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission
     #            fails
-    public remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -374,7 +374,7 @@ public client class CircuitBreakerClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         // No need to check for the response as we already check for the response in the submit method
         return self.httpClient->getResponse(httpFuture);
     }
@@ -384,7 +384,7 @@ public client class CircuitBreakerClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote function hasPromise(HttpFuture httpFuture) returns boolean {
+    public remote isolated function hasPromise(HttpFuture httpFuture) returns boolean {
         return self.httpClient->hasPromise(httpFuture);
     }
 
@@ -392,7 +392,7 @@ public client class CircuitBreakerClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return self.httpClient->getNextPromise(httpFuture);
     }
 
@@ -400,7 +400,7 @@ public client class CircuitBreakerClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return self.httpClient->getPromisedResponse(promise);
     }
 
@@ -408,19 +408,19 @@ public client class CircuitBreakerClient {
     # HTTP remote functions provider.
     #
     # + promise - The `http:PushPromise` to be rejected
-    public remote function rejectPromise(PushPromise promise) {
+    public remote isolated function rejectPromise(PushPromise promise) {
         return self.httpClient->rejectPromise(promise);
     }
 
     # Force the circuit into a closed state in which it will allow requests regardless of the error percentage
     # until the failure threshold exceeds.
-    public function forceClose() {
+    public isolated function forceClose() {
         self.currentCircuitState = CB_CLOSED_STATE;
     }
 
     # Force the circuit into a open state in which it will suspend all requests
     # until `resetTimeInMillis` interval exceeds.
-    public function forceOpen() {
+    public isolated function forceOpen() {
         self.currentCircuitState = CB_OPEN_STATE;
         self.circuitHealth.lastForcedOpenTime = time:currentTime();
     }
@@ -428,7 +428,7 @@ public client class CircuitBreakerClient {
     # Provides the `http:CircuitState` of the circuit breaker.
     #
     # + return - The current `http:CircuitState` of the circuit breaker
-    public function getCurrentState() returns CircuitState {
+    public isolated function getCurrentState() returns CircuitState {
         return self.currentCircuitState;
     }
 }
@@ -440,7 +440,7 @@ public client class CircuitBreakerClient {
 # + currentStateValue - Circuit Breaker current state value
 # + circuitBreakerInferredConfig - Configurations derived from `CircuitBreakerConfig`
 # + return - State of the circuit
-function updateCircuitState(CircuitHealth circuitHealth, CircuitState currentStateValue,
+isolated function updateCircuitState(CircuitHealth circuitHealth, CircuitState currentStateValue,
                             CircuitBreakerInferredConfig circuitBreakerInferredConfig) returns CircuitState {
     lock {
         CircuitState currentState = currentStateValue;
@@ -485,7 +485,7 @@ function updateCircuitState(CircuitHealth circuitHealth, CircuitState currentSta
     }
 }
 
-function updateCircuitHealthAndRespond(Response|ClientError serviceResponse, CircuitHealth circuitHealth,
+isolated function updateCircuitHealthAndRespond(Response|ClientError serviceResponse, CircuitHealth circuitHealth,
                                CircuitBreakerInferredConfig circuitBreakerInferredConfig) returns Response|ClientError {
     if (serviceResponse is Response) {
         if (circuitBreakerInferredConfig.statusCodes[serviceResponse.statusCode]) {
@@ -499,7 +499,7 @@ function updateCircuitHealthAndRespond(Response|ClientError serviceResponse, Cir
     return serviceResponse;
 }
 
-function updateCircuitHealthFailure(CircuitHealth circuitHealth,
+isolated function updateCircuitHealthFailure(CircuitHealth circuitHealth,
                                     CircuitBreakerInferredConfig circuitBreakerInferredConfig) {
     lock {
         int currentBucketId = getCurrentBucketId(circuitHealth, circuitBreakerInferredConfig);
@@ -520,7 +520,7 @@ function updateCircuitHealthFailure(CircuitHealth circuitHealth,
     }
 }
 
-function updateCircuitHealthSuccess(CircuitHealth circuitHealth,
+isolated function updateCircuitHealthSuccess(CircuitHealth circuitHealth,
                                     CircuitBreakerInferredConfig circuitBreakerInferredConfig) {
     lock {
         int currentBucketId = getCurrentBucketId(circuitHealth, circuitBreakerInferredConfig);
@@ -539,7 +539,7 @@ function updateCircuitHealthSuccess(CircuitHealth circuitHealth,
 }
 
 // Handles open circuit state.
-function handleOpenCircuit(CircuitHealth circuitHealth, CircuitBreakerInferredConfig circuitBreakerInferredConfig)
+isolated function handleOpenCircuit(CircuitHealth circuitHealth, CircuitBreakerInferredConfig circuitBreakerInferredConfig)
              returns (ClientError) {
     time:Time effectiveErrorTime = getEffectiveErrorTime(circuitHealth);
     int timeDif = time:currentTime().time - effectiveErrorTime.time;
@@ -551,7 +551,7 @@ function handleOpenCircuit(CircuitHealth circuitHealth, CircuitBreakerInferredCo
 }
 
 // Validates the struct configurations passed to create circuit breaker.
-function validateCircuitBreakerConfiguration(CircuitBreakerConfig circuitBreakerConfig) {
+isolated function validateCircuitBreakerConfiguration(CircuitBreakerConfig circuitBreakerConfig) {
     float failureThreshold = circuitBreakerConfig.failureThreshold;
     if (failureThreshold < 0 || failureThreshold > 1) {
         string errorMessage = "Invalid failure threshold. Failure threshold value"
@@ -564,7 +564,7 @@ function validateCircuitBreakerConfiguration(CircuitBreakerConfig circuitBreaker
 #
 # + circuitHealth - Circuit Breaker health status
 # + return - Current failure ratio
-function getCurrentFailureRatio(CircuitHealth circuitHealth) returns float {
+isolated function getCurrentFailureRatio(CircuitHealth circuitHealth) returns float {
     int totalCount = 0;
     int totalFailures = 0;
 
@@ -585,7 +585,7 @@ function getCurrentFailureRatio(CircuitHealth circuitHealth) returns float {
 #
 # + circuitHealth - Circuit Breaker health status
 # + return - Total requests count
-function getTotalRequestsCount(CircuitHealth circuitHealth) returns int {
+isolated function getTotalRequestsCount(CircuitHealth circuitHealth) returns int {
     int totalCount = 0;
 
     foreach var bucket in circuitHealth.totalBuckets {
@@ -600,7 +600,7 @@ function getTotalRequestsCount(CircuitHealth circuitHealth) returns int {
 # + circuitHealth - Circuit Breaker health status
 # + circuitBreakerInferredConfig - Configurations derived from `CircuitBreakerConfig`
 # + return - Current bucket id
-function getCurrentBucketId(CircuitHealth circuitHealth, CircuitBreakerInferredConfig circuitBreakerInferredConfig)
+isolated function getCurrentBucketId(CircuitHealth circuitHealth, CircuitBreakerInferredConfig circuitBreakerInferredConfig)
              returns int {
     int elapsedTime = (time:currentTime().time - circuitHealth.startTime.time) % circuitBreakerInferredConfig.
         rollingWindow.timeWindowInMillis;
@@ -613,7 +613,7 @@ function getCurrentBucketId(CircuitHealth circuitHealth, CircuitBreakerInferredC
 #
 # + circuitHealth - Circuit Breaker health status
 # + circuitBreakerInferredConfig - Configurations derived from `CircuitBreakerConfig`
-function updateRejectedRequestCount(CircuitHealth circuitHealth,
+isolated function updateRejectedRequestCount(CircuitHealth circuitHealth,
                                                 CircuitBreakerInferredConfig circuitBreakerInferredConfig) {
 
     int currentBucketId = getCurrentBucketId(circuitHealth, circuitBreakerInferredConfig);
@@ -626,11 +626,11 @@ function updateRejectedRequestCount(CircuitHealth circuitHealth,
 #
 # + circuitHealth - - Circuit Breaker health status.
 # + bucketId - - Id of the bucket should reset.
-function resetBucketStats(CircuitHealth circuitHealth, int bucketId) {
+isolated function resetBucketStats(CircuitHealth circuitHealth, int bucketId) {
     circuitHealth.totalBuckets[bucketId] = {};
 }
 
-function getEffectiveErrorTime(CircuitHealth circuitHealth) returns time:Time {
+isolated function getEffectiveErrorTime(CircuitHealth circuitHealth) returns time:Time {
     time:Time? lastErrorTime = circuitHealth?.lastErrorTime;
     time:Time? lastForcedOpenTime = circuitHealth?.lastForcedOpenTime;
     if (lastErrorTime is time:Time && lastForcedOpenTime is time:Time) {
@@ -645,7 +645,7 @@ function getEffectiveErrorTime(CircuitHealth circuitHealth) returns time:Time {
 #
 # + circuitHealth - Circuit Breaker health status
 # + circuitBreakerInferredConfig - Configurations derived from `CircuitBreakerConfig`
-function prepareRollingWindow(CircuitHealth circuitHealth, CircuitBreakerInferredConfig circuitBreakerInferredConfig) {
+isolated function prepareRollingWindow(CircuitHealth circuitHealth, CircuitBreakerInferredConfig circuitBreakerInferredConfig) {
 
     int currentTime = time:currentTime().time;
     time:Time? lastRequestTime = circuitHealth?.lastRequestTime;
@@ -693,7 +693,7 @@ function prepareRollingWindow(CircuitHealth circuitHealth, CircuitBreakerInferre
 # Reinitializes the Buckets to the default state.
 #
 # + circuitHealth - Circuit Breaker health status
-function reInitializeBuckets(CircuitHealth circuitHealth) {
+isolated function reInitializeBuckets(CircuitHealth circuitHealth) {
     Bucket?[] bucketArray = [];
     int bucketIndex = 0;
     while (bucketIndex < circuitHealth.totalBuckets.length()) {
@@ -707,7 +707,7 @@ function reInitializeBuckets(CircuitHealth circuitHealth) {
 #
 # + bucketId - Possition of the currrently used bucket
 # + circuitHealth - Circuit Breaker health status
-function updateLastUsedBucketId(int bucketId, CircuitHealth circuitHealth) {
+isolated function updateLastUsedBucketId(int bucketId, CircuitHealth circuitHealth) {
     if (bucketId != circuitHealth.lastUsedBucketId) {
         resetBucketStats(circuitHealth, bucketId);
         circuitHealth.lastUsedBucketId = bucketId;
@@ -720,7 +720,7 @@ function updateLastUsedBucketId(int bucketId, CircuitHealth circuitHealth) {
 # + circuitHealth - Circuit Breaker health status
 # + currentState - current state of the circuit
 # + return - Calculated state value of the circuit
-function switchCircuitStateOpenToHalfOpenOnResetTime(CircuitBreakerInferredConfig circuitBreakerInferredConfig,
+isolated function switchCircuitStateOpenToHalfOpenOnResetTime(CircuitBreakerInferredConfig circuitBreakerInferredConfig,
                                         CircuitHealth circuitHealth, CircuitState currentState) returns CircuitState {
     CircuitState currentCircuitState = currentState;
     if (currentState == CB_OPEN_STATE) {

--- a/http-ballerina/src/http/resiliency/http_circuit_breaker.bal
+++ b/http-ballerina/src/http/resiliency/http_circuit_breaker.bal
@@ -138,7 +138,7 @@ public client class CircuitBreakerClient {
     # + circuitBreakerInferredConfig - Configurations derived from the `http:CircuitBreakerConfig`
     # + httpClient - The underlying `HttpActions` instance, which will be making the actual network calls
     # + circuitHealth - The circuit health monitor
-    public isolated function init(string url, ClientConfiguration config, CircuitBreakerInferredConfig
+    public function init(string url, ClientConfiguration config, CircuitBreakerInferredConfig
         circuitBreakerInferredConfig, HttpClient httpClient, CircuitHealth circuitHealth) {
         RollingWindow rollingWindow = circuitBreakerInferredConfig.rollingWindow;
         if (rollingWindow.timeWindowInMillis < rollingWindow.bucketSizeInMillis) {
@@ -351,7 +351,7 @@ public client class CircuitBreakerClient {
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission
     #            fails
-    public remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -374,7 +374,7 @@ public client class CircuitBreakerClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         // No need to check for the response as we already check for the response in the submit method
         return self.httpClient->getResponse(httpFuture);
     }
@@ -384,7 +384,7 @@ public client class CircuitBreakerClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote isolated function hasPromise(HttpFuture httpFuture) returns boolean {
+    public remote function hasPromise(HttpFuture httpFuture) returns boolean {
         return self.httpClient->hasPromise(httpFuture);
     }
 
@@ -392,7 +392,7 @@ public client class CircuitBreakerClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return self.httpClient->getNextPromise(httpFuture);
     }
 
@@ -400,7 +400,7 @@ public client class CircuitBreakerClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return self.httpClient->getPromisedResponse(promise);
     }
 
@@ -408,19 +408,19 @@ public client class CircuitBreakerClient {
     # HTTP remote functions provider.
     #
     # + promise - The `http:PushPromise` to be rejected
-    public remote isolated function rejectPromise(PushPromise promise) {
+    public remote function rejectPromise(PushPromise promise) {
         return self.httpClient->rejectPromise(promise);
     }
 
     # Force the circuit into a closed state in which it will allow requests regardless of the error percentage
     # until the failure threshold exceeds.
-    public isolated function forceClose() {
+    public function forceClose() {
         self.currentCircuitState = CB_CLOSED_STATE;
     }
 
     # Force the circuit into a open state in which it will suspend all requests
     # until `resetTimeInMillis` interval exceeds.
-    public isolated function forceOpen() {
+    public function forceOpen() {
         self.currentCircuitState = CB_OPEN_STATE;
         self.circuitHealth.lastForcedOpenTime = time:currentTime();
     }
@@ -428,7 +428,7 @@ public client class CircuitBreakerClient {
     # Provides the `http:CircuitState` of the circuit breaker.
     #
     # + return - The current `http:CircuitState` of the circuit breaker
-    public isolated function getCurrentState() returns CircuitState {
+    public function getCurrentState() returns CircuitState {
         return self.currentCircuitState;
     }
 }

--- a/http-ballerina/src/http/resiliency/http_load_balancer_rule.bal
+++ b/http-ballerina/src/http/resiliency/http_load_balancer_rule.bal
@@ -24,5 +24,5 @@ public type LoadBalancerRule object {
     # + loadBalanceCallerActionsArray - Array of HTTP clients which needs to be load balanced
     # + return - Chosen `Client` from the algorithm or an `http:ClientError`
     #            for the failure in the algorithm implementation
-    public function getNextClient(Client?[] loadBalanceCallerActionsArray) returns Client|ClientError;
+    public isolated function getNextClient(Client?[] loadBalanceCallerActionsArray) returns Client|ClientError;
 };

--- a/http-ballerina/src/http/resiliency/http_retry_client.bal
+++ b/http-ballerina/src/http/resiliency/http_retry_client.bal
@@ -53,7 +53,7 @@ public client class RetryClient {
     # + config - HTTP ClientConfiguration to be used for HTTP client invocation
     # + retryInferredConfig - Derived set of configurations associated with retry
     # + httpClient - HTTP client for outbound HTTP requests
-    public function init(string url, ClientConfiguration config, RetryInferredConfig retryInferredConfig,
+    public isolated function init(string url, ClientConfiguration config, RetryInferredConfig retryInferredConfig,
                                         HttpClient httpClient) {
         self.url = url;
         self.config = config;
@@ -68,7 +68,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function post(string path, RequestMessage message) returns @tainted Response|ClientError {
+    public remote isolated function post(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_POST, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -84,7 +84,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function head(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
+    public remote isolated function head(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_HEAD, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -100,7 +100,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function put(string path, RequestMessage message) returns @tainted Response|ClientError {
+    public remote isolated function put(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_PUT, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -115,7 +115,7 @@ public client class RetryClient {
     # + path - Resource path
     # + request - An HTTP inbound request message
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function forward(string path, Request request) returns @tainted Response|ClientError {
+    public remote isolated function forward(string path, Request request) returns @tainted Response|ClientError {
         var result = performRetryAction(path, request, HTTP_FORWARD, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -133,7 +133,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function execute(string httpVerb, string path, RequestMessage message) returns
+    public remote isolated function execute(string httpVerb, string path, RequestMessage message) returns
             @tainted Response|ClientError {
         var result = performRetryClientExecuteAction(path, <Request>message, httpVerb, self);
         if (result is HttpFuture) {
@@ -150,7 +150,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function patch(string path, RequestMessage message) returns @tainted Response|ClientError {
+    public remote isolated function patch(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_PATCH, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -166,7 +166,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:Response` message, or else an `http:ClientError` if the invocation fails
-    public remote function delete(string path, RequestMessage message = ()) returns
+    public remote isolated function delete(string path, RequestMessage message = ()) returns
             @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_DELETE, self);
         if (result is HttpFuture) {
@@ -183,7 +183,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function get(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
+    public remote isolated function get(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_GET, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -199,7 +199,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function options(string path, RequestMessage message = ()) returns
+    public remote isolated function options(string path, RequestMessage message = ()) returns
             @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_OPTIONS, self);
         if (result is HttpFuture) {
@@ -218,7 +218,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission fails
-    public remote function submit(string httpVerb, string path, RequestMessage message) returns
+    public remote isolated function submit(string httpVerb, string path, RequestMessage message) returns
             @tainted HttpFuture|ClientError {
         var result = performRetryClientExecuteAction(path, <Request>message, HTTP_SUBMIT, self, verb = httpVerb);
         if (result is Response) {
@@ -232,7 +232,7 @@ public client class RetryClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         // This need not be retried as the response is already checked when submit is called.
         return self.httpClient->getResponse(httpFuture);
     }
@@ -241,7 +241,7 @@ public client class RetryClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote function hasPromise(HttpFuture httpFuture) returns (boolean) {
+    public remote isolated function hasPromise(HttpFuture httpFuture) returns (boolean) {
         return self.httpClient->hasPromise(httpFuture);
     }
 
@@ -249,7 +249,7 @@ public client class RetryClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return self.httpClient->getNextPromise(httpFuture);
     }
 
@@ -257,7 +257,7 @@ public client class RetryClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return self.httpClient->getPromisedResponse(promise);
     }
 
@@ -265,7 +265,7 @@ public client class RetryClient {
     # When an `http:PushPromise` is rejected, there is no chance of fetching a promised response using the rejected promise.
     #
     # + promise - The Push Promise to be rejected
-    public remote function rejectPromise(PushPromise promise) {
+    public remote isolated function rejectPromise(PushPromise promise) {
         return self.httpClient->rejectPromise(promise);
     }
 }
@@ -274,14 +274,14 @@ public client class RetryClient {
 // Performs execute remote function of the retry client. extract the corresponding http integer value representation
 // of the http verb and invokes the perform action method.
 // verb is used for submit methods only.
-function performRetryClientExecuteAction(@untainted string path, Request request, @untainted string httpVerb,
+isolated function performRetryClientExecuteAction(@untainted string path, Request request, @untainted string httpVerb,
                                          RetryClient retryClient, string verb = "") returns @tainted HttpResponse|ClientError {
     HttpOperation connectorAction = extractHttpOperation(httpVerb);
     return performRetryAction(path, request, connectorAction, retryClient, verb = verb);
 }
 
 // Handles all the actions exposed through the retry client.
-function performRetryAction(@untainted string path, Request request, HttpOperation requestAction,
+isolated function performRetryAction(@untainted string path, Request request, HttpOperation requestAction,
                             RetryClient retryClient, string verb = "") returns @tainted HttpResponse|ClientError {
     HttpClient httpClient = retryClient.httpClient;
     int currentRetryCount = 0;
@@ -336,7 +336,7 @@ function performRetryAction(@untainted string path, Request request, HttpOperati
     return httpConnectorErr;
 }
 
-function initializeBackOffFactorAndMaxWaitInterval(RetryClient retryClient) {
+isolated function initializeBackOffFactorAndMaxWaitInterval(RetryClient retryClient) {
     if (retryClient.retryInferredConfig.backOffFactor <= 0.0) {
         retryClient.retryInferredConfig.backOffFactor = 1.0;
     }
@@ -345,13 +345,13 @@ function initializeBackOffFactorAndMaxWaitInterval(RetryClient retryClient) {
     }
 }
 
-function getWaitTime(float backOffFactor, int maxWaitTime, int interval) returns int {
+isolated function getWaitTime(float backOffFactor, int maxWaitTime, int interval) returns int {
     int waitTime = <int>(interval * backOffFactor);
     waitTime = waitTime > maxWaitTime ? maxWaitTime : waitTime;
     return waitTime;
 }
 
-function calculateEffectiveIntervalAndRetryCount(RetryClient retryClient, int currentRetryCount, int currentDelay)
+isolated function calculateEffectiveIntervalAndRetryCount(RetryClient retryClient, int currentRetryCount, int currentDelay)
                                                  returns [int, int] {
     int interval = currentDelay;
     if (currentRetryCount != 0) {

--- a/http-ballerina/src/http/resiliency/http_retry_client.bal
+++ b/http-ballerina/src/http/resiliency/http_retry_client.bal
@@ -68,7 +68,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function post(string path, RequestMessage message) returns @tainted Response|ClientError {
+    public remote function post(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_POST, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -84,7 +84,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function head(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
+    public remote function head(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_HEAD, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -100,7 +100,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function put(string path, RequestMessage message) returns @tainted Response|ClientError {
+    public remote function put(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_PUT, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -115,7 +115,7 @@ public client class RetryClient {
     # + path - Resource path
     # + request - An HTTP inbound request message
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function forward(string path, Request request) returns @tainted Response|ClientError {
+    public remote function forward(string path, Request request) returns @tainted Response|ClientError {
         var result = performRetryAction(path, request, HTTP_FORWARD, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -133,7 +133,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function execute(string httpVerb, string path, RequestMessage message) returns
+    public remote function execute(string httpVerb, string path, RequestMessage message) returns
             @tainted Response|ClientError {
         var result = performRetryClientExecuteAction(path, <Request>message, httpVerb, self);
         if (result is HttpFuture) {
@@ -150,7 +150,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function patch(string path, RequestMessage message) returns @tainted Response|ClientError {
+    public remote function patch(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_PATCH, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -166,7 +166,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:Response` message, or else an `http:ClientError` if the invocation fails
-    public remote isolated function delete(string path, RequestMessage message = ()) returns
+    public remote function delete(string path, RequestMessage message = ()) returns
             @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_DELETE, self);
         if (result is HttpFuture) {
@@ -183,7 +183,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function get(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
+    public remote function get(string path, RequestMessage message = ()) returns @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_GET, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -199,7 +199,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function options(string path, RequestMessage message = ()) returns
+    public remote function options(string path, RequestMessage message = ()) returns
             @tainted Response|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_OPTIONS, self);
         if (result is HttpFuture) {

--- a/http-ballerina/src/http/resiliency/http_retry_client.bal
+++ b/http-ballerina/src/http/resiliency/http_retry_client.bal
@@ -53,7 +53,7 @@ public client class RetryClient {
     # + config - HTTP ClientConfiguration to be used for HTTP client invocation
     # + retryInferredConfig - Derived set of configurations associated with retry
     # + httpClient - HTTP client for outbound HTTP requests
-    public isolated function init(string url, ClientConfiguration config, RetryInferredConfig retryInferredConfig,
+    public function init(string url, ClientConfiguration config, RetryInferredConfig retryInferredConfig,
                                         HttpClient httpClient) {
         self.url = url;
         self.config = config;
@@ -218,7 +218,7 @@ public client class RetryClient {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission fails
-    public remote isolated function submit(string httpVerb, string path, RequestMessage message) returns
+    public remote function submit(string httpVerb, string path, RequestMessage message) returns
             @tainted HttpFuture|ClientError {
         var result = performRetryClientExecuteAction(path, <Request>message, HTTP_SUBMIT, self, verb = httpVerb);
         if (result is Response) {
@@ -232,7 +232,7 @@ public client class RetryClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         // This need not be retried as the response is already checked when submit is called.
         return self.httpClient->getResponse(httpFuture);
     }
@@ -241,7 +241,7 @@ public client class RetryClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote isolated function hasPromise(HttpFuture httpFuture) returns (boolean) {
+    public remote function hasPromise(HttpFuture httpFuture) returns (boolean) {
         return self.httpClient->hasPromise(httpFuture);
     }
 
@@ -249,7 +249,7 @@ public client class RetryClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return self.httpClient->getNextPromise(httpFuture);
     }
 
@@ -257,7 +257,7 @@ public client class RetryClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return self.httpClient->getPromisedResponse(promise);
     }
 
@@ -265,7 +265,7 @@ public client class RetryClient {
     # When an `http:PushPromise` is rejected, there is no chance of fetching a promised response using the rejected promise.
     #
     # + promise - The Push Promise to be rejected
-    public remote isolated function rejectPromise(PushPromise promise) {
+    public remote function rejectPromise(PushPromise promise) {
         return self.httpClient->rejectPromise(promise);
     }
 }
@@ -274,14 +274,14 @@ public client class RetryClient {
 // Performs execute remote function of the retry client. extract the corresponding http integer value representation
 // of the http verb and invokes the perform action method.
 // verb is used for submit methods only.
-isolated function performRetryClientExecuteAction(@untainted string path, Request request, @untainted string httpVerb,
+function performRetryClientExecuteAction(@untainted string path, Request request, @untainted string httpVerb,
                                          RetryClient retryClient, string verb = "") returns @tainted HttpResponse|ClientError {
     HttpOperation connectorAction = extractHttpOperation(httpVerb);
     return performRetryAction(path, request, connectorAction, retryClient, verb = verb);
 }
 
 // Handles all the actions exposed through the retry client.
-isolated function performRetryAction(@untainted string path, Request request, HttpOperation requestAction,
+function performRetryAction(@untainted string path, Request request, HttpOperation requestAction,
                             RetryClient retryClient, string verb = "") returns @tainted HttpResponse|ClientError {
     HttpClient httpClient = retryClient.httpClient;
     int currentRetryCount = 0;

--- a/http-ballerina/src/http/resiliency/http_round_robin_rule.bal
+++ b/http-ballerina/src/http/resiliency/http_round_robin_rule.bal
@@ -26,7 +26,7 @@ public class LoadBalancerRoundRobinRule {
     # + loadBalanceCallerActionsArray - Array of HTTP clients, which needs to be load balanced
     # + return - Chosen `http:Client` from the algorithm or else an `http:ClientError` for a failure in
     #            the algorithm implementation
-    public function getNextClient(Client?[] loadBalanceCallerActionsArray) returns Client|ClientError {
+    public isolated function getNextClient(Client?[] loadBalanceCallerActionsArray) returns Client|ClientError {
         Client httpClient = <Client>loadBalanceCallerActionsArray[self.index];
         lock {
             if (self.index == ((loadBalanceCallerActionsArray.length()) - 1)) {

--- a/http-ballerina/src/http/resiliency/load_balance_client_endpoint.bal
+++ b/http-ballerina/src/http/resiliency/load_balance_client_endpoint.bal
@@ -56,7 +56,7 @@ public client class LoadBalanceClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function post(string path, RequestMessage message) returns Response|ClientError {
+    public remote function post(string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_POST);
     }
@@ -67,7 +67,7 @@ public client class LoadBalanceClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function head(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function head(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_HEAD);
     }
@@ -78,7 +78,7 @@ public client class LoadBalanceClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function patch(string path, RequestMessage message) returns Response|ClientError {
+    public remote function patch(string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_PATCH);
     }
@@ -89,7 +89,7 @@ public client class LoadBalanceClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function put(string path, RequestMessage message) returns Response|ClientError {
+    public remote function put(string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_PUT);
     }
@@ -100,7 +100,7 @@ public client class LoadBalanceClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function options(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function options(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_OPTIONS);
     }
@@ -110,7 +110,7 @@ public client class LoadBalanceClient {
     # + path - Resource path
     # + request - An optional HTTP request
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function forward(string path, Request request) returns Response|ClientError {
+    public remote function forward(string path, Request request) returns Response|ClientError {
         return performLoadBalanceAction(self, path, request, HTTP_FORWARD);
     }
 
@@ -122,7 +122,7 @@ public client class LoadBalanceClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
+    public remote function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceExecuteAction(self, path, req, httpVerb);
     }
@@ -133,7 +133,7 @@ public client class LoadBalanceClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function delete(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function delete(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_DELETE);
     }
@@ -144,7 +144,7 @@ public client class LoadBalanceClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote isolated function get(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote function get(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_GET);
     }

--- a/http-ballerina/src/http/resiliency/load_balance_client_endpoint.bal
+++ b/http-ballerina/src/http/resiliency/load_balance_client_endpoint.bal
@@ -32,7 +32,7 @@ public client class LoadBalanceClient {
     # Load Balancer adds an additional layer to the HTTP client to make network interactions more resilient.
     #
     # + loadBalanceClientConfig - The configurations for the load balance client endpoint
-    public function init(LoadBalanceClientConfiguration loadBalanceClientConfig) {
+    public isolated function init(LoadBalanceClientConfiguration loadBalanceClientConfig) {
         self.loadBalanceClientConfig = loadBalanceClientConfig;
         self.failover = loadBalanceClientConfig.failover;
         var lbClients = createLoadBalanceHttpClientArray(loadBalanceClientConfig);
@@ -56,7 +56,7 @@ public client class LoadBalanceClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function post(string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function post(string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_POST);
     }
@@ -67,7 +67,7 @@ public client class LoadBalanceClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function head(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function head(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_HEAD);
     }
@@ -78,7 +78,7 @@ public client class LoadBalanceClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function patch(string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function patch(string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_PATCH);
     }
@@ -89,7 +89,7 @@ public client class LoadBalanceClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function put(string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function put(string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_PUT);
     }
@@ -100,7 +100,7 @@ public client class LoadBalanceClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function options(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function options(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_OPTIONS);
     }
@@ -110,7 +110,7 @@ public client class LoadBalanceClient {
     # + path - Resource path
     # + request - An optional HTTP request
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function forward(string path, Request request) returns Response|ClientError {
+    public remote isolated function forward(string path, Request request) returns Response|ClientError {
         return performLoadBalanceAction(self, path, request, HTTP_FORWARD);
     }
 
@@ -122,7 +122,7 @@ public client class LoadBalanceClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
+    public remote isolated function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceExecuteAction(self, path, req, httpVerb);
     }
@@ -133,7 +133,7 @@ public client class LoadBalanceClient {
     # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `io:ReadableByteChannel`
     #             or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function delete(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function delete(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_DELETE);
     }
@@ -144,7 +144,7 @@ public client class LoadBalanceClient {
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to fulfill the request
-    public remote function get(string path, RequestMessage message = ()) returns Response|ClientError {
+    public remote isolated function get(string path, RequestMessage message = ()) returns Response|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_GET);
     }
@@ -157,7 +157,7 @@ public client class LoadBalanceClient {
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission
     #            fails
-    public remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         return UnsupportedActionError("Load balancer client not supported for submit action");
     }
 
@@ -165,7 +165,7 @@ public client class LoadBalanceClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         return UnsupportedActionError("Load balancer client not supported for getResponse action");
     }
 
@@ -173,7 +173,7 @@ public client class LoadBalanceClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote function hasPromise(HttpFuture httpFuture) returns boolean {
+    public remote isolated function hasPromise(HttpFuture httpFuture) returns boolean {
         return false;
     }
 
@@ -181,7 +181,7 @@ public client class LoadBalanceClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return UnsupportedActionError("Load balancer client not supported for getNextPromise action");
     }
 
@@ -189,14 +189,14 @@ public client class LoadBalanceClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return UnsupportedActionError("Load balancer client not supported for getPromisedResponse action");
     }
 
     # The rejectPromise implementation of the LoadBalancer Connector.
     #
     # + promise - The Push Promise to be rejected
-    public remote function rejectPromise(PushPromise promise) {}
+    public remote isolated function rejectPromise(PushPromise promise) {}
 }
 
 # Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.
@@ -211,7 +211,7 @@ public type LoadBalanceActionError distinct error<LoadBalanceActionErrorData>;
 
 // Performs execute action of the Load Balance connector. extract the corresponding http integer value representation
 // of the http verb and invokes the perform action method.
-function performLoadBalanceExecuteAction(LoadBalanceClient lb, string path, Request request,
+isolated function performLoadBalanceExecuteAction(LoadBalanceClient lb, string path, Request request,
                                          string httpVerb) returns Response|ClientError {
     HttpOperation connectorAction = extractHttpOperation(httpVerb);
     if (connectorAction != HTTP_NONE) {
@@ -222,7 +222,7 @@ function performLoadBalanceExecuteAction(LoadBalanceClient lb, string path, Requ
 }
 
 // Handles all the actions exposed through the Load Balance connector.
-function performLoadBalanceAction(LoadBalanceClient lb, string path, Request request, HttpOperation requestAction)
+isolated function performLoadBalanceAction(LoadBalanceClient lb, string path, Request request, HttpOperation requestAction)
              returns Response|ClientError {
     int loadBalanceTermination = 0; // Tracks at which point failover within the load balancing should be terminated.
     //TODO: workaround to initialize a type inside a function. Change this once fix is available.
@@ -269,7 +269,7 @@ function performLoadBalanceAction(LoadBalanceClient lb, string path, Request req
 }
 
 // Populates generic error specific to Load Balance connector by including all the errors returned from endpoints.
-function populateGenericLoadBalanceActionError(LoadBalanceActionErrorData loadBalanceActionErrorData)
+isolated function populateGenericLoadBalanceActionError(LoadBalanceActionErrorData loadBalanceActionErrorData)
                                                     returns ClientError {
     int nErrs = loadBalanceActionErrorData.httpActionErr.length();
     error? lastError = loadBalanceActionErrorData.httpActionErr[nErrs - 1];
@@ -313,7 +313,7 @@ public type LoadBalanceClientConfiguration record {|
     boolean failover = true;
 |};
 
-function createClientEPConfigFromLoalBalanceEPConfig(LoadBalanceClientConfiguration lbConfig,
+isolated function createClientEPConfigFromLoalBalanceEPConfig(LoadBalanceClientConfiguration lbConfig,
                                                      TargetService target) returns ClientConfiguration {
     ClientConfiguration clientEPConfig = {
         http1Settings: lbConfig.http1Settings,
@@ -333,7 +333,7 @@ function createClientEPConfigFromLoalBalanceEPConfig(LoadBalanceClientConfigurat
     return clientEPConfig;
 }
 
-function createLoadBalanceHttpClientArray(LoadBalanceClientConfiguration loadBalanceClientConfig)
+isolated function createLoadBalanceHttpClientArray(LoadBalanceClientConfiguration loadBalanceClientConfig)
                                                                                     returns Client?[]|error {
     Client cl;
     Client?[] httpClients = [];

--- a/http-ballerina/src/http/resiliency/load_balance_client_endpoint.bal
+++ b/http-ballerina/src/http/resiliency/load_balance_client_endpoint.bal
@@ -32,7 +32,7 @@ public client class LoadBalanceClient {
     # Load Balancer adds an additional layer to the HTTP client to make network interactions more resilient.
     #
     # + loadBalanceClientConfig - The configurations for the load balance client endpoint
-    public isolated function init(LoadBalanceClientConfiguration loadBalanceClientConfig) {
+    public function init(LoadBalanceClientConfiguration loadBalanceClientConfig) {
         self.loadBalanceClientConfig = loadBalanceClientConfig;
         self.failover = loadBalanceClientConfig.failover;
         var lbClients = createLoadBalanceHttpClientArray(loadBalanceClientConfig);
@@ -157,7 +157,7 @@ public client class LoadBalanceClient {
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission
     #            fails
-    public remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
+    public remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         return UnsupportedActionError("Load balancer client not supported for submit action");
     }
 
@@ -165,7 +165,7 @@ public client class LoadBalanceClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getResponse(HttpFuture httpFuture) returns Response|ClientError {
+    public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         return UnsupportedActionError("Load balancer client not supported for getResponse action");
     }
 
@@ -173,7 +173,7 @@ public client class LoadBalanceClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - A `boolean`, which represents whether an `http:PushPromise` exists
-    public remote isolated function hasPromise(HttpFuture httpFuture) returns boolean {
+    public remote function hasPromise(HttpFuture httpFuture) returns boolean {
         return false;
     }
 
@@ -181,7 +181,7 @@ public client class LoadBalanceClient {
     #
     # + httpFuture - The `http:HttpFuture` related to a previous asynchronous invocation
     # + return - An `http:PushPromise` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
+    public remote function getNextPromise(HttpFuture httpFuture) returns PushPromise|ClientError {
         return UnsupportedActionError("Load balancer client not supported for getNextPromise action");
     }
 
@@ -189,14 +189,14 @@ public client class LoadBalanceClient {
     #
     # + promise - The related `http:PushPromise`
     # + return - A promised `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote isolated function getPromisedResponse(PushPromise promise) returns Response|ClientError {
+    public remote function getPromisedResponse(PushPromise promise) returns Response|ClientError {
         return UnsupportedActionError("Load balancer client not supported for getPromisedResponse action");
     }
 
     # The rejectPromise implementation of the LoadBalancer Connector.
     #
     # + promise - The Push Promise to be rejected
-    public remote isolated function rejectPromise(PushPromise promise) {}
+    public remote function rejectPromise(PushPromise promise) {}
 }
 
 # Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.
@@ -211,7 +211,7 @@ public type LoadBalanceActionError distinct error<LoadBalanceActionErrorData>;
 
 // Performs execute action of the Load Balance connector. extract the corresponding http integer value representation
 // of the http verb and invokes the perform action method.
-isolated function performLoadBalanceExecuteAction(LoadBalanceClient lb, string path, Request request,
+function performLoadBalanceExecuteAction(LoadBalanceClient lb, string path, Request request,
                                          string httpVerb) returns Response|ClientError {
     HttpOperation connectorAction = extractHttpOperation(httpVerb);
     if (connectorAction != HTTP_NONE) {
@@ -222,7 +222,7 @@ isolated function performLoadBalanceExecuteAction(LoadBalanceClient lb, string p
 }
 
 // Handles all the actions exposed through the Load Balance connector.
-isolated function performLoadBalanceAction(LoadBalanceClient lb, string path, Request request, HttpOperation requestAction)
+function performLoadBalanceAction(LoadBalanceClient lb, string path, Request request, HttpOperation requestAction)
              returns Response|ClientError {
     int loadBalanceTermination = 0; // Tracks at which point failover within the load balancing should be terminated.
     //TODO: workaround to initialize a type inside a function. Change this once fix is available.
@@ -333,7 +333,7 @@ isolated function createClientEPConfigFromLoalBalanceEPConfig(LoadBalanceClientC
     return clientEPConfig;
 }
 
-isolated function createLoadBalanceHttpClientArray(LoadBalanceClientConfiguration loadBalanceClientConfig)
+function createLoadBalanceHttpClientArray(LoadBalanceClientConfiguration loadBalanceClientConfig)
                                                                                     returns Client?[]|error {
     Client cl;
     Client?[] httpClients = [];

--- a/http-ballerina/src/http/service_endpoint.bal
+++ b/http-ballerina/src/http/service_endpoint.bal
@@ -36,21 +36,21 @@ public class Listener {
     # Starts the registered service programmatically.
     #
     # + return - An `error` if an error occurred during the listener starting process
-    public function __start() returns error? {
+    public isolated function __start() returns error? {
         return self.startEndpoint();
     }
 
     # Stops the service listener gracefully. Already-accepted requests will be served before connection closure.
     #
     # + return - An `error` if an error occurred during the listener stopping process
-    public function __gracefulStop() returns error? {
+    public isolated function __gracefulStop() returns error? {
         return self.gracefulStop();
     }
 
     # Stops the service listener immediately. It is not implemented yet.
     #
     # + return - An `error` if an error occurred during the listener stop process
-    public function __immediateStop() returns error? {
+    public isolated function __immediateStop() returns error? {
         error err = error("not implemented");
         return err;
     }
@@ -60,7 +60,7 @@ public class Listener {
     # + s - The service that needs to be attached
     # + name - Name of the service
     # + return - An `error` an error occurred during the service attachment process or else nil
-    public function __attach(service s, string? name = ()) returns error? {
+    public isolated function __attach(service s, string? name = ()) returns error? {
         return self.register(s, name);
     }
 
@@ -69,7 +69,7 @@ public class Listener {
     #
     # + s - The service to be detached
     # + return - An `error` if one occurred during detaching of a service or else `()`
-    public function __detach(service s) returns error? {
+    public isolated function __detach(service s) returns error? {
         return self.detach(s);
     }
 
@@ -77,7 +77,7 @@ public class Listener {
     #
     # + port - Listening port of the HTTP service listener
     # + config - Configurations for the HTTP service listener
-    public function init(int port, ListenerConfiguration? config = ()) {
+    public isolated function init(int port, ListenerConfiguration? config = ()) {
         self.instanceId = uuid();
         self.config = config ?: {};
         self.port = port;
@@ -99,7 +99,7 @@ public class Listener {
         }
     }
     
-    public function initEndpoint() returns error? {
+    public isolated function initEndpoint() returns error? {
         return externInitEndpoint(self);
     }
 
@@ -108,21 +108,21 @@ public class Listener {
     # + s - The service that needs to be attached
     # + name - Name of the service
     # + return - An `error` if an error occurred during the service attachment process or else nil
-    function register(service s, string? name) returns error? {
+    isolated function register(service s, string? name) returns error? {
         return externRegister(self, s, name);
     }
 
     # Starts the registered service.
     #
     # + return - An `error` if an error occurred during the listener start process
-    function startEndpoint() returns error? {
+    isolated function startEndpoint() returns error? {
         return externStart(self);
     }
 
     # Stops the service listener gracefully.
     #
     # + return - An `error` if an error occurred during the listener stop process
-    function gracefulStop() returns error? {
+    isolated function gracefulStop() returns error? {
         return externGracefulStop(self);
     }
 
@@ -130,32 +130,32 @@ public class Listener {
     #
     # + s - The service that needs to be detached
     # + return - An `error` if an error occurred during the service detachment process or else nil
-    function detach(service s) returns error? {
+    isolated function detach(service s) returns error? {
         return externDetach(self, s);
     }
 }
 
-function externInitEndpoint(Listener listenerObj) returns error? = @java:Method {
+isolated function externInitEndpoint(Listener listenerObj) returns error? = @java:Method {
     'class: "org.ballerinalang.net.http.serviceendpoint.InitEndpoint",
     name: "initEndpoint"
 } external;
 
-function externRegister(Listener listenerObj, service s, string? name) returns error? = @java:Method {
+isolated function externRegister(Listener listenerObj, service s, string? name) returns error? = @java:Method {
     'class: "org.ballerinalang.net.http.serviceendpoint.Register",
     name: "register"
 } external;
 
-function externStart(Listener listenerObj) returns error? = @java:Method {
+isolated function externStart(Listener listenerObj) returns error? = @java:Method {
     'class: "org.ballerinalang.net.http.serviceendpoint.Start",
     name: "start"
 } external;
 
-function externGracefulStop(Listener listenerObj) returns error? = @java:Method {
+isolated function externGracefulStop(Listener listenerObj) returns error? = @java:Method {
     'class: "org.ballerinalang.net.http.serviceendpoint.GracefulStop",
     name: "gracefulStop"
 } external;
 
-function externDetach(Listener listenerObj, service s) returns error? = @java:Method {
+isolated function externDetach(Listener listenerObj, service s) returns error? = @java:Method {
     'class: "org.ballerinalang.net.http.serviceendpoint.Detach",
     name: "detach"
 } external;
@@ -306,7 +306,7 @@ public const REQUEST_METHOD = "REQUEST_METHOD";
 # Adds authentication and authorization filters.
 #
 # + config - `ServiceEndpointConfiguration` instance
-function addAuthFilters(ListenerConfiguration config) {
+isolated function addAuthFilters(ListenerConfiguration config) {
     // Add authentication and authorization filters as the first two filters if there are no any filters specified OR
     // the auth filter position is specified as 0. If there are any filters specified, the authentication and
     // authorization filters should be added into the position specified.
@@ -348,7 +348,7 @@ class AttributeFilter {
 
     *RequestFilter;
 
-    public function filterRequest(Caller caller, Request request, FilterContext context) returns boolean {
+    public isolated function filterRequest(Caller caller, Request request, FilterContext context) returns boolean {
         runtime:InvocationContext ctx = runtime:getInvocationContext();
         ctx.attributes[SERVICE_NAME] = context.getServiceName();
         ctx.attributes[RESOURCE_NAME] = context.getResourceName();
@@ -357,7 +357,7 @@ class AttributeFilter {
     }
 }
 
-function addAttributeFilter(ListenerConfiguration config) {
+isolated function addAttributeFilter(ListenerConfiguration config) {
     AttributeFilter attributeFilter = new;
     config.filters.unshift(attributeFilter);
 }

--- a/http-ballerina/src/http/websocket/websocket_caller.bal
+++ b/http-ballerina/src/http/websocket/websocket_caller.bal
@@ -25,7 +25,7 @@ public client class WebSocketCaller {
 
     private WebSocketConnector conn = new;
 
-    function init() {
+    isolated function init() {
         // package private function to prevent object creation
     }
 
@@ -35,7 +35,7 @@ public client class WebSocketCaller {
     # + data - Data to be sent. If it is a byte[], it is converted to a UTF-8 string for sending
     # + finalFrame - Set to `true` if this is a final frame of a (long) message
     # + return  - An `error` if an error occurs when sending
-    public remote function pushText(string|json|xml|boolean|int|float|byte|byte[] data,
+    public remote isolated function pushText(string|json|xml|boolean|int|float|byte|byte[] data,
         boolean finalFrame = true) returns WebSocketError? {
         return self.conn.pushText(data, finalFrame);
     }
@@ -46,7 +46,7 @@ public client class WebSocketCaller {
     # + data - Binary data to be sent
     # + finalFrame - Set to `true` if this is a final frame of a (long) message
     # + return  - An `error` if an error occurs when sending
-    public remote function pushBinary(byte[] data, boolean finalFrame = true) returns WebSocketError? {
+    public remote isolated function pushBinary(byte[] data, boolean finalFrame = true) returns WebSocketError? {
         return self.conn.pushBinary(data, finalFrame);
     }
 
@@ -54,7 +54,7 @@ public client class WebSocketCaller {
     #
     # + data - Binary data to be sent
     # + return  - An `error` if an error occurs when sending
-    public remote function ping(byte[] data) returns WebSocketError? {
+    public remote isolated function ping(byte[] data) returns WebSocketError? {
         return self.conn.ping(data);
     }
 
@@ -63,7 +63,7 @@ public client class WebSocketCaller {
     #
     # + data - Binary data to be sent
     # + return  - An `error` if an error occurs when sending
-    public remote function pong(byte[] data) returns WebSocketError? {
+    public remote isolated function pong(byte[] data) returns WebSocketError? {
         return self.conn.pong(data);
     }
 
@@ -77,7 +77,7 @@ public client class WebSocketCaller {
     #                   until a close frame is received. If WebSocket frame is received from the remote endpoint
     #                   within the waiting period, the connection is terminated immediately.
     # + return - An `error` if an error occurs when sending
-    public remote function close(int? statusCode = 1000, string? reason = (),
+    public remote isolated function close(int? statusCode = 1000, string? reason = (),
         int timeoutInSeconds = 60) returns WebSocketError? {
         return self.conn.close(statusCode, reason, timeoutInSeconds);
     }
@@ -86,7 +86,7 @@ public client class WebSocketCaller {
     #
     # + key - The key, which identifies the attribute
     # + value - The value of the attribute
-    public function setAttribute(string key, any value) {
+    public isolated function setAttribute(string key, any value) {
         self.attributes[key] = value;
     }
 
@@ -94,7 +94,7 @@ public client class WebSocketCaller {
     #
     # + key - The key to identify the attribute
     # + return - The attribute related to the given key or `nil`
-    public function getAttribute(string key) returns any {
+    public isolated function getAttribute(string key) returns any {
         return self.attributes[key];
     }
 
@@ -102,35 +102,35 @@ public client class WebSocketCaller {
     #
     # + key - The key to identify the attribute
     # + return - The attribute related to the given key or `nil`
-    public function removeAttribute(string key) returns any {
+    public isolated function removeAttribute(string key) returns any {
         return self.attributes.remove(key);
     }
 
     # Gives the connection id associated with this connection.
     #
     # + return - The unique ID associated with the connection
-    public function getConnectionId() returns string {
+    public isolated function getConnectionId() returns string {
         return self.id;
     }
 
     # Gives the subprotocol if any that is negotiated with the client.
     #
     # + return - The subprotocol if any negotiated with the client or `nil`
-    public function getNegotiatedSubProtocol() returns string? {
+    public isolated function getNegotiatedSubProtocol() returns string? {
         return self.negotiatedSubProtocol;
     }
 
     # Gives the secured status of the connection.
     #
     # + return - `true` if the connection is secure
-    public function isSecure() returns boolean {
+    public isolated function isSecure() returns boolean {
         return self.secure;
     }
 
     # Gives the open or closed status of the connection.
     #
     # + return - `true` if the connection is open
-    public function isOpen() returns boolean {
+    public isolated function isOpen() returns boolean {
         return self.open;
     }
 }

--- a/http-ballerina/src/http/websocket/websocket_client.bal
+++ b/http-ballerina/src/http/websocket/websocket_client.bal
@@ -36,7 +36,7 @@ public client class WebSocketClient {
     #
     # + url - URL of the target service
     # + config - The configurations to be used when initializing the client
-    public function init(string url, WebSocketClientConfiguration? config = ()) {
+    public isolated function init(string url, WebSocketClientConfiguration? config = ()) {
         self.url = url;
         if (config is WebSocketClientConfiguration) {
             addCookies(config);
@@ -46,7 +46,7 @@ public client class WebSocketClient {
     }
 
     # Initializes the endpoint.
-    public function initEndpoint() {
+    public isolated function initEndpoint() {
         var retryConfig = self.config?.retryConfig;
         if (retryConfig is WebSocketRetryConfig) {
             return externRetryInitEndpoint(self);
@@ -61,7 +61,7 @@ public client class WebSocketClient {
     # + data - Data to be sent. If it is a byte[], it is converted to a UTF-8 string for sending
     # + finalFrame - Set to `true` if this is a final frame of a (long) message
     # + return  - An `error` if an error occurs when sending
-    public remote function pushText(string|json|xml|boolean|int|float|byte|byte[] data,
+    public remote isolated function pushText(string|json|xml|boolean|int|float|byte|byte[] data,
     boolean finalFrame = true) returns WebSocketError? {
         return self.conn.pushText(data, finalFrame);
     }
@@ -72,7 +72,7 @@ public client class WebSocketClient {
     # + data - Binary data to be sent
     # + finalFrame - Set to `true` if this is a final frame of a (long) message
     # + return  - An `error` if an error occurs when sending
-    public remote function pushBinary(byte[] data, boolean finalFrame = true) returns WebSocketError? {
+    public remote isolated function pushBinary(byte[] data, boolean finalFrame = true) returns WebSocketError? {
         return self.conn.pushBinary(data, finalFrame);
     }
 
@@ -80,7 +80,7 @@ public client class WebSocketClient {
     #
     # + data - Binary data to be sent
     # + return  - An `error` if an error occurs when sending
-    public remote function ping(byte[] data) returns WebSocketError? {
+    public remote isolated function ping(byte[] data) returns WebSocketError? {
         return self.conn.ping(data);
     }
 
@@ -89,7 +89,7 @@ public client class WebSocketClient {
     #
     # + data - Binary data to be sent
     # + return  - An `error` if an error occurs when sending
-    public remote function pong(byte[] data) returns WebSocketError? {
+    public remote isolated function pong(byte[] data) returns WebSocketError? {
         return self.conn.pong(data);
     }
 
@@ -103,7 +103,7 @@ public client class WebSocketClient {
     #                   waits until a close frame is received. If the WebSocket frame is received from the remote
     #                   endpoint within the waiting period, the connection is terminated immediately.
     # + return - An `error` if an error occurs while closing the WebSocket connection
-    public remote function close(int? statusCode = 1000, string? reason = (),
+    public remote isolated function close(int? statusCode = 1000, string? reason = (),
         int timeoutInSeconds = 60) returns WebSocketError? {
         return self.conn.close(statusCode, reason, timeoutInSeconds);
     }
@@ -112,7 +112,7 @@ public client class WebSocketClient {
     # WebSocketListener, it can be called only in the `upgrade` or `onOpen` resources.
     #
     # + return - an `error` if an error occurs while checking the connection state
-    public remote function ready() returns WebSocketError? {
+    public remote isolated function ready() returns WebSocketError? {
         return self.conn.ready();
     }
 
@@ -120,7 +120,7 @@ public client class WebSocketClient {
     #
     # + key - The key, which identifies the attribute
     # + value - The value of the attribute
-    public function setAttribute(string key, any value) {
+    public isolated function setAttribute(string key, any value) {
         self.attributes[key] = value;
     }
 
@@ -128,7 +128,7 @@ public client class WebSocketClient {
     #
     # + key - The key to identify the attribute
     # + return - The attribute related to the given key or `nil`
-    public function getAttribute(string key) returns any {
+    public isolated function getAttribute(string key) returns any {
         return self.attributes[key];
     }
 
@@ -136,42 +136,42 @@ public client class WebSocketClient {
     #
     # + key - The key to identify the attribute
     # + return - The attribute related to the given key or `nil`
-    public function removeAttribute(string key) returns any {
+    public isolated function removeAttribute(string key) returns any {
         return self.attributes.remove(key);
     }
 
     # Gives the connection id associated with this connection.
     #
     # + return - The unique ID associated with the connection
-    public function getConnectionId() returns string {
+    public isolated function getConnectionId() returns string {
         return self.id;
     }
 
     # Gives the subprotocol if any that is negotiated with the client.
     #
     # + return - The subprotocol if any negotiated with the client or `nil`
-    public function getNegotiatedSubProtocol() returns string? {
+    public isolated function getNegotiatedSubProtocol() returns string? {
         return self.negotiatedSubProtocol;
     }
 
     # Gives the secured status of the connection.
     #
     # + return - `true` if the connection is secure
-    public function isSecure() returns boolean {
+    public isolated function isSecure() returns boolean {
         return self.secure;
     }
 
     # Gives the open or closed status of the connection.
     #
     # + return - `true` if the connection is open
-    public function isOpen() returns boolean {
+    public isolated function isOpen() returns boolean {
         return self.open;
     }
 
     # Gives the HTTP response if any received for the client handshake request.
     #
     # + return - The HTTP response received from the client handshake request
-    public function getHttpResponse() returns Response? {
+    public isolated function getHttpResponse() returns Response? {
         return self.response;
     }    
 }
@@ -233,11 +233,11 @@ public type CommonWebSocketClientConfiguration record {|
 # Adds cookies to the custom header.
 #
 # + config - Represents the cookies to be added
-public function addCookies(WebSocketClientConfiguration|WebSocketFailoverClientConfiguration config) {
+public isolated function addCookies(WebSocketClientConfiguration|WebSocketFailoverClientConfiguration config) {
     string cookieHeader = "";
     var cookiesToAdd = config["cookies"];
     if (cookiesToAdd is Cookie[]) {
-        Cookie[] sortedCookies = cookiesToAdd.sort(array:ASCENDING, function(Cookie c) returns int {
+        Cookie[] sortedCookies = cookiesToAdd.sort(array:ASCENDING, isolated function(Cookie c) returns int {
             var cookiePath = c.path;
             int l = 0;
             if (cookiePath is string) {
@@ -276,12 +276,12 @@ public type WebSocketRetryConfig record {|
     int maxWaitIntervalInMillis = 30000;
 |};
 
-function externWSInitEndpoint(WebSocketClient wsClient) = @java:Method {
+isolated function externWSInitEndpoint(WebSocketClient wsClient) = @java:Method {
     'class: "org.ballerinalang.net.http.websocket.client.InitEndpoint",
     name: "initEndpoint"
 } external;
 
-function externRetryInitEndpoint(WebSocketClient wsClient) = @java:Method {
+isolated function externRetryInitEndpoint(WebSocketClient wsClient) = @java:Method {
     'class: "org.ballerinalang.net.http.websocket.client.RetryInitEndpoint",
     name: "initEndpoint"
 } external;

--- a/http-ballerina/src/http/websocket/websocket_connector.bal
+++ b/http-ballerina/src/http/websocket/websocket_connector.bal
@@ -27,7 +27,7 @@ class WebSocketConnector {
     # + data - Data to be sent. If it is a byte[], it is converted to a UTF-8 string for sending
     # + finalFrame - Set to `true` if this is a final frame of a (long) message
     # + return  - An `error` if an error occurs when sending
-    public function pushText(string|json|xml|boolean|int|float|byte|byte[] data, boolean finalFrame)
+    public isolated function pushText(string|json|xml|boolean|int|float|byte|byte[] data, boolean finalFrame)
     returns WebSocketError? {
         string text = "";
         if (data is byte[]) {
@@ -51,7 +51,7 @@ class WebSocketConnector {
     # + data - Binary data to be sent
     # + finalFrame - Set to `true` if this is a final frame of a (long) message
     # + return  - An `error` if an error occurs when sending
-    public function pushBinary(byte[] data, boolean finalFrame) returns WebSocketError? {
+    public isolated function pushBinary(byte[] data, boolean finalFrame) returns WebSocketError? {
         return externPushBinary(self, data, finalFrame);
     }
 
@@ -59,7 +59,7 @@ class WebSocketConnector {
     #
     # + data - Binary data to be sent
     # + return  - An `error` if an error occurs when sending
-    public function ping(byte[] data) returns WebSocketError? {
+    public isolated function ping(byte[] data) returns WebSocketError? {
         return externPing(self, data);
     }
 
@@ -68,7 +68,7 @@ class WebSocketConnector {
     #
     # + data - Binary data to be sent
     # + return  - An `error` if an error occurs when sending
-    public function pong(byte[] data) returns WebSocketError? {
+    public isolated function pong(byte[] data) returns WebSocketError? {
         return externPong(self, data);
     }
 
@@ -76,7 +76,7 @@ class WebSocketConnector {
     # WebSocketListener can be called only in the `upgrade` or `onOpen` resources.
     #
     # + return - An `error` if an error occurs when sending
-    public function ready() returns WebSocketError? {
+    public isolated function ready() returns WebSocketError? {
         return externReady(self);
     }
 
@@ -90,7 +90,7 @@ class WebSocketConnector {
     #                   until a close frame is received. If WebSocket frame is received from the remote endpoint
     #                   within the waiting period, the connection is terminated immediately.
     # + return - An `error` if an error occurs when sending
-    public function close(int? statusCode = 1000, string? reason = (), int timeoutInSecs = 60) returns WebSocketError? {
+    public isolated function close(int? statusCode = 1000, string? reason = (), int timeoutInSecs = 60) returns WebSocketError? {
         if (statusCode is int) {
             if (statusCode <= 999 || statusCode >= 1004 && statusCode <= 1006 || statusCode >= 1012 &&
                 statusCode <= 2999 || statusCode > 4999) {
@@ -104,36 +104,36 @@ class WebSocketConnector {
     }
 }
 
-function externPushText(WebSocketConnector wsConnector, string text, boolean finalFrame) returns WebSocketError? =
+isolated function externPushText(WebSocketConnector wsConnector, string text, boolean finalFrame) returns WebSocketError? =
 @java:Method {
     'class: "org.ballerinalang.net.http.actions.websocketconnector.WebSocketConnector"
 } external;
 
-function externPushBinary(WebSocketConnector wsConnector, byte[] data, boolean finalFrame) returns WebSocketError? =
+isolated function externPushBinary(WebSocketConnector wsConnector, byte[] data, boolean finalFrame) returns WebSocketError? =
 @java:Method {
     'class: "org.ballerinalang.net.http.actions.websocketconnector.WebSocketConnector",
     name: "pushBinary"
 } external;
 
-function externPing(WebSocketConnector wsConnector, byte[] data) returns WebSocketError? =
+isolated function externPing(WebSocketConnector wsConnector, byte[] data) returns WebSocketError? =
 @java:Method {
     'class: "org.ballerinalang.net.http.actions.websocketconnector.WebSocketConnector",
     name: "ping"
 } external;
 
-function externPong(WebSocketConnector wsConnector, byte[] data) returns WebSocketError? =
+isolated function externPong(WebSocketConnector wsConnector, byte[] data) returns WebSocketError? =
 @java:Method {
     'class: "org.ballerinalang.net.http.actions.websocketconnector.WebSocketConnector",
     name: "pong"
 } external;
 
-function externClose(WebSocketConnector wsConnector, int statusCode, string reason, int timeoutInSecs)
+isolated function externClose(WebSocketConnector wsConnector, int statusCode, string reason, int timeoutInSecs)
                      returns WebSocketError? =
 @java:Method {
     'class: "org.ballerinalang.net.http.actions.websocketconnector.Close"
 } external;
 
-function externReady(WebSocketConnector wsConnector) returns WebSocketError? = @java:Method {
+isolated function externReady(WebSocketConnector wsConnector) returns WebSocketError? = @java:Method {
     'class: "org.ballerinalang.net.http.actions.websocketconnector.Ready",
     name: "ready"
 } external;

--- a/http-ballerina/src/http/websocket/websocket_failover_client.bal
+++ b/http-ballerina/src/http/websocket/websocket_failover_client.bal
@@ -33,7 +33,7 @@ public client class WebSocketFailoverClient {
     # Initializes the   failover client, which provides failover capabilities to a WebSocket client endpoint.
     #
     # + config - The `WebSocketFailoverClientConfiguration` of the endpoint
-    public function init(WebSocketFailoverClientConfiguration config) {
+    public isolated function init(WebSocketFailoverClientConfiguration config) {
         self.url = config.targetUrls[0];
         addCookies(config);
         self.config = config;
@@ -46,7 +46,7 @@ public client class WebSocketFailoverClient {
     # + data - Data to be sent. If it is a byte[], it is converted to a UTF-8 string for sending
     # + finalFrame - Set to `true` if this is a final frame of a (long) message
     # + return  - An `error` if an error occurs when sending
-    public remote function pushText(string|json|xml|boolean|int|float|byte|byte[] data,
+    public remote isolated function pushText(string|json|xml|boolean|int|float|byte|byte[] data,
     boolean finalFrame = true) returns WebSocketError? {
         return self.conn.pushText(data, finalFrame);
     }
@@ -57,7 +57,7 @@ public client class WebSocketFailoverClient {
     # + data - Binary data to be sent
     # + finalFrame - Set to `true` if this is a final frame of a (long) message
     # + return  - An `error` if an error occurs when sending
-    public remote function pushBinary(byte[] data, boolean finalFrame = true) returns WebSocketError? {
+    public remote isolated function pushBinary(byte[] data, boolean finalFrame = true) returns WebSocketError? {
         return self.conn.pushBinary(data, finalFrame);
     }
 
@@ -65,7 +65,7 @@ public client class WebSocketFailoverClient {
     #
     # + data - Binary data to be sent
     # + return  - An `error` if an error occurs when sending
-    public remote function ping(byte[] data) returns WebSocketError? {
+    public remote isolated function ping(byte[] data) returns WebSocketError? {
         return self.conn.ping(data);
     }
 
@@ -74,7 +74,7 @@ public client class WebSocketFailoverClient {
     #
     # + data - Binary data to be sent
     # + return  - An `error` if an error occurs when sending
-    public remote function pong(byte[] data) returns WebSocketError? {
+    public remote isolated function pong(byte[] data) returns WebSocketError? {
         return self.conn.pong(data);
     }
 
@@ -88,7 +88,7 @@ public client class WebSocketFailoverClient {
     #                   waits until a close frame is received. If the WebSocket frame is received from the remote
     #                   endpoint within the waiting period, the connection is terminated immediately.
     # + return - An `error` if an error occurs while closing the webSocket connection
-    public remote function close(int? statusCode = 1000, string? reason = (),
+    public remote isolated function close(int? statusCode = 1000, string? reason = (),
     int timeoutInSeconds = 60) returns WebSocketError? {
         return self.conn.close(statusCode, reason, timeoutInSeconds);
     }
@@ -97,7 +97,7 @@ public client class WebSocketFailoverClient {
     # WebSocketListener, it can be called only in the `upgrade` or `onOpen` resources.
     #
     # + return - An `error` if an error occurs while checking the connection state
-    public remote function ready() returns WebSocketError? {
+    public remote isolated function ready() returns WebSocketError? {
         return self.conn.ready();
     }
 
@@ -105,7 +105,7 @@ public client class WebSocketFailoverClient {
     #
     # + key - The key to identify the attribute
     # + value - The value of the attribute
-    public function setAttribute(string key, any value) {
+    public isolated function setAttribute(string key, any value) {
         self.attributes[key] = value;
     }
 
@@ -113,7 +113,7 @@ public client class WebSocketFailoverClient {
     #
     # + key - The key to identify the attribute
     # + return - The attribute related to the given key or `nil`
-    public function getAttribute(string key) returns any {
+    public isolated function getAttribute(string key) returns any {
         return self.attributes[key];
     }
 
@@ -121,42 +121,42 @@ public client class WebSocketFailoverClient {
     #
     # + key - The key to identify the attribute
     # + return - The attribute related to the given key or `nil`
-    public function removeAttribute(string key) returns any {
+    public isolated function removeAttribute(string key) returns any {
         return self.attributes.remove(key);
     }
 
     # Gives the connection ID associated with this connection.
     #
     # + return - The unique ID associated with the connection
-    public function getConnectionId() returns string {
+    public isolated function getConnectionId() returns string {
         return self.id;
     }
 
     # Gives the subprotocol if any that is negotiated with the client.
     #
     # + return - Returns the subprotocol if any that is negotiated with the client or `nil`
-    public function getNegotiatedSubProtocol() returns string? {
+    public isolated function getNegotiatedSubProtocol() returns string? {
         return self.negotiatedSubProtocol;
     }
 
     # Gives the secured status of the connection.
     #
     # + return - Returns `true` if the connection is secure
-    public function isSecure() returns boolean {
+    public isolated function isSecure() returns boolean {
         return self.secure;
     }
 
     # Gives the open or closed status of the connection.
     #
     # + return - Returns `true` if the connection is open
-    public function isOpen() returns boolean {
+    public isolated function isOpen() returns boolean {
         return self.open;
     }
 
     # Gives any HTTP response of     the client handshake request if received.
     #
     # + return - Returns the HTTP response received for the client handshake request
-    public function getHttpResponse() returns Response? {
+    public isolated function getHttpResponse() returns Response? {
         return self.response;
     }
 }
@@ -183,7 +183,7 @@ public type WebSocketFailoverClientConfiguration record {|
     int failoverIntervalInMillis = 1000;
 |};
 
-function externFailoverInit(WebSocketFailoverClient wsClient) = @java:Method {
+isolated function externFailoverInit(WebSocketFailoverClient wsClient) = @java:Method {
     'class: "org.ballerinalang.net.http.websocket.client.FailoverInitEndpoint",
     name: "initEndpoint"
 } external;

--- a/old-tests/test/java/org/ballerinalang/stdlib/services/basics/SignatureTest.java
+++ b/old-tests/test/java/org/ballerinalang/stdlib/services/basics/SignatureTest.java
@@ -41,7 +41,7 @@ public class SignatureTest {
                 "test-src/services/signature/no-request-param.bal").getPath()).getAbsolutePath());
 
         Assert.assertEquals(compileResult.getErrorCount(), 1);
-        Assert.assertEquals(compileResult.getDiagnostics().clone()[0].getMessage(),
+        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().clone()[0].getMessage(),
                 "resource signature parameter count should be >= 2");
     }
 
@@ -51,7 +51,7 @@ public class SignatureTest {
                 "test-src/services/signature/no-con-param.bal").getPath()).getAbsolutePath());
 
         Assert.assertEquals(compileResult.getErrorCount(), 1);
-        Assert.assertEquals(compileResult.getDiagnostics().clone()[0].getMessage(),
+        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().clone()[0].getMessage(),
                 "first parameter should be of type ballerina/http:1.0.0:Caller");
     }
 
@@ -61,7 +61,7 @@ public class SignatureTest {
                 "test-src/services/signature/with-res-param.bal").getPath()).getAbsolutePath());
 
         Assert.assertEquals(compileResult.getErrorCount(), 1);
-        Assert.assertEquals(compileResult.getDiagnostics().clone()[0].getMessage(),
+        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().clone()[0].getMessage(),
                 "second parameter should be of type ballerina/http:1.0.0:Request");
     }
 
@@ -71,7 +71,7 @@ public class SignatureTest {
                 "test-src/services/signature/int-param.bal").getPath()).getAbsolutePath());
 
         Assert.assertEquals(compileResult.getErrorCount(), 1);
-        Assert.assertEquals(compileResult.getDiagnostics().clone()[0].getMessage(),
+        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().clone()[0].getMessage(),
                 "second parameter should be of type ballerina/http:1.0.0:Request");
     }
 
@@ -93,7 +93,7 @@ public class SignatureTest {
     public void testSignatureWithMismatchedBodyParam() {
         CompileResult compileResult = BCompileUtil.compile(new File(getClass().getClassLoader().getResource(
                 "test-src/services/signature/mismatched-body-param.bal").getPath()).getAbsolutePath());
-        Diagnostic[] diag = compileResult.getDiagnostics();
+        Diagnostic[] diag = compileResult.getErrorAndWarnDiagnostics();
         Assert.assertEquals(diag.length, 2);
         Assert.assertEquals(diag[0].getMessage(), "invalid resource parameter(s): cannot specify > 2 parameters " +
                 "without specifying path config and/or body config in the resource annotation");
@@ -107,7 +107,7 @@ public class SignatureTest {
                 "test-src/services/signature/invalid-return.bal").getPath()).getAbsolutePath());
 
         Assert.assertEquals(compileResult.getErrorCount(), 1);
-        Assert.assertEquals(compileResult.getDiagnostics().clone()[0].getMessage(), "invalid resource function return" +
+        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().clone()[0].getMessage(), "invalid resource function return" +
                 " type 'int', expected a subtype of 'error?' containing '()'");
     }
 

--- a/old-tests/test/java/org/ballerinalang/stdlib/websocket/WebSocketCompilationTest.java
+++ b/old-tests/test/java/org/ballerinalang/stdlib/websocket/WebSocketCompilationTest.java
@@ -196,6 +196,6 @@ public class WebSocketCompilationTest {
     }
 
     private void assertExpectedDiagnosticsLength(CompileResult compileResult, int expectedLength) {
-        Assert.assertEquals(compileResult.getDiagnostics().length, expectedLength);
+        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, expectedLength);
     }
 }


### PR DESCRIPTION
## Related Issues
> [Make HTTP1/1 Client remote functions isolated](https://github.com/ballerina-platform/module-ballerina-http/issues/52) (Due to cookie implementation which had used few non-isolated IO operations)
Fixes https://github.com/ballerina-platform/module-ballerina-http/issues/51