### PR TITLE
Fix failing websocket test cases

### DIFF
--- a/http-ballerina/src/http-tests/tests/integration-tests/service/websocket/34_retry_client.bal
+++ b/http-ballerina/src/http-tests/tests/integration-tests/service/websocket/34_retry_client.bal
@@ -19,7 +19,7 @@ import ballerina/runtime;
 import ballerina/test;
 import http;
 
-string expectedOutput = "";
+string expectedOutput34 = "";
 
 listener http:Listener retryEP = new (21034);
 
@@ -46,7 +46,7 @@ service wsUpgradeRetryService = @http:WebSocketServiceConfig {} service {
 
 service retryClientCallbackService = @http:WebSocketServiceConfig {} service {
     resource function onText(http:WebSocketClient wsEp, string text) {
-        expectedOutput = <@untainted>text;
+        expectedOutput34 = <@untainted>text;
     }
 };
 
@@ -85,6 +85,6 @@ public function testRetry() {
     runtime:sleep(1500);
     checkpanic retryEP.__start();
     runtime:sleep(5000);
-    test:assertEquals(expectedOutput, "Hi madam");
+    test:assertEquals(expectedOutput34, "Hi madam");
     checkpanic wsClientEp->close(statusCode = 1000, reason = "Close the connection");
 }

--- a/http-ballerina/src/http-tests/tests/integration-tests/service/websocket/35_fail_failover.bal
+++ b/http-ballerina/src/http-tests/tests/integration-tests/service/websocket/35_fail_failover.bal
@@ -18,10 +18,12 @@ import ballerina/runtime;
 import ballerina/test;
 import http;
 
+string expectedError35 = "";
+
 service failFailoverCallbackService = @http:WebSocketServiceConfig {} service {
 
     resource function onError(http:WebSocketFailoverClient conn, error err) {
-        expectedError = <@untainted>err.message();
+        expectedError35 = <@untainted>err.message();
     }
 };
 
@@ -40,7 +42,7 @@ public function testFailingFailover() {
     });
     var out = trap wsClientEp->ready();
     runtime:sleep(500);
-    test:assertEquals(expectedError, "ConnectionError: IO Error");
+    test:assertEquals(expectedError35, "ConnectionError: IO Error");
     if (out is error) {
         test:assertEquals(out.message(), "ConnectionError: The WebSocket connection has not been made");
     } else {

--- a/http-ballerina/src/http-tests/tests/integration-tests/service/websocket/37_cookie_client.bal
+++ b/http-ballerina/src/http-tests/tests/integration-tests/service/websocket/37_cookie_client.bal
@@ -20,6 +20,8 @@ import ballerina/runtime;
 import ballerina/test;
 import http;
 
+string expectedOutput37 = "";
+
 http:ClientConfiguration clientEPConfig = {
     cookieConfig: {
         enabled: true
@@ -66,7 +68,7 @@ service on new http:Listener(21037) {
 service CookieService = @http:WebSocketServiceConfig {} service {
 
     resource function onText(http:WebSocketClient conn, string text, boolean finalFrame) {
-        expectedOutput = <@untainted>text;
+        expectedOutput37 = <@untainted>text;
     }
 };
 
@@ -76,6 +78,6 @@ public function testCookieSupport() {
     http:WebSocketClient wsClientEp = new ("ws://localhost:21037");
     checkpanic wsClientEp->pushText("Hi");
     runtime:sleep(500);
-    test:assertEquals(expectedOutput, "Hello World!");
+    test:assertEquals(expectedOutput37, "Hello World!");
     checkpanic wsClientEp->close(statusCode = 1000, reason = "Close the connection");
 }

--- a/http-ballerina/src/http-tests/tests/integration-tests/service/websocket/38_incorrect_cookie.bal
+++ b/http-ballerina/src/http-tests/tests/integration-tests/service/websocket/38_incorrect_cookie.bal
@@ -20,7 +20,8 @@ import ballerina/runtime;
 import ballerina/test;
 import http;
 
-string expectedError = "";
+string expectedError38 = "";
+
 http:ClientConfiguration clientConfig = {
     cookieConfig: {
         enabled: true
@@ -65,7 +66,7 @@ service on new http:Listener(21038) {
 service ErrorCookieService = @http:WebSocketServiceConfig {} service {
 
     resource function onError(http:WebSocketClient conn, error err) {
-        expectedError = <@untainted>err.message();
+        expectedError38 = <@untainted>err.message();
     }
 };
 
@@ -74,6 +75,6 @@ service ErrorCookieService = @http:WebSocketServiceConfig {} service {
 public function IncorrectCookieTestCase() {
     http:WebSocketClient wsClientEp = new ("ws://localhost:21038");
     runtime:sleep(500);
-    test:assertEquals(expectedError, "InvalidHandshakeError: Invalid handshake response getStatus: 401 Unauthorized");
+    test:assertEquals(expectedError38, "InvalidHandshakeError: Invalid handshake response getStatus: 401 Unauthorized");
     checkpanic wsClientEp->close(statusCode = 1000, reason = "Close the connection");
 }

--- a/http-ballerina/src/http-tests/tests/integration-tests/service/websocket/39_authentication_success_client.bal
+++ b/http-ballerina/src/http-tests/tests/integration-tests/service/websocket/39_authentication_success_client.bal
@@ -19,6 +19,9 @@ import ballerina/runtime;
 import ballerina/test;
 import http;
 
+string expectedOutput39 = "";
+string expectedError39 = "";
+
 @http:WebSocketServiceConfig {
 }
 service on new http:Listener(21039) {
@@ -46,11 +49,11 @@ service on new http:Listener(21039) {
 service authenticationService = @http:WebSocketServiceConfig {} service {
 
     resource function onText(http:WebSocketClient conn, string text, boolean finalFrame) {
-        expectedOutput = <@untainted>text;
+        expectedOutput39 = <@untainted>text;
     }
 
     resource function onError(http:WebSocketClient conn, error err) {
-        expectedError = <@untainted>err.message();
+        expectedError39 = <@untainted>err.message();
     }
 };
 
@@ -59,6 +62,6 @@ service authenticationService = @http:WebSocketServiceConfig {} service {
 public function testBasicAuthenticationSuccess() {
     http:WebSocketClient wsClientEp = new ("ws://localhost:21039");
     runtime:sleep(500);
-    test:assertEquals(expectedOutput, "Hello World!");
+    test:assertEquals(expectedOutput39, "Hello World!");
     checkpanic wsClientEp->close(statusCode = 1000, reason = "Close the connection");
 }

--- a/http-ballerina/src/http-tests/tests/integration-tests/service/websocket/41_authentication_failure_client.bal
+++ b/http-ballerina/src/http-tests/tests/integration-tests/service/websocket/41_authentication_failure_client.bal
@@ -19,6 +19,8 @@ import ballerina/runtime;
 import ballerina/test;
 import http;
 
+string expectedError41 = "";
+
 @http:WebSocketServiceConfig {
 }
 service on new http:Listener(21041) {
@@ -33,7 +35,7 @@ service on new http:Listener(21041) {
 
         http:WebSocketClient wsClient = new ("ws://localhost:21042/auth/ws",
                 config = {
-                callbackService: authenticationService,
+                callbackService: unAuthenticationService,
                 customHeaders: {
                     [http:AUTH_HEADER]: string `Basic ${token}`
                 }
@@ -46,7 +48,7 @@ service on new http:Listener(21041) {
 service unAuthenticationService = @http:WebSocketServiceConfig {} service {
 
     resource function onError(http:WebSocketClient conn, error err) {
-        expectedError = <@untainted>err.message();
+        expectedError41 = <@untainted>err.message();
     }
 };
 
@@ -55,5 +57,5 @@ service unAuthenticationService = @http:WebSocketServiceConfig {} service {
 public function testBasicAuthenticationFailure() {
     http:WebSocketClient wsClientEp = new ("ws://localhost:21041");
     runtime:sleep(500);
-    test:assertEquals(expectedError, "InvalidHandshakeError: Invalid handshake response getStatus: 401 Unauthorized");
+    test:assertEquals(expectedError41, "InvalidHandshakeError: Invalid handshake response getStatus: 401 Unauthorized");
 }

--- a/http-ballerina/src/http-tests/tests/integration-tests/service/websocket/42_authentication_failure_server.bal
+++ b/http-ballerina/src/http-tests/tests/integration-tests/service/websocket/42_authentication_failure_server.bal
@@ -35,7 +35,7 @@ service upgradeServ on httpServ {
     @http:ResourceConfig {
         webSocketUpgrade: {
             upgradePath: "/ws",
-            upgradeService: upgradedService
+            upgradeService: upgradedServ
         }
     }
     resource function upgrader(http:Caller caller, http:Request req) {

--- a/http-ballerina/src/http-tests/tests/integration-tests/service/websocket/43_failover_client.bal
+++ b/http-ballerina/src/http-tests/tests/integration-tests/service/websocket/43_failover_client.bal
@@ -19,6 +19,8 @@ import ballerina/runtime;
 import ballerina/test;
 import http;
 
+string expectedOutput43 = "";
+
 @http:WebSocketServiceConfig {
     path: "/websocket"
 }
@@ -50,7 +52,7 @@ service failoverServer on new http:Listener(21043) {
 service failoverClientCallbackService = @http:WebSocketServiceConfig {} service {
 
     resource function onText(http:WebSocketFailoverClient wsEp, string text) {
-        expectedOutput = <@untainted>text;
+        expectedOutput43 = <@untainted>text;
     }
 
     resource function onBinary(http:WebSocketFailoverClient wsEp, byte[] data) {
@@ -76,7 +78,7 @@ public function testBinaryFrameWithThirdServer() {
     });
     checkpanic wsClientEp->pushText("Hello");
     runtime:sleep(500);
-    test:assertEquals(expectedOutput, "Hello");
+    test:assertEquals(expectedOutput43, "Hello");
     checkpanic wsClientEp->close(statusCode = 1000, reason = "Close the connection");
 }
 
@@ -94,7 +96,7 @@ public function testTextFrameWithSecondServer() {
     });
     checkpanic wsClientEp->pushText("Hello");
     runtime:sleep(500);
-    test:assertEquals(expectedOutput, "Hello");
+    test:assertEquals(expectedOutput43, "Hello");
     checkpanic wsClientEp->close(statusCode = 1000, reason = "Close the connection");
 }
 
@@ -131,6 +133,6 @@ public function testHandshakeTimeout() {
     });
     checkpanic wsClientEp->pushText("Hello everyone");
     runtime:sleep(500);
-    test:assertEquals(expectedOutput, "Hello everyone");
+    test:assertEquals(expectedOutput43, "Hello everyone");
     checkpanic wsClientEp->close(statusCode = 1000, reason = "Close the connection");
 }


### PR DESCRIPTION
## Purpose
This PR will fix the failing 8 websocket test cases.

```
2020-09-22T12:38:09.9217900Z 	[fail] testCookieSupport:
2020-09-22T12:38:09.9218284Z 	    Assertion Failed!
2020-09-22T12:38:09.9219167Z 	    	expected: 'Hello World!'
2020-09-22T12:38:09.9219624Z 	    	actual	: 'Hi madam'
2020-09-22T12:38:09.9220167Z 	    	at ballerina.test.0_0_0:createBallerinaError(assert.bal:42)
2020-09-22T12:38:09.9220876Z 	    	ballerina.test.0_0_0:assertEquals(assert.bal:75)
2020-09-22T12:38:09.9222797Z 	    	ballerina.http-tests.1_0_0.tests.integration-tests.service.websocket.37_cookie_client:testCookieSupport(tests/integration-tests/service/websocket/37_cookie_client.bal:79)
2020-09-22T12:38:09.9224222Z 
2020-09-22T12:38:09.9224798Z 	[fail] IncorrectCookieTestCase:
2020-09-22T12:38:09.9225290Z 	    Assertion Failed!
2020-09-22T12:38:09.9226215Z 	    	expected: 'InvalidHandshakeError: Invalid handshake response getStatus: 401 Unauthorized'
2020-09-22T12:38:09.9227415Z 	    	actual	: 'ConnectionError: IO Error'
2020-09-22T12:38:09.9228087Z 	    	at ballerina.test.0_0_0:createBallerinaError(assert.bal:42)
2020-09-22T12:38:09.9228821Z 	    	ballerina.test.0_0_0:assertEquals(assert.bal:75)
2020-09-22T12:38:09.9230933Z 	    	ballerina.http-tests.1_0_0.tests.integration-tests.service.websocket.38_incorrect_cookie:IncorrectCookieTestCase(tests/integration-tests/service/websocket/38_incorrect_cookie.bal:77)
2020-09-22T12:38:09.9232370Z 
2020-09-22T12:38:09.9232902Z 	[fail] testBasicAuthenticationSuccess:
2020-09-22T12:38:09.9233494Z 	    Assertion Failed!
2020-09-22T12:38:09.9234159Z 	    	expected: 'Hello World!'
2020-09-22T12:38:09.9234655Z 	    	actual	: 'Hi madam'
2020-09-22T12:38:09.9235495Z 	    	at ballerina.test.0_0_0:createBallerinaError(assert.bal:42)
2020-09-22T12:38:09.9236333Z 	    	ballerina.test.0_0_0:assertEquals(assert.bal:75)
2020-09-22T12:38:09.9264331Z 	    	ballerina.http-tests.1_0_0.tests.integration-tests.service.websocket.39_authentication_success_client:testBasicAuthenticationSuccess(tests/integration-tests/service/websocket/39_authentication_success_client.bal:62)
2020-09-22T12:38:09.9266030Z 
2020-09-22T12:38:09.9266582Z 	[fail] testBasicAuthenticationFailure:
2020-09-22T12:38:09.9267180Z 	    Assertion Failed!
2020-09-22T12:38:09.9268314Z 	    	expected: 'InvalidHandshakeError: Invalid handshake response getStatus: 401 Unauthorized'
2020-09-22T12:38:09.9269276Z 	    	actual	: 'ConnectionError: IO Error'
2020-09-22T12:38:09.9270052Z 	    	at ballerina.test.0_0_0:createBallerinaError(assert.bal:42)
2020-09-22T12:38:09.9270798Z 	    	ballerina.test.0_0_0:assertEquals(assert.bal:75)
2020-09-22T12:38:09.9273073Z 	    	ballerina.http-tests.1_0_0.tests.integration-tests.service.websocket.41_authentication_failure_client:testBasicAuthenticationFailure(tests/integration-tests/service/websocket/41_authentication_failure_client.bal:58)
2020-09-22T12:38:09.9274745Z 
2020-09-22T12:38:09.9275359Z 	[fail] testBinaryFrameWithThirdServer:
2020-09-22T12:38:09.9275912Z 	    Assertion Failed!
2020-09-22T12:38:09.9276347Z 	    	expected: 'Hello'
2020-09-22T12:38:09.9276776Z 	    	actual	: 'Hi madam'
2020-09-22T12:38:09.9277310Z 	    	at ballerina.test.0_0_0:createBallerinaError(assert.bal:42)
2020-09-22T12:38:09.9278177Z 	    	ballerina.test.0_0_0:assertEquals(assert.bal:75)
2020-09-22T12:38:09.9280253Z 	    	ballerina.http-tests.1_0_0.tests.integration-tests.service.websocket.43_failover_client:testBinaryFrameWithThirdServer(tests/integration-tests/service/websocket/43_failover_client.bal:79)
2020-09-22T12:38:09.9281819Z 
2020-09-22T12:38:09.9282311Z 	[fail] testTextFrameWithSecondServer:
2020-09-22T12:38:09.9282853Z 	    Assertion Failed!
2020-09-22T12:38:09.9283308Z 	    	expected: 'Hello'
2020-09-22T12:38:09.9283733Z 	    	actual	: 'Hi madam'
2020-09-22T12:38:09.9284253Z 	    	at ballerina.test.0_0_0:createBallerinaError(assert.bal:42)
2020-09-22T12:38:09.9289610Z 	    	ballerina.test.0_0_0:assertEquals(assert.bal:75)
2020-09-22T12:38:09.9291728Z 	    	ballerina.http-tests.1_0_0.tests.integration-tests.service.websocket.43_failover_client:testTextFrameWithSecondServer(tests/integration-tests/service/websocket/43_failover_client.bal:97)
2020-09-22T12:38:09.9293137Z 
2020-09-22T12:38:09.9293637Z 	[fail] testBinaryFrameWithFirstServer:
2020-09-22T12:38:09.9294629Z 	    {ballerina}TypeCastError {"message":"incompatible types: '()' cannot be cast to 'string'"}
2020-09-22T12:38:09.9295372Z 	    	at ballerina.test.0_0_0:getBallerinaType(assert.bal:162)
2020-09-22T12:38:09.9296101Z 	    	ballerina.test.0_0_0:getInequalityErrorMsg(assert.bal:138)
2020-09-22T12:38:09.9296795Z 	    	ballerina.test.0_0_0:assertEquals(assert.bal:74)
2020-09-22T12:38:09.9298740Z 	    	ballerina.http-tests.1_0_0.tests.integration-tests.service.websocket.43_failover_client:testBinaryFrameWithFirstServer(tests/integration-tests/service/websocket/43_failover_client.bal:116)
2020-09-22T12:38:09.9300136Z 
2020-09-22T12:38:09.9300493Z 	[fail] testHandshakeTimeout:
2020-09-22T12:38:09.9300905Z 	    Assertion Failed!
2020-09-22T12:38:09.9301391Z 	    	expected: 'Hello everyone'
2020-09-22T12:38:09.9301853Z 	    	actual	: 'Hi madam'
2020-09-22T12:38:09.9302392Z 	    	at ballerina.test.0_0_0:createBallerinaError(assert.bal:42)
2020-09-22T12:38:09.9303074Z 	    	ballerina.test.0_0_0:assertEquals(assert.bal:75)
2020-09-22T12:38:09.9304863Z 	    	ballerina.http-tests.1_0_0.tests.integration-tests.service.websocket.43_failover_client:testHandshakeTimeout(tests/integration-tests/service/websocket/43_failover_client.bal:134)
```