### PR TITLE
Migrate NonBlockingCallback to BalEnv

### DIFF
--- a/http-ballerina/src/http/http_connection.bal
+++ b/http-ballerina/src/http/http_connection.bal
@@ -300,6 +300,5 @@ isolated function externAcceptWebSocketUpgrade(Caller caller, map<string> header
 isolated function externCancelWebSocketUpgrade(Caller caller, int status, string reason) returns WebSocketError? =
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.connection.CancelWebSocketUpgrade",
-    name: "cancelWebSocketUpgrade",
-    paramTypes: ["org.ballerinalang.jvm.values.ObjectValue", "long", "org.ballerinalang.jvm.api.values.BString"]
+    name: "cancelWebSocketUpgrade"
 } external;

--- a/http-native/src/main/java/org/ballerinalang/net/http/DataContext.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/DataContext.java
@@ -19,12 +19,12 @@
 package org.ballerinalang.net.http;
 
 import org.ballerinalang.jvm.api.BValueCreator;
+import org.ballerinalang.jvm.api.BalFuture;
 import org.ballerinalang.jvm.api.values.BError;
 import org.ballerinalang.jvm.api.values.BMap;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.api.values.BString;
 import org.ballerinalang.jvm.scheduling.Strand;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.wso2.transport.http.netty.contract.HttpClientConnector;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 
@@ -38,21 +38,21 @@ public class DataContext {
     private Strand strand;
     private HttpClientConnector clientConnector;
     private BObject requestObj;
-    private NonBlockingCallback callback;
+    private BalFuture balFuture;
     private HttpCarbonMessage correlatedMessage;
 
-    public DataContext(Strand strand, HttpClientConnector clientConnector, NonBlockingCallback callback,
+    public DataContext(Strand strand, HttpClientConnector clientConnector, BalFuture balFuture,
                        BObject requestObj, HttpCarbonMessage outboundRequestMsg) {
         this.strand = strand;
-        this.callback = callback;
+        this.balFuture = balFuture;
         this.clientConnector = clientConnector;
         this.requestObj = requestObj;
         this.correlatedMessage = outboundRequestMsg;
     }
 
-    public DataContext(Strand strand, NonBlockingCallback callback, HttpCarbonMessage inboundRequestMsg) {
+    public DataContext(Strand strand, BalFuture balFuture, HttpCarbonMessage inboundRequestMsg) {
         this.strand = strand;
-        this.callback = callback;
+        this.balFuture = balFuture;
         this.clientConnector = null;
         this.requestObj = null;
         this.correlatedMessage = inboundRequestMsg;
@@ -61,20 +61,18 @@ public class DataContext {
     public void notifyInboundResponseStatus(BObject inboundResponse, BError httpConnectorError) {
         //Make the request associate with this response consumable again so that it can be reused.
         if (inboundResponse != null) {
-            getCallback().setReturnValues(inboundResponse);
+            getFuture().complete(inboundResponse);
         } else if (httpConnectorError != null) {
-            getCallback().setReturnValues(httpConnectorError);
+            getFuture().complete(httpConnectorError);
         } else {
             BMap<BString, Object> err = BValueCreator.createRecordValue(BALLERINA_BUILTIN_PKG_ID,
                                                                               STRUCT_GENERIC_ERROR);
-            getCallback().setReturnValues(err);
+            getFuture().complete(err);
         }
-        getCallback().notifySuccess();
     }
 
     public void notifyOutboundResponseStatus(BError httpConnectorError) {
-        getCallback().setReturnValues(httpConnectorError);
-        getCallback().notifySuccess();
+        getFuture().complete(httpConnectorError);
     }
 
     public HttpCarbonMessage getOutboundRequest() {
@@ -93,7 +91,7 @@ public class DataContext {
         return strand;
     }
 
-    public NonBlockingCallback getCallback() {
-        return callback;
+    public BalFuture getFuture() {
+        return balFuture;
     }
 }

--- a/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/Execute.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/Execute.java
@@ -16,12 +16,12 @@
 
 package org.ballerinalang.net.http.actions.httpclient;
 
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BMap;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.api.values.BString;
 import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
@@ -38,14 +38,14 @@ import static org.ballerinalang.net.http.HttpConstants.CLIENT_ENDPOINT_SERVICE_U
  */
 public class Execute extends AbstractHTTPAction {
     @SuppressWarnings("unchecked")
-    public static Object execute(BObject httpClient, BString verb, BString path, BObject requestObj) {
+    public static Object execute(BalEnv env, BObject httpClient, BString verb, BString path, BObject requestObj) {
         String url = httpClient.getStringValue(CLIENT_ENDPOINT_SERVICE_URI).getValue();
         Strand strand = Scheduler.getStrand();
         BMap<BString, Object> config = (BMap<BString, Object>) httpClient.get(CLIENT_ENDPOINT_CONFIG);
         HttpClientConnector clientConnector = (HttpClientConnector) httpClient.getNativeData(HttpConstants.CLIENT);
         HttpCarbonMessage outboundRequestMsg = createOutboundRequestMsg(strand, config, url, verb.getValue(),
                                                                         path.getValue(), requestObj);
-        DataContext dataContext = new DataContext(strand, clientConnector, new NonBlockingCallback(strand), requestObj,
+        DataContext dataContext = new DataContext(strand, clientConnector, env.markAsync(), requestObj,
                                                   outboundRequestMsg);
         executeNonBlockingAction(dataContext, false);
         return null;

--- a/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/Forward.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/Forward.java
@@ -18,12 +18,12 @@
 
 package org.ballerinalang.net.http.actions.httpclient;
 
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.api.values.BString;
 import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.util.exceptions.BallerinaException;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
@@ -40,12 +40,12 @@ import static org.ballerinalang.net.http.HttpUtil.checkRequestBodySizeHeadersAva
  */
 public class Forward extends AbstractHTTPAction {
     @SuppressWarnings("unchecked")
-    public static Object forward(BObject httpClient, BString path, BObject requestObj) {
+    public static Object forward(BalEnv env, BObject httpClient, BString path, BObject requestObj) {
         String url = httpClient.getStringValue(CLIENT_ENDPOINT_SERVICE_URI).getValue();
         Strand strand = Scheduler.getStrand();
         HttpCarbonMessage outboundRequestMsg = createOutboundRequestMsg(strand, url, path.getValue(), requestObj);
         HttpClientConnector clientConnector = (HttpClientConnector) httpClient.getNativeData(HttpConstants.CLIENT);
-        DataContext dataContext = new DataContext(strand, clientConnector, new NonBlockingCallback(strand), requestObj,
+        DataContext dataContext = new DataContext(strand, clientConnector, env.markAsync(), requestObj,
                                                   outboundRequestMsg);
         executeNonBlockingAction(dataContext, false);
         return null;

--- a/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetNextPromise.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetNextPromise.java
@@ -18,11 +18,11 @@ package org.ballerinalang.net.http.actions.httpclient;
 
 import org.ballerinalang.jvm.api.BStringUtils;
 import org.ballerinalang.jvm.api.BValueCreator;
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.util.exceptions.BallerinaException;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
@@ -37,10 +37,10 @@ import org.wso2.transport.http.netty.message.ResponseHandle;
  */
 public class GetNextPromise extends AbstractHTTPAction {
 
-    public static Object getNextPromise(BObject clientObj, BObject handleObj) {
+    public static Object getNextPromise(BalEnv env, BObject clientObj, BObject handleObj) {
         Strand strand = Scheduler.getStrand();
         HttpClientConnector clientConnector = (HttpClientConnector) clientObj.getNativeData(HttpConstants.CLIENT);
-        DataContext dataContext = new DataContext(strand, clientConnector, new NonBlockingCallback(strand), handleObj,
+        DataContext dataContext = new DataContext(strand, clientConnector, env.markAsync(), handleObj,
                                                   null);
         ResponseHandle responseHandle = (ResponseHandle) handleObj.getNativeData(HttpConstants.TRANSPORT_HANDLE);
         if (responseHandle == null) {

--- a/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetPromisedResponse.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetPromisedResponse.java
@@ -16,12 +16,12 @@
 
 package org.ballerinalang.net.http.actions.httpclient;
 
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BError;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.util.exceptions.BallerinaException;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
@@ -36,10 +36,10 @@ import org.wso2.transport.http.netty.message.HttpCarbonMessage;
  */
 public class GetPromisedResponse extends AbstractHTTPAction {
 
-    public static Object getPromisedResponse(BObject clientObj, BObject pushPromiseObj) {
+    public static Object getPromisedResponse(BalEnv env, BObject clientObj, BObject pushPromiseObj) {
         Strand strand = Scheduler.getStrand();
         HttpClientConnector clientConnector = (HttpClientConnector) clientObj.getNativeData(HttpConstants.CLIENT);
-        DataContext dataContext = new DataContext(strand, clientConnector, new NonBlockingCallback(strand),
+        DataContext dataContext = new DataContext(strand, clientConnector, env.markAsync(),
                                                   pushPromiseObj, null);
         Http2PushPromise http2PushPromise = HttpUtil.getPushPromise(pushPromiseObj, null);
         if (http2PushPromise == null) {

--- a/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetResponse.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/GetResponse.java
@@ -16,12 +16,12 @@
 
 package org.ballerinalang.net.http.actions.httpclient;
 
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BError;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.util.exceptions.BallerinaException;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
@@ -35,10 +35,10 @@ import org.wso2.transport.http.netty.message.ResponseHandle;
  */
 public class GetResponse extends AbstractHTTPAction {
 
-    public static Object getResponse(BObject clientObj, BObject handleObj) {
+    public static Object getResponse(BalEnv env, BObject clientObj, BObject handleObj) {
         Strand strand = Scheduler.getStrand();
         HttpClientConnector clientConnector = (HttpClientConnector) clientObj.getNativeData(HttpConstants.CLIENT);
-        DataContext dataContext = new DataContext(strand, clientConnector, new NonBlockingCallback(strand), handleObj,
+        DataContext dataContext = new DataContext(strand, clientConnector, env.markAsync(), handleObj,
                                                   null);
         ResponseHandle responseHandle = (ResponseHandle) handleObj.getNativeData(HttpConstants.TRANSPORT_HANDLE);
         if (responseHandle == null) {

--- a/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/HasPromise.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/HasPromise.java
@@ -16,11 +16,12 @@
 
 package org.ballerinalang.net.http.actions.httpclient;
 
+import org.ballerinalang.jvm.api.BalEnv;
+import org.ballerinalang.jvm.api.BalFuture;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.util.exceptions.BallerinaException;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.net.http.HttpConstants;
 import org.wso2.transport.http.netty.contract.HttpClientConnector;
 import org.wso2.transport.http.netty.contract.HttpClientConnectorListener;
@@ -31,7 +32,7 @@ import org.wso2.transport.http.netty.message.ResponseHandle;
  */
 public class HasPromise extends AbstractHTTPAction {
 
-    public static boolean hasPromise(BObject clientObj, BObject handleObj) {
+    public static boolean hasPromise(BalEnv env, BObject clientObj, BObject handleObj) {
         Strand strand = Scheduler.getStrand();
         ResponseHandle responseHandle = (ResponseHandle) handleObj.getNativeData(HttpConstants.TRANSPORT_HANDLE);
         if (responseHandle == null) {
@@ -39,22 +40,21 @@ public class HasPromise extends AbstractHTTPAction {
         }
         HttpClientConnector clientConnector = (HttpClientConnector) clientObj.getNativeData(HttpConstants.CLIENT);
         clientConnector.hasPushPromise(responseHandle).
-                setPromiseAvailabilityListener(new PromiseAvailabilityCheckListener(new NonBlockingCallback(strand)));
+                setPromiseAvailabilityListener(new PromiseAvailabilityCheckListener(env.markAsync()));
         return false;
     }
 
     private static class PromiseAvailabilityCheckListener implements HttpClientConnectorListener {
 
-        private NonBlockingCallback callback;
+        private BalFuture balFuture;
 
-        PromiseAvailabilityCheckListener(NonBlockingCallback callback) {
-            this.callback = callback;
+        PromiseAvailabilityCheckListener(BalFuture balFuture) {
+            this.balFuture = balFuture;
         }
 
         @Override
         public void onPushPromiseAvailability(boolean isPromiseAvailable) {
-            callback.setReturnValues(isPromiseAvailable);
-            callback.notifySuccess();
+            balFuture.complete(isPromiseAvailable);
         }
     }
 }

--- a/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/HttpClientAction.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/HttpClientAction.java
@@ -18,13 +18,13 @@
 
 package org.ballerinalang.net.http.actions.httpclient;
 
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BMap;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.api.values.BString;
 import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.util.exceptions.BallerinaException;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
@@ -42,7 +42,7 @@ import static org.ballerinalang.net.http.HttpConstants.CLIENT_ENDPOINT_SERVICE_U
  */
 public class HttpClientAction extends AbstractHTTPAction {
 
-    public static Object executeClientAction(BObject httpClient, BString path,
+    public static Object executeClientAction(BalEnv env, BObject httpClient, BString path,
                                              BObject requestObj, BString httpMethod) {
         Strand strand = Scheduler.getStrand();
         String url = httpClient.getStringValue(CLIENT_ENDPOINT_SERVICE_URI).getValue();
@@ -51,7 +51,7 @@ public class HttpClientAction extends AbstractHTTPAction {
         HttpCarbonMessage outboundRequestMsg = createOutboundRequestMsg(strand, url, config, path.getValue().
                 replaceAll(HttpConstants.REGEX, HttpConstants.SINGLE_SLASH), requestObj);
         outboundRequestMsg.setHttpMethod(httpMethod.getValue());
-        DataContext dataContext = new DataContext(strand, clientConnector, new NonBlockingCallback(strand), requestObj,
+        DataContext dataContext = new DataContext(strand, clientConnector, env.markAsync(), requestObj,
                                                   outboundRequestMsg);
         executeNonBlockingAction(dataContext, false);
         return null;

--- a/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/Submit.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/Submit.java
@@ -16,12 +16,12 @@
 
 package org.ballerinalang.net.http.actions.httpclient;
 
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BMap;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.api.values.BString;
 import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
 import org.wso2.transport.http.netty.contract.HttpClientConnector;
@@ -35,7 +35,7 @@ import static org.ballerinalang.net.http.HttpConstants.CLIENT_ENDPOINT_SERVICE_U
  */
 public class Submit extends Execute {
     @SuppressWarnings("unchecked")
-    public static Object submit(BObject httpClient, BString httpVerb, BString path, BObject requestObj) {
+    public static Object submit(BalEnv env, BObject httpClient, BString httpVerb, BString path, BObject requestObj) {
         Strand strand = Scheduler.getStrand();
         String url = httpClient.getStringValue(CLIENT_ENDPOINT_SERVICE_URI).getValue();
         BMap<BString, Object> config = (BMap<BString, Object>) httpClient.get(CLIENT_ENDPOINT_CONFIG);
@@ -43,7 +43,7 @@ public class Submit extends Execute {
         HttpCarbonMessage outboundRequestMsg = createOutboundRequestMsg(strand, url, config, path.getValue(),
                                                                         requestObj);
         outboundRequestMsg.setHttpMethod(httpVerb.getValue());
-        DataContext dataContext = new DataContext(strand, clientConnector, new NonBlockingCallback(strand), requestObj,
+        DataContext dataContext = new DataContext(strand, clientConnector, env.markAsync(), requestObj,
                                                   outboundRequestMsg);
         executeNonBlockingAction(dataContext, true);
         return null;

--- a/http-native/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/Close.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/Close.java
@@ -17,11 +17,12 @@
 package org.ballerinalang.net.http.actions.websocketconnector;
 
 import io.netty.channel.ChannelFuture;
+import org.ballerinalang.jvm.api.BalEnv;
+import org.ballerinalang.jvm.api.BalFuture;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.api.values.BString;
 import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.net.http.websocket.WebSocketConstants;
 import org.ballerinalang.net.http.websocket.WebSocketUtil;
 import org.ballerinalang.net.http.websocket.observability.WebSocketObservabilityConstants;
@@ -34,30 +35,27 @@ import org.wso2.transport.http.netty.contract.websocket.WebSocketConnection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.ballerinalang.net.http.websocket.WebSocketConstants.ErrorCode;
-
 /**
  * {@code Get} is the GET action implementation of the HTTP Connector.
  */
 public class Close {
     private static final Logger log = LoggerFactory.getLogger(Close.class);
 
-    public static Object externClose(BObject wsConnection, long statusCode, BString reason, long timeoutInSecs) {
+    public static Object externClose(BalEnv env, BObject wsConnection, long statusCode, BString reason, long timeoutInSecs) {
         Strand strand = Scheduler.getStrand();
-        NonBlockingCallback callback = new NonBlockingCallback(strand);
+        BalFuture balFuture = env.markAsync();
         WebSocketConnectionInfo connectionInfo = (WebSocketConnectionInfo) wsConnection
                 .getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_CONNECTION_INFO);
         WebSocketObservabilityUtil.observeResourceInvocation(strand, connectionInfo,
                                                              WebSocketConstants.RESOURCE_NAME_CLOSE);
         try {
             CountDownLatch countDownLatch = new CountDownLatch(1);
-            ChannelFuture closeFuture = initiateConnectionClosure(callback, (int) statusCode, reason.getValue(),
+            ChannelFuture closeFuture = initiateConnectionClosure((int) statusCode, reason.getValue(),
                                                                   connectionInfo, countDownLatch);
-            waitForTimeout(callback, (int) timeoutInSecs, countDownLatch, connectionInfo);
+            waitForTimeout((int) timeoutInSecs, countDownLatch, connectionInfo);
             closeFuture.channel().close().addListener(future -> {
                 WebSocketUtil.setListenerOpenField(connectionInfo);
-                callback.setReturnValues(null);
-                callback.notifySuccess();
+                balFuture.complete(null);
             });
             WebSocketObservabilityUtil.observeSend(WebSocketObservabilityConstants.MESSAGE_TYPE_CLOSE,
                                                    connectionInfo);
@@ -67,12 +65,12 @@ public class Close {
                                                     WebSocketObservabilityConstants.ERROR_TYPE_MESSAGE_SENT,
                                                     WebSocketObservabilityConstants.MESSAGE_TYPE_CLOSE,
                                                     e.getMessage());
-            callback.notifyFailure(WebSocketUtil.createErrorByType(e));
+            balFuture.complete(WebSocketUtil.createErrorByType(e));
         }
         return null;
     }
 
-    private static ChannelFuture initiateConnectionClosure(NonBlockingCallback callback, int statusCode, String reason,
+    private static ChannelFuture initiateConnectionClosure(int statusCode, String reason,
                                                            WebSocketConnectionInfo connectionInfo,
                                                            CountDownLatch latch) throws IllegalAccessException {
         WebSocketConnection webSocketConnection = connectionInfo.getWebSocketConnection();
@@ -85,18 +83,16 @@ public class Close {
         return closeFuture.addListener(future -> {
             Throwable cause = future.cause();
             if (!future.isSuccess() && cause != null) {
-                setReturnValues(cause.getMessage(), callback);
+                addError(cause.getMessage());
                 WebSocketObservabilityUtil.observeError(connectionInfo,
                                                         WebSocketObservabilityConstants.ERROR_TYPE_CLOSE,
                                                         cause.getMessage());
-            } else {
-                callback.setReturnValues(null);
             }
             latch.countDown();
         });
     }
 
-    private static void waitForTimeout(NonBlockingCallback callback, int timeoutInSecs,
+    private static void waitForTimeout(int timeoutInSecs,
                                        CountDownLatch latch, WebSocketConnectionInfo connectionInfo) {
         try {
             if (timeoutInSecs < 0) {
@@ -107,23 +103,25 @@ public class Close {
                     String errMsg = String.format(
                             "Could not receive a WebSocket close frame from remote endpoint within %d seconds",
                             timeoutInSecs);
-                    setReturnValues(errMsg, callback);
+                    addError(errMsg);
                     WebSocketObservabilityUtil.observeError(connectionInfo,
                                                             WebSocketObservabilityConstants.ERROR_TYPE_CLOSE, errMsg);
                 }
             }
         } catch (InterruptedException err) {
             String errMsg = "Connection interrupted while closing the connection";
-            setReturnValues(errMsg, callback);
+            addError(errMsg);
             WebSocketObservabilityUtil.observeError(connectionInfo,
                                                     WebSocketObservabilityConstants.ERROR_TYPE_CLOSE, errMsg);
             Thread.currentThread().interrupt();
         }
     }
 
-    private static void setReturnValues(String errMsg, NonBlockingCallback callback) {
-        callback.setReturnValues(WebSocketUtil.getWebSocketException(errMsg, null,
-                ErrorCode.WsConnectionClosureError.errorCode(), null));
+    private static void addError(String errMsg) {
+//        TODO: error should be reported caller, see #59
+//
+//        WebSocketException error = WebSocketUtil.getWebSocketException(errMsg, null,
+//                                        ErrorCode.WsConnectionClosureError.errorCode(), null);
     }
 
     private Close() {

--- a/http-native/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/WebSocketConnector.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/WebSocketConnector.java
@@ -16,12 +16,13 @@
 package org.ballerinalang.net.http.actions.websocketconnector;
 
 import io.netty.channel.ChannelFuture;
+import org.ballerinalang.jvm.api.BalEnv;
+import org.ballerinalang.jvm.api.BalFuture;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.api.values.BString;
 import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.values.ArrayValue;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.net.http.websocket.WebSocketConstants;
 import org.ballerinalang.net.http.websocket.WebSocketUtil;
 import org.ballerinalang.net.http.websocket.observability.WebSocketObservabilityConstants;
@@ -38,16 +39,16 @@ import java.nio.ByteBuffer;
 public class WebSocketConnector {
     private static final Logger log = LoggerFactory.getLogger(WebSocketConnector.class);
 
-    public static Object externPushText(BObject wsConnection, BString text, boolean finalFrame) {
+    public static Object externPushText(BalEnv env, BObject wsConnection, BString text, boolean finalFrame) {
         Strand strand = Scheduler.getStrand();
-        NonBlockingCallback callback = new NonBlockingCallback(strand);
+        BalFuture balFuture = env.markAsync();
         WebSocketConnectionInfo connectionInfo = (WebSocketConnectionInfo) wsConnection
                 .getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_CONNECTION_INFO);
         WebSocketObservabilityUtil.observeResourceInvocation(strand, connectionInfo,
                                                              WebSocketConstants.RESOURCE_NAME_PUSH_TEXT);
         try {
             ChannelFuture future = connectionInfo.getWebSocketConnection().pushText(text.getValue(), finalFrame);
-            WebSocketUtil.handleWebSocketCallback(callback, future, log, connectionInfo);
+            WebSocketUtil.handleWebSocketCallback(balFuture, future, log, connectionInfo);
             WebSocketObservabilityUtil.observeSend(WebSocketObservabilityConstants.MESSAGE_TYPE_TEXT,
                                                    connectionInfo);
         } catch (Exception e) {
@@ -56,15 +57,15 @@ public class WebSocketConnector {
                                                     WebSocketObservabilityConstants.ERROR_TYPE_MESSAGE_SENT,
                                                     WebSocketObservabilityConstants.MESSAGE_TYPE_TEXT,
                                                     e.getMessage());
-            WebSocketUtil.setCallbackFunctionBehaviour(connectionInfo, callback, e);
+            WebSocketUtil.setCallbackFunctionBehaviour(connectionInfo, balFuture, e);
         }
         return null;
     }
 
-    public static Object pushBinary(BObject wsConnection, ArrayValue binaryData,
+    public static Object pushBinary(BalEnv env, BObject wsConnection, ArrayValue binaryData,
                                     boolean finalFrame) {
         Strand strand = Scheduler.getStrand();
-        NonBlockingCallback callback = new NonBlockingCallback(strand);
+        BalFuture balFuture = env.markAsync();
         WebSocketConnectionInfo connectionInfo = (WebSocketConnectionInfo) wsConnection
                 .getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_CONNECTION_INFO);
         WebSocketObservabilityUtil.observeResourceInvocation(strand, connectionInfo,
@@ -72,7 +73,7 @@ public class WebSocketConnector {
         try {
             ChannelFuture webSocketChannelFuture = connectionInfo.getWebSocketConnection().pushBinary(
                     ByteBuffer.wrap(binaryData.getBytes()), finalFrame);
-            WebSocketUtil.handleWebSocketCallback(callback, webSocketChannelFuture, log, connectionInfo);
+            WebSocketUtil.handleWebSocketCallback(balFuture, webSocketChannelFuture, log, connectionInfo);
             WebSocketObservabilityUtil.observeSend(WebSocketObservabilityConstants.MESSAGE_TYPE_BINARY,
                                                    connectionInfo);
         } catch (Exception e) {
@@ -81,21 +82,21 @@ public class WebSocketConnector {
                                                     WebSocketObservabilityConstants.ERROR_TYPE_MESSAGE_SENT,
                                                     WebSocketObservabilityConstants.MESSAGE_TYPE_BINARY,
                                                     e.getMessage());
-            WebSocketUtil.setCallbackFunctionBehaviour(connectionInfo, callback, e);
+            WebSocketUtil.setCallbackFunctionBehaviour(connectionInfo, balFuture, e);
         }
         return null;
     }
 
-    public static Object ping(BObject wsConnection, ArrayValue binaryData) {
+    public static Object ping(BalEnv env, BObject wsConnection, ArrayValue binaryData) {
         Strand strand = Scheduler.getStrand();
-        NonBlockingCallback callback = new NonBlockingCallback(strand);
+        BalFuture balFuture = env.markAsync();
         WebSocketConnectionInfo connectionInfo = (WebSocketConnectionInfo) wsConnection
                 .getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_CONNECTION_INFO);
         WebSocketObservabilityUtil.observeResourceInvocation(strand, connectionInfo,
                                                              WebSocketConstants.RESOURCE_NAME_PING);
         try {
             ChannelFuture future = connectionInfo.getWebSocketConnection().ping(ByteBuffer.wrap(binaryData.getBytes()));
-            WebSocketUtil.handleWebSocketCallback(callback, future, log, connectionInfo);
+            WebSocketUtil.handleWebSocketCallback(balFuture, future, log, connectionInfo);
             WebSocketObservabilityUtil.observeSend(WebSocketObservabilityConstants.MESSAGE_TYPE_PING,
                                                    connectionInfo);
         } catch (Exception e) {
@@ -104,21 +105,21 @@ public class WebSocketConnector {
                                                     WebSocketObservabilityConstants.ERROR_TYPE_MESSAGE_SENT,
                                                     WebSocketObservabilityConstants.MESSAGE_TYPE_PING,
                                                     e.getMessage());
-            WebSocketUtil.setCallbackFunctionBehaviour(connectionInfo, callback, e);
+            WebSocketUtil.setCallbackFunctionBehaviour(connectionInfo, balFuture, e);
         }
         return null;
     }
 
-    public static Object pong(BObject wsConnection, ArrayValue binaryData) {
+    public static Object pong(BalEnv env, BObject wsConnection, ArrayValue binaryData) {
         Strand strand = Scheduler.getStrand();
-        NonBlockingCallback callback = new NonBlockingCallback(strand);
+        BalFuture balFuture = env.markAsync();
         WebSocketConnectionInfo connectionInfo = (WebSocketConnectionInfo) wsConnection
                 .getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_CONNECTION_INFO);
         WebSocketObservabilityUtil.observeResourceInvocation(strand, connectionInfo,
                                                              WebSocketConstants.RESOURCE_NAME_PONG);
         try {
             ChannelFuture future = connectionInfo.getWebSocketConnection().pong(ByteBuffer.wrap(binaryData.getBytes()));
-            WebSocketUtil.handleWebSocketCallback(callback, future, log, connectionInfo);
+            WebSocketUtil.handleWebSocketCallback(balFuture, future, log, connectionInfo);
             WebSocketObservabilityUtil.observeSend(WebSocketObservabilityConstants.MESSAGE_TYPE_PONG,
                                                    connectionInfo);
         } catch (Exception e) {
@@ -127,7 +128,7 @@ public class WebSocketConnector {
                                                     WebSocketObservabilityConstants.ERROR_TYPE_MESSAGE_SENT,
                                                     WebSocketObservabilityConstants.MESSAGE_TYPE_PONG,
                                                     e.getMessage());
-            WebSocketUtil.setCallbackFunctionBehaviour(connectionInfo, callback, e);
+            WebSocketUtil.setCallbackFunctionBehaviour(connectionInfo, balFuture, e);
         }
         return null;
     }

--- a/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/ExternHttpDataSourceBuilder.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/ExternHttpDataSourceBuilder.java
@@ -18,10 +18,10 @@
 
 package org.ballerinalang.net.http.nativeimpl;
 
+import org.ballerinalang.jvm.api.BalEnv;
+import org.ballerinalang.jvm.api.BalFuture;
 import org.ballerinalang.jvm.api.values.BError;
 import org.ballerinalang.jvm.api.values.BObject;
-import org.ballerinalang.jvm.scheduling.Scheduler;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.mime.nativeimpl.MimeDataSourceBuilder;
 import org.ballerinalang.mime.nativeimpl.MimeEntityBody;
 import org.ballerinalang.mime.util.EntityBodyChannel;
@@ -58,84 +58,84 @@ public class ExternHttpDataSourceBuilder extends MimeDataSourceBuilder {
 
     private static final Logger log = LoggerFactory.getLogger(ExternHttpDataSourceBuilder.class);
 
-    public static Object getNonBlockingByteArray(BObject entityObj) {
+    public static Object getNonBlockingByteArray(BalEnv env, BObject entityObj) {
         Object transportMessage = entityObj.getNativeData(TRANSPORT_MESSAGE);
         if (isStreamingRequired(entityObj) || transportMessage == null) {
             return getByteArray(entityObj);
         }
 
         // access payload in non blocking manner
-        NonBlockingCallback callback = null;
+        BalFuture balFuture = null;
         try {
             Object messageDataSource = EntityBodyHandler.getMessageDataSource(entityObj);
             if (messageDataSource != null) {
                 return getAlreadyBuiltByteArray(entityObj, messageDataSource);
             }
-            callback = new NonBlockingCallback(Scheduler.getStrand());
-            constructNonBlockingDataSource(callback, entityObj, SourceType.BLOB);
+            balFuture = env.markAsync();
+            constructNonBlockingDataSource(balFuture, entityObj, SourceType.BLOB);
         } catch (Exception exception) {
-            notifyError(callback, exception, "blob");
+            notifyError(balFuture, exception, "blob");
         }
         return null;
     }
 
-    public static Object getNonBlockingJson(BObject entityObj) {
+    public static Object getNonBlockingJson(BalEnv env, BObject entityObj) {
         if (isStreamingRequired(entityObj)) {
             return getJson(entityObj);
         }
 
         // access payload in non blocking manner
-        NonBlockingCallback callback = null;
+        BalFuture balFuture = null;
         try {
             Object dataSource = EntityBodyHandler.getMessageDataSource(entityObj);
             if (dataSource != null) {
                 return getAlreadyBuiltJson(dataSource);
             }
-            callback = new NonBlockingCallback(Scheduler.getStrand());
-            constructNonBlockingDataSource(callback, entityObj, SourceType.JSON);
+             balFuture = env.markAsync();
+            constructNonBlockingDataSource(balFuture, entityObj, SourceType.JSON);
         } catch (Exception exception) {
-            notifyError(callback, exception, "json");
+            notifyError(balFuture, exception, "json");
         }
         return null;
     }
 
-    public static Object getNonBlockingText(BObject entityObj) {
+    public static Object getNonBlockingText(BalEnv env, BObject entityObj) {
         if (isStreamingRequired(entityObj)) {
             return getText(entityObj);
         }
 
         // access payload in non blocking manner
-        NonBlockingCallback callback = null;
+        BalFuture balFuture = null;
         try {
             Object dataSource = EntityBodyHandler.getMessageDataSource(entityObj);
             if (dataSource != null) {
                 return org.ballerinalang.jvm.api.BStringUtils.fromString(MimeUtil.getMessageAsString(dataSource));
             }
-            callback = new NonBlockingCallback(Scheduler.getStrand());
-            constructNonBlockingDataSource(callback, entityObj, SourceType.TEXT);
+            balFuture = env.markAsync();
+            constructNonBlockingDataSource(balFuture, entityObj, SourceType.TEXT);
         } catch (Exception exception) {
-            notifyError(callback, exception, "text");
+            notifyError(balFuture, exception, "text");
         }
         return null;
     }
 
-    public static Object getNonBlockingXml(BObject entityObj) {
+    public static Object getNonBlockingXml(BalEnv env, BObject entityObj) {
         if (isStreamingRequired(entityObj)) {
             return getXml(entityObj);
         }
 
         // access payload in non blocking manner
-        NonBlockingCallback callback = null;
+        BalFuture balFuture = null;
         try {
             Object dataSource = EntityBodyHandler.getMessageDataSource(entityObj);
             if (dataSource != null) {
                 return getAlreadyBuiltXml(dataSource);
             }
 
-            callback = new NonBlockingCallback(Scheduler.getStrand());
-            constructNonBlockingDataSource(callback, entityObj, SourceType.XML);
+            balFuture = env.markAsync();
+            constructNonBlockingDataSource(balFuture, entityObj, SourceType.XML);
         } catch (Exception exception) {
-            notifyError(callback, exception, "xml");
+            notifyError(balFuture, exception, "xml");
         }
         return null;
     }
@@ -154,7 +154,7 @@ public class ExternHttpDataSourceBuilder extends MimeDataSourceBuilder {
         return MimeEntityBody.getByteChannel(entityObj);
     }
 
-    public static void constructNonBlockingDataSource(NonBlockingCallback callback, BObject entity,
+    public static void constructNonBlockingDataSource(BalFuture balFuture, BObject entity,
                                                       SourceType sourceType) {
         HttpCarbonMessage inboundMessage = extractTransportMessageFromEntity(entity);
         inboundMessage.getFullHttpCarbonMessage().addListener(new FullHttpMessageListener() {
@@ -167,7 +167,7 @@ public class ExternHttpDataSourceBuilder extends MimeDataSourceBuilder {
                     switch (sourceType) {
                         case JSON:
                             dataSource = constructJsonDataSource(entity, inputStream);
-                            updateJsonDataSourceAndNotify(callback, entity, dataSource);
+                            updateJsonDataSourceAndNotify(balFuture, entity, dataSource);
                             return;
                         case TEXT:
                             dataSource = constructStringDataSource(entity, inputStream);
@@ -179,9 +179,9 @@ public class ExternHttpDataSourceBuilder extends MimeDataSourceBuilder {
                             dataSource = constructBlobDataSource(inputStream);
                             break;
                     }
-                    updateDataSourceAndNotify(callback, entity, dataSource);
+                    updateDataSourceAndNotify(balFuture, entity, dataSource);
                 } catch (Exception e) {
-                    createErrorAndNotify(callback, "Error occurred while extracting " +
+                    createErrorAndNotify(balFuture, "Error occurred while extracting " +
                             sourceType.toString().toLowerCase(Locale.ENGLISH) + " data from entity: " + getErrorMsg(e));
                 } finally {
                     try {
@@ -194,37 +194,36 @@ public class ExternHttpDataSourceBuilder extends MimeDataSourceBuilder {
 
             @Override
             public void onError(Exception ex) {
-                createErrorAndNotify(callback, "Error occurred while extracting content from message : " +
+                createErrorAndNotify(balFuture, "Error occurred while extracting content from message : " +
                         ex.getMessage());
             }
         });
     }
 
-    private static void notifyError(NonBlockingCallback callback, Exception exception, String type) {
+    private static void notifyError(BalFuture balFuture, Exception exception, String type) {
         BError error = (BError) createError(exception, type);
-        setReturnValuesAndNotify(callback, error);
+        setReturnValuesAndNotify(balFuture, error);
     }
 
-    private static void createErrorAndNotify(NonBlockingCallback callback, String errMsg) {
+    private static void createErrorAndNotify(BalFuture balFuture, String errMsg) {
         BError error = MimeUtil.createError(PARSER_ERROR, errMsg);
-        setReturnValuesAndNotify(callback, error);
+        setReturnValuesAndNotify(balFuture, error);
     }
 
-    private static void setReturnValuesAndNotify(NonBlockingCallback callback, Object result) {
-        callback.setReturnValues(result);
-        callback.notifySuccess();
+    private static void setReturnValuesAndNotify(BalFuture balFuture, Object result) {
+        balFuture.complete(result);
     }
 
-    private static void updateDataSourceAndNotify(NonBlockingCallback callback, BObject entityObj,
+    private static void updateDataSourceAndNotify(BalFuture balFuture, BObject entityObj,
                                                   Object result) {
         updateDataSource(entityObj, result);
-        setReturnValuesAndNotify(callback, result);
+        setReturnValuesAndNotify(balFuture, result);
     }
 
-    private static void updateJsonDataSourceAndNotify(NonBlockingCallback callback, BObject entityObj,
+    private static void updateJsonDataSourceAndNotify(BalFuture balFuture, BObject entityObj,
                                                       Object result) {
         updateJsonDataSource(entityObj, result);
-        setReturnValuesAndNotify(callback, result);
+        setReturnValuesAndNotify(balFuture, result);
     }
 
     private static HttpCarbonMessage extractTransportMessageFromEntity(BObject entityObj) {

--- a/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/CancelWebSocketUpgrade.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/CancelWebSocketUpgrade.java
@@ -18,10 +18,10 @@ package org.ballerinalang.net.http.nativeimpl.connection;
 
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import org.ballerinalang.jvm.api.BalEnv;
+import org.ballerinalang.jvm.api.BalFuture;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.api.values.BString;
-import org.ballerinalang.jvm.scheduling.Scheduler;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.net.http.websocket.WebSocketConstants;
 import org.ballerinalang.net.http.websocket.WebSocketUtil;
 import org.slf4j.Logger;
@@ -36,14 +36,14 @@ import org.wso2.transport.http.netty.contract.websocket.WebSocketHandshaker;
 public class CancelWebSocketUpgrade {
     private static final Logger log = LoggerFactory.getLogger(CancelWebSocketUpgrade.class);
 
-    public static Object cancelWebSocketUpgrade(BObject connectionObj, long statusCode, BString reason) {
-        NonBlockingCallback callback = new NonBlockingCallback(Scheduler.getStrand());
+    public static Object cancelWebSocketUpgrade(BalEnv env, BObject connectionObj, long statusCode, BString reason) {
+        BalFuture balFuture = env.markAsync();
         try {
             WebSocketHandshaker webSocketHandshaker =
                     (WebSocketHandshaker) connectionObj.getNativeData(WebSocketConstants.WEBSOCKET_HANDSHAKER);
             if (webSocketHandshaker == null) {
                 WebSocketUtil.setNotifyFailure("Not a WebSocket upgrade request. " +
-                        "Cannot cancel the request", callback);
+                        "Cannot cancel the request", balFuture);
                 return null;
             }
             ChannelFuture future = webSocketHandshaker.cancelHandshake((int) statusCode, reason.getValue());
@@ -53,15 +53,14 @@ public class CancelWebSocketUpgrade {
                     channelFuture.channel().close();
                 }
                 if (!future.isSuccess() && cause != null) {
-                    callback.notifyFailure(WebSocketUtil.createErrorByType(cause));
+                    balFuture.complete(WebSocketUtil.createErrorByType(cause));
                 } else {
-                    callback.setReturnValues(null);
-                    callback.notifySuccess();
+                    balFuture.complete(null);
                 }
             });
         } catch (Exception e) {
             log.error("Error when cancelling WebsSocket upgrade request", e);
-            callback.notifyFailure(WebSocketUtil.createErrorByType(e));
+            balFuture.complete(WebSocketUtil.createErrorByType(e));
         }
         return null;
     }

--- a/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/Promise.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/Promise.java
@@ -18,10 +18,10 @@
 
 package org.ballerinalang.net.http.nativeimpl.connection;
 
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpUtil;
 import org.wso2.transport.http.netty.contract.HttpResponseFuture;
@@ -32,10 +32,10 @@ import org.wso2.transport.http.netty.message.HttpCarbonMessage;
  * {@code Promise} is the extern function to respond back to the client with a PUSH_PROMISE frame.
  */
 public class Promise extends ConnectionAction {
-    public static Object promise(BObject connectionObj, BObject pushPromiseObj) {
+    public static Object promise(BalEnv env, BObject connectionObj, BObject pushPromiseObj) {
         HttpCarbonMessage inboundRequestMsg = HttpUtil.getCarbonMsg(connectionObj, null);
         Strand strand = Scheduler.getStrand();
-        DataContext dataContext = new DataContext(strand, new NonBlockingCallback(strand), inboundRequestMsg);
+        DataContext dataContext = new DataContext(strand, env.markAsync(), inboundRequestMsg);
         HttpUtil.serverConnectionStructCheck(inboundRequestMsg);
 
         Http2PushPromise http2PushPromise = HttpUtil.getPushPromise(pushPromiseObj,

--- a/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/PushPromisedResponse.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/PushPromisedResponse.java
@@ -20,10 +20,10 @@ package org.ballerinalang.net.http.nativeimpl.connection;
 
 import org.ballerinalang.jvm.api.BErrorCreator;
 import org.ballerinalang.jvm.api.BStringUtils;
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.mime.util.EntityBodyHandler;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpUtil;
@@ -42,11 +42,11 @@ import static org.ballerinalang.net.http.HttpUtil.extractEntity;
  */
 public class PushPromisedResponse extends ConnectionAction {
 
-    public static Object pushPromisedResponse(BObject connectionObj, BObject pushPromiseObj,
-                                     BObject outboundResponseObj) {
+    public static Object pushPromisedResponse(BalEnv env, BObject connectionObj, BObject pushPromiseObj,
+                                              BObject outboundResponseObj) {
         HttpCarbonMessage inboundRequestMsg = HttpUtil.getCarbonMsg(connectionObj, null);
         Strand strand = Scheduler.getStrand();
-        DataContext dataContext = new DataContext(strand, new NonBlockingCallback(strand), inboundRequestMsg);
+        DataContext dataContext = new DataContext(strand, env.markAsync(), inboundRequestMsg);
         HttpUtil.serverConnectionStructCheck(inboundRequestMsg);
 
         Http2PushPromise http2PushPromise = HttpUtil.getPushPromise(pushPromiseObj, null);

--- a/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/Respond.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/Respond.java
@@ -20,6 +20,7 @@ package org.ballerinalang.net.http.nativeimpl.connection;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BError;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.observability.ObserveUtils;
@@ -27,7 +28,6 @@ import org.ballerinalang.jvm.observability.ObserverContext;
 import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.State;
 import org.ballerinalang.jvm.scheduling.Strand;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.net.http.DataContext;
 import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpErrorType;
@@ -57,11 +57,11 @@ public class Respond extends ConnectionAction {
 
     private static final Logger log = LoggerFactory.getLogger(Respond.class);
 
-    public static Object nativeRespond(BObject connectionObj, BObject outboundResponseObj) {
+    public static Object nativeRespond(BalEnv env, BObject connectionObj, BObject outboundResponseObj) {
 
         HttpCarbonMessage inboundRequestMsg = HttpUtil.getCarbonMsg(connectionObj, null);
         Strand strand = Scheduler.getStrand();
-        DataContext dataContext = new DataContext(strand, new NonBlockingCallback(strand), inboundRequestMsg);
+        DataContext dataContext = new DataContext(strand, env.markAsync(), inboundRequestMsg);
         if (isDirtyResponse(outboundResponseObj)) {
             String errorMessage = "Couldn't complete the respond operation as the response has been already used.";
             HttpUtil.sendOutboundResponse(inboundRequestMsg, HttpUtil.createErrorMessage(errorMessage, 500));

--- a/http-native/src/main/java/org/ballerinalang/net/http/websocket/WebSocketUtil.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/websocket/WebSocketUtil.java
@@ -27,6 +27,7 @@ import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
 import org.ballerinalang.jvm.api.BErrorCreator;
 import org.ballerinalang.jvm.api.BStringUtils;
 import org.ballerinalang.jvm.api.BValueCreator;
+import org.ballerinalang.jvm.api.BalFuture;
 import org.ballerinalang.jvm.api.values.BError;
 import org.ballerinalang.jvm.api.values.BMap;
 import org.ballerinalang.jvm.api.values.BObject;
@@ -35,7 +36,6 @@ import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.services.ErrorHandlerUtils;
 import org.ballerinalang.jvm.types.BPackage;
 import org.ballerinalang.jvm.types.BType;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpErrorType;
 import org.ballerinalang.net.http.HttpUtil;
@@ -116,30 +116,29 @@ public class WebSocketUtil {
         webSocketClient.set(WebSocketConstants.LISTENER_IS_OPEN_FIELD, webSocketConnection.isOpen());
     }
 
-    public static void handleWebSocketCallback(NonBlockingCallback callback,
+    public static void handleWebSocketCallback(BalFuture balFuture,
                                                ChannelFuture webSocketChannelFuture, Logger log,
                                                WebSocketConnectionInfo connectionInfo) {
         webSocketChannelFuture.addListener(future -> {
             Throwable cause = future.cause();
             if (!future.isSuccess() && cause != null) {
                 log.error(ERROR_MESSAGE, cause);
-                setCallbackFunctionBehaviour(connectionInfo, callback, cause);
+                setCallbackFunctionBehaviour(connectionInfo, balFuture, cause);
             } else {
                 // This is needed because since the same strand is used in all actions if an action is called before
                 // this one it will cause this action to return the return value of the previous action.
-                callback.setReturnValues(null);
-                callback.notifySuccess();
+                balFuture.complete(null);
             }
         });
     }
 
     public static void setCallbackFunctionBehaviour(WebSocketConnectionInfo connectionInfo,
-                                                    NonBlockingCallback callback, Throwable error) {
+                                                    BalFuture balFuture, Throwable error) {
         if (hasSupportForResiliency(connectionInfo)) {
             ErrorHandlerUtils.printError(error);
-            callback.notifySuccess();
+            balFuture.complete(null);
         } else {
-            callback.notifyFailure(WebSocketUtil.createErrorByType(error));
+            balFuture.complete(WebSocketUtil.createErrorByType(error));
         }
     }
 
@@ -589,8 +588,8 @@ public class WebSocketUtil {
         return exception;
     }
 
-    public static void setNotifyFailure(String msg, NonBlockingCallback callback) {
-        callback.notifyFailure(getWebSocketException(msg, null,
+    public static void setNotifyFailure(String msg, BalFuture balFuture) {
+        balFuture.complete(getWebSocketException(msg, null,
                 WebSocketConstants.ErrorCode.WsInvalidHandshakeError.errorCode(), null));
     }
 


### PR DESCRIPTION
## Purpose
Remove deprecated API
subtask of ballerina-platform/ballerina-lang#25254

## Goals
Replace deprecated API NonBlockingCallback with BalEnv param for interop

## Related PRs
API deprecated in - ballerina-platform/ballerina-lang#25787
Duplicate change prior to stdlib move - ballerina-platform/ballerina-lang#25854

## Bugs
Bugs on web socket close are ignored to make the tests pass