### PR TITLE
Replace deprecated usage of addMainTag

### DIFF
--- a/http-native/src/main/java/org/ballerinalang/net/http/BallerinaHTTPConnectorListener.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/BallerinaHTTPConnectorListener.java
@@ -106,9 +106,9 @@ public class BallerinaHTTPConnectorListener implements HttpConnectorListener {
             Map<String, String> httpHeaders = new HashMap<>();
             inboundMessage.getHeaders().forEach(entry -> httpHeaders.put(entry.getKey(), entry.getValue()));
             observerContext.addProperty(PROPERTY_TRACE_PROPERTIES, httpHeaders);
-            observerContext.addMainTag(TAG_KEY_HTTP_METHOD, inboundMessage.getHttpMethod());
-            observerContext.addMainTag(TAG_KEY_PROTOCOL, (String) inboundMessage.getProperty(HttpConstants.PROTOCOL));
-            observerContext.addMainTag(TAG_KEY_HTTP_URL, inboundMessage.getRequestUrl());
+            observerContext.addTag(TAG_KEY_HTTP_METHOD, inboundMessage.getHttpMethod());
+            observerContext.addTag(TAG_KEY_PROTOCOL, (String) inboundMessage.getProperty(HttpConstants.PROTOCOL));
+            observerContext.addTag(TAG_KEY_HTTP_URL, inboundMessage.getRequestUrl());
             properties.put(ObservabilityConstants.KEY_OBSERVER_CONTEXT, observerContext);
         }
         Callback callback = new HttpCallableUnitCallback(inboundMessage);

--- a/http-native/src/main/java/org/ballerinalang/net/http/websocket/observability/WebSocketMetricsUtil.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/websocket/observability/WebSocketMetricsUtil.java
@@ -69,7 +69,7 @@ class WebSocketMetricsUtil {
             return;
         }
         //Define type of message (text, binary, control, close)
-        observerContext.addMainTag(WebSocketObservabilityConstants.TAG_MESSAGE_TYPE, type);
+        observerContext.addTag(WebSocketObservabilityConstants.TAG_MESSAGE_TYPE, type);
         //Increment messages received metric
         incrementCounterMetric(observerContext, WebSocketObservabilityConstants.METRIC_MESSAGES_RECEIVED[0],
                                WebSocketObservabilityConstants.METRIC_MESSAGES_RECEIVED[1]);
@@ -87,7 +87,7 @@ class WebSocketMetricsUtil {
         if (!ObserveUtils.isMetricsEnabled()) {
             return;
         }
-        observerContext.addMainTag(WebSocketObservabilityConstants.TAG_RESOURCE, resource);
+        observerContext.addTag(WebSocketObservabilityConstants.TAG_RESOURCE, resource);
         incrementCounterMetric(observerContext, WebSocketObservabilityConstants.METRIC_RESOURCES_INVOKED[0],
                                WebSocketObservabilityConstants.METRIC_RESOURCES_INVOKED[1]);
     }

--- a/http-native/src/main/java/org/ballerinalang/net/http/websocket/observability/WebSocketObserverContext.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/websocket/observability/WebSocketObserverContext.java
@@ -52,13 +52,8 @@ public class WebSocketObserverContext extends ObserverContext {
      */
     public void setTags(WebSocketConnectionInfo connectionInfo) {
         String clientOrServerContext = WebSocketObservabilityUtil.getClientOrServerContext(connectionInfo);
-        if (WebSocketObservabilityConstants.CONTEXT_SERVER.equals(clientOrServerContext)) {
-            addMainTag(WebSocketObservabilityConstants.TAG_CONTEXT, clientOrServerContext);
-            addMainTag(WebSocketObservabilityConstants.TAG_SERVICE, servicePathOrClientUrl);
-        } else {
-            addTag(WebSocketObservabilityConstants.TAG_CONTEXT, clientOrServerContext);
-            addTag(WebSocketObservabilityConstants.TAG_SERVICE, servicePathOrClientUrl);
-        }
+        addTag(WebSocketObservabilityConstants.TAG_CONTEXT, clientOrServerContext);
+        addTag(WebSocketObservabilityConstants.TAG_SERVICE, servicePathOrClientUrl);
     }
 
     String getConnectionId() {


### PR DESCRIPTION
## Purpose
> With the removal of separation of tags in ballerina-platform/ballerina-lang#26578 `addMainTag` had been deprecated. The usages needs to be removed.

## Goals
> Remove usages of deprecated methods in the ObserverContext

## Approach
> `addMainTag` had been changed to `addTag`

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A