### PR TITLE
Add exact status code for traces of ballerina/http/Client calls

### DIFF
--- a/http-ballerina/http_client_endpoint.bal
+++ b/http-ballerina/http_client_endpoint.bal
@@ -253,8 +253,9 @@ public client class Client {
     public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         Response|ClientError response = self.httpClient->getResponse(httpFuture);
         if (response is Response) {
-            error? metricErr = observe:addTagToSpan(HTTP_STATUS_CODE,response.statusCode.toString());
-            error? traceErr = observe:addTagToMetrics(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(response.statusCode));
+            string statusCode = response.statusCode.toString();
+            error? metricErr = observe:addTagToSpan(HTTP_STATUS_CODE, statusCode);
+            error? traceErr = observe:addTagToMetrics(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(statusCode));
 
         }
         return response;

--- a/http-ballerina/http_client_endpoint.bal
+++ b/http-ballerina/http_client_endpoint.bal
@@ -252,7 +252,7 @@ public client class Client {
     # + return - An `http:Response` message or else an `http: ClientError` if the invocation fails
     public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         Response|ClientError response = self.httpClient->getResponse(httpFuture);
-        if (response is Response) {
+        if (response is Response && observabilityEnabled) {
             string statusCode = response.statusCode.toString();
             error? metricErr = observe:addTagToSpan(HTTP_STATUS_CODE, statusCode);
             error? traceErr = observe:addTagToMetrics(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(statusCode));

--- a/http-ballerina/http_client_endpoint.bal
+++ b/http-ballerina/http_client_endpoint.bal
@@ -253,7 +253,9 @@ public client class Client {
     public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         Response|ClientError response = self.httpClient->getResponse(httpFuture);
         if (response is Response) {
-            error? err = observe:addTagToSpan(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(response.statusCode));
+            error? metricErr = observe:addTagToSpan(HTTP_STATUS_CODE,response.statusCode.toString());
+            error? traceErr = observe:addTagToMetrics(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(response.statusCode));
+
         }
         return response;
     }

--- a/http-ballerina/http_client_endpoint.bal
+++ b/http-ballerina/http_client_endpoint.bal
@@ -254,8 +254,8 @@ public client class Client {
         Response|ClientError response = self.httpClient->getResponse(httpFuture);
         if (response is Response && observabilityEnabled) {
             string statusCode = response.statusCode.toString();
-            error? metricErr = observe:addTagToSpan(HTTP_STATUS_CODE, statusCode);
-            error? traceErr = observe:addTagToMetrics(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(statusCode));
+            _ = checkpanic observe:addTagToSpan(HTTP_STATUS_CODE, statusCode);
+            _ = checkpanic observe:addTagToMetrics(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(statusCode));
 
         }
         return response;

--- a/http-ballerina/http_client_endpoint.bal
+++ b/http-ballerina/http_client_endpoint.bal
@@ -252,7 +252,7 @@ public client class Client {
     # + return - An `http:Response` message or else an `http: ClientError` if the invocation fails
     public remote function getResponse(HttpFuture httpFuture) returns Response|ClientError {
         Response|ClientError response = self.httpClient->getResponse(httpFuture);
-        if (response is Response && observabilityEnabled) {
+        if (observabilityEnabled && response is Response) {
             string statusCode = response.statusCode.toString();
             _ = checkpanic observe:addTagToSpan(HTTP_STATUS_CODE, statusCode);
             _ = checkpanic observe:addTagToMetrics(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(statusCode));

--- a/http-ballerina/http_client_endpoint.bal
+++ b/http-ballerina/http_client_endpoint.bal
@@ -256,7 +256,6 @@ public client class Client {
             string statusCode = response.statusCode.toString();
             _ = checkpanic observe:addTagToSpan(HTTP_STATUS_CODE, statusCode);
             _ = checkpanic observe:addTagToMetrics(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(statusCode));
-
         }
         return response;
     }

--- a/http-ballerina/http_commons.bal
+++ b/http-ballerina/http_commons.bal
@@ -230,8 +230,8 @@ isolated function createErrorForNoPayload(mime:Error err) returns GenericClientE
     return GenericClientError(message, err);
 }
 
-isolated function getStatusCodeRange(int statusCode) returns string {
-    return statusCode.toString().substring(0,1) + STATUS_CODE_GROUP_SUFFIX;
+isolated function getStatusCodeRange(string statusCode) returns string {
+    return statusCode.substring(0,1) + STATUS_CODE_GROUP_SUFFIX;
 }
 
 # Returns a random UUID string.
@@ -252,10 +252,11 @@ isolated function uuid() returns string {
 # + method - http method of the request
 # + statusCode - status code of the response
 isolated function addObservabilityInformation(string path, string method, int statusCode, string url) {
+    string statusCodeConverted = statusCode.toString();
     error? err = observe:addTagToSpan(HTTP_URL, path);
     err = observe:addTagToSpan(HTTP_METHOD, method);
-    err = observe:addTagToMetrics(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(statusCode));
-    err = observe:addTagToSpan(HTTP_STATUS_CODE, statusCode.toString());
+    err = observe:addTagToMetrics(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(statusCodeConverted));
+    err = observe:addTagToSpan(HTTP_STATUS_CODE, statusCodeConverted);
     err = observe:addTagToSpan(HTTP_BASE_URL, url);
 }
 

--- a/http-ballerina/http_commons.bal
+++ b/http-ballerina/http_commons.bal
@@ -254,7 +254,8 @@ isolated function uuid() returns string {
 isolated function addObservabilityInformation(string path, string method, int statusCode, string url) {
     error? err = observe:addTagToSpan(HTTP_URL, path);
     err = observe:addTagToSpan(HTTP_METHOD, method);
-    err = observe:addTagToSpan(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(statusCode));
+    err = observe:addTagToMetrics(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(statusCode));
+    err = observe:addTagToSpan(HTTP_STATUS_CODE, statusCode.toString());
     err = observe:addTagToSpan(HTTP_BASE_URL, url);
 }
 

--- a/http-ballerina/http_commons.bal
+++ b/http-ballerina/http_commons.bal
@@ -253,11 +253,15 @@ isolated function uuid() returns string {
 # + statusCode - status code of the response
 isolated function addObservabilityInformation(string path, string method, int statusCode, string url) {
     string statusCodeConverted = statusCode.toString();
-    error? err = observe:addTagToSpan(HTTP_URL, path);
-    err = observe:addTagToSpan(HTTP_METHOD, method);
-    err = observe:addTagToMetrics(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(statusCodeConverted));
-    err = observe:addTagToSpan(HTTP_STATUS_CODE, statusCodeConverted);
-    err = observe:addTagToSpan(HTTP_BASE_URL, url);
+    _ = checkpanic observe:addTagToSpan(HTTP_URL, path);
+    _ = checkpanic observe:addTagToSpan(HTTP_METHOD, method);
+    _ = checkpanic observe:addTagToSpan(HTTP_STATUS_CODE, statusCodeConverted);
+    _ = checkpanic observe:addTagToSpan(HTTP_BASE_URL, url);
+
+    _ = checkpanic observe:addTagToMetrics(HTTP_URL, path);
+    _ = checkpanic observe:addTagToMetrics(HTTP_METHOD, method);
+    _ = checkpanic observe:addTagToMetrics(HTTP_BASE_URL, url);
+    _ = checkpanic observe:addTagToMetrics(HTTP_STATUS_CODE_GROUP, getStatusCodeRange(statusCodeConverted));
 }
 
 isolated function getIllegalDataBindingStateError() returns IllegalDataBindingStateError {

--- a/http-ballerina/http_commons.bal
+++ b/http-ballerina/http_commons.bal
@@ -231,7 +231,7 @@ isolated function createErrorForNoPayload(mime:Error err) returns GenericClientE
 }
 
 isolated function getStatusCodeRange(string statusCode) returns string {
-    return statusCode.substring(0,1) + STATUS_CODE_GROUP_SUFFIX;
+    return statusCode.substring(0, 1) + STATUS_CODE_GROUP_SUFFIX;
 }
 
 # Returns a random UUID string.

--- a/http-ballerina/http_constants.bal
+++ b/http-ballerina/http_constants.bal
@@ -123,6 +123,9 @@ const HTTP_METHOD = "http.method";
 # Constant for telemetry tag http.status_code_group
 const HTTP_STATUS_CODE_GROUP = "http.status_code_group";
 
+# Constant for telemetry tag http.status_code
+const HTTP_STATUS_CODE = "http.status_code";
+
 # Constant for telemetry tag http.base_url
 const HTTP_BASE_URL = "http.base_url";
 


### PR DESCRIPTION
## Purpose
> Traces  of **ballerina/http/Client** calls are providing only http_status_code_group. The status codes are grouped like '2xx' and '4xx'. 

## Goals
> Add exact status code for traces  of **ballerina/http/Client** calls

## Test environment
> Java 11.0.8 

## Related PRs
> https://github.com/ballerina-platform/ballerina-lang/pull/26692