### PR TITLE
Fix request payload binding syntax

### DIFF
--- a/http-ballerina-tests/http-tests/http2_generic_test.bal
+++ b/http-ballerina-tests/http-tests/http2_generic_test.bal
@@ -44,7 +44,7 @@ service generalCases on ep {
     }
 }
 
-function handleResponse(http:Response|http:Payload|error result) returns string {
+function handleResponse(http:Response|http:PayloadTypes|error result) returns string {
     string response = "";
     if (result is http:Response) {
         response = "Call succeeded";

--- a/http-ballerina-tests/http-tests/http2_generic_test.bal
+++ b/http-ballerina-tests/http-tests/http2_generic_test.bal
@@ -44,7 +44,7 @@ service generalCases on ep {
     }
 }
 
-function handleResponse(http:Response|http:PayloadTypes|error result) returns string {
+function handleResponse(http:Response|http:PayloadType|error result) returns string {
     string response = "";
     if (result is http:Response) {
         response = "Call succeeded";

--- a/http-ballerina-tests/http-tests/http2_multipart_test.bal
+++ b/http-ballerina-tests/http-tests/http2_multipart_test.bal
@@ -62,7 +62,7 @@ service multipartDemoService on new http:Listener(9100, { httpVersion: "2.0" }) 
         path: "/initial"
     }
     resource function requestInitializer(http:Caller caller, http:Request request) {
-        http:Response|http:Payload|error finalResponse;
+        http:Response|http:PayloadTypes|error finalResponse;
         http:Request req = new;
         if (request.getHeader("priorKnowledge") == "true") {
             req.setHeader("priorKnowledge", "true");
@@ -102,7 +102,7 @@ service multipartDemoService on new http:Listener(9100, { httpVersion: "2.0" }) 
         mime:Entity[] bodyParts = [jsonBodyPart, xmlFilePart, textPart];
         http:Request request = new;
         request.setBodyParts(bodyParts, contentType = mime:MULTIPART_FORM_DATA);
-        http:Response|http:Payload|error returnResponse;
+        http:Response|http:PayloadTypes|error returnResponse;
         if (req.getHeader("priorKnowledge") == "true") {
             returnResponse = priorKnowclientEP1->post("/multiparts/decode", request);
         } else {

--- a/http-ballerina-tests/http-tests/http2_multipart_test.bal
+++ b/http-ballerina-tests/http-tests/http2_multipart_test.bal
@@ -62,7 +62,7 @@ service multipartDemoService on new http:Listener(9100, { httpVersion: "2.0" }) 
         path: "/initial"
     }
     resource function requestInitializer(http:Caller caller, http:Request request) {
-        http:Response|http:PayloadTypes|error finalResponse;
+        http:Response|http:PayloadType|error finalResponse;
         http:Request req = new;
         if (request.getHeader("priorKnowledge") == "true") {
             req.setHeader("priorKnowledge", "true");
@@ -102,7 +102,7 @@ service multipartDemoService on new http:Listener(9100, { httpVersion: "2.0" }) 
         mime:Entity[] bodyParts = [jsonBodyPart, xmlFilePart, textPart];
         http:Request request = new;
         request.setBodyParts(bodyParts, contentType = mime:MULTIPART_FORM_DATA);
-        http:Response|http:PayloadTypes|error returnResponse;
+        http:Response|http:PayloadType|error returnResponse;
         if (req.getHeader("priorKnowledge") == "true") {
             returnResponse = priorKnowclientEP1->post("/multiparts/decode", request);
         } else {

--- a/http-ballerina-tests/tests/http_verbs_passthrough_test.bal
+++ b/http-ballerina-tests/tests/http_verbs_passthrough_test.bal
@@ -104,15 +104,11 @@ service /getQuote on httpVerbListenerEP {
         checkpanic caller->respond(res);
     }
 
-    // @http:ResourceConfig {
-    //     methods:["POST"],
-    //     body:"person"
-    // }
-    // resource function employee (http:Caller caller, http:Request req, json person) {
-    //     http:Response res = new;
-    //     res.setJsonPayload(<@untainted> person);
-    //     checkpanic caller->respond(res);
-    // }
+    resource function post employee (http:Caller caller, http:Request req, @http:Payload json person) {
+        http:Response res = new;
+        res.setJsonPayload(<@untainted> person);
+        checkpanic caller->respond(res);
+    }
 }
 
 //Test simple passthrough test case For HEAD with URL. /sampleHead
@@ -203,29 +199,28 @@ function testForwardActionWithPOST() {
     }
 }
 
-//Test HTTP data binding with JSON payload with URL. /getQuote/employee
-// @test:Config {}
-// function testDataBindingJsonPayload() {
-//     json payload = {name:"WSO2", team:"ballerina"};
-//     var response = httpVerbClient->post("/getQuote/employee", payload);
-//     if (response is http:Response) {
-//         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
-//         assertJsonPayload(response.getJsonPayload(), payload);
-//     } else if (response is error) {
-//         test:assertFail(msg = "Found unexpected output type: " + response.message());
-//     }
-// }
+// Test HTTP data binding with JSON payload with URL. /getQuote/employee
+@test:Config {}
+function testDataBindingJsonPayload() {
+    json payload = {name:"WSO2", team:"ballerina"};
+    var response = httpVerbClient->post("/getQuote/employee", payload);
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertJsonPayload(response.getJsonPayload(), payload);
+    } else if (response is error) {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}
 
-// //Test HTTP data binding with incompatible payload with URL. /getQuote/employee
-// @test:Config {}
-// function testDataBindingWithIncompatiblePayload() {
-//     string payload = "name:WSO2,team:ballerina";
-//     var response = httpVerbClient->post("/getQuote/employee", payload);
-//     if (response is http:Response) {
-//         test:assertEquals(response.statusCode, 400, msg = "Found unexpected output");
-//         assertTrueTextPayload(response.getTextPayload(), "data binding failed: error(\"unrecognized token 'name:WSO2,team:ballerina'");
-//     } else if (response is error) {
-//         test:assertFail(msg = "Found unexpected output type: " + response.message());
-//     }
-// }
-
+//Test HTTP data binding with incompatible payload with URL. /getQuote/employee
+@test:Config {}
+function testDataBindingWithIncompatiblePayload() {
+    string payload = "name:WSO2,team:ballerina";
+    var response = httpVerbClient->post("/getQuote/employee", payload);
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 400, msg = "Found unexpected output");
+        assertTrueTextPayload(response.getTextPayload(), "data binding failed: error(\"unrecognized token 'name:WSO2,team:ballerina'");
+    } else if (response is error) {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}

--- a/http-ballerina-tests/tests/http_verbs_passthrough_test.bal
+++ b/http-ballerina-tests/tests/http_verbs_passthrough_test.bal
@@ -104,7 +104,7 @@ service /getQuote on httpVerbListenerEP {
         checkpanic caller->respond(res);
     }
 
-    resource function post employee (http:Caller caller, http:Request req, @http:Payload json person) {
+    resource function post employee (http:Caller caller, http:Request req, @http:Payload {} json person) {
         http:Response res = new;
         res.setJsonPayload(<@untainted> person);
         checkpanic caller->respond(res);

--- a/http-ballerina-tests/tests/resiliency_unit_circuit_breaker_test.bal
+++ b/http-ballerina-tests/tests/resiliency_unit_circuit_breaker_test.bal
@@ -340,7 +340,7 @@ public client class MockClient {
     }
 
     remote function post(@untainted string path, http:RequestMessage message,
-            http:TargetType targetType = http:Response) returns http:Response|http:Payload|http:ClientError {
+            http:TargetType targetType = http:Response) returns http:Response|http:PayloadTypes|http:ClientError {
         return getUnsupportedError();
     }
 
@@ -351,27 +351,27 @@ public client class MockClient {
     }
 
     remote function put(@untainted string path, http:RequestMessage message,
-            http:TargetType targetType = http:Response) returns http:Response|http:Payload|http:ClientError {
+            http:TargetType targetType = http:Response) returns http:Response|http:PayloadTypes|http:ClientError {
         return getUnsupportedError();
     }
 
     remote function execute(@untainted string httpVerb, @untainted string path, http:RequestMessage message,
-           http:TargetType targetType = http:Response) returns @tainted http:Response|http:Payload|http:ClientError {
+           http:TargetType targetType = http:Response) returns @tainted http:Response|http:PayloadTypes|http:ClientError {
         return getUnsupportedError();
     }
 
     remote function patch(@untainted string path, http:RequestMessage message, http:TargetType targetType = http:Response)
-                                             returns @tainted http:Response|http:Payload|http:ClientError {
+                                             returns @tainted http:Response|http:PayloadTypes|http:ClientError {
         return getUnsupportedError();
     }
 
     remote function delete(@untainted string path, http:RequestMessage message = (),
-          http:TargetType targetType = http:Response) returns @tainted http:Response|http:Payload|http:ClientError {
+          http:TargetType targetType = http:Response) returns @tainted http:Response|http:PayloadTypes|http:ClientError {
         return getUnsupportedError();
     }
 
     remote function get(@untainted string path, http:RequestMessage message = (),
-           http:TargetType targetType = http:Response) returns @tainted http:Response|http:Payload|http:ClientError {
+           http:TargetType targetType = http:Response) returns @tainted http:Response|http:PayloadTypes|http:ClientError {
         http:Request req = buildRequest(message);
         http:Response response = new;
         actualRequestNumber = actualRequestNumber + 1;
@@ -424,13 +424,13 @@ public client class MockClient {
     }
 
     remote function options(@untainted string path, http:RequestMessage message = (),
-           http:TargetType targetType = http:Response) returns @tainted http:Response|http:Payload|http:ClientError {
+           http:TargetType targetType = http:Response) returns @tainted http:Response|http:PayloadTypes|http:ClientError {
         return getUnsupportedError();
     }
 
     remote function forward(@untainted string path, http:Request request, http:TargetType targetType =
     http:Response)
-                                               returns @tainted http:Response|http:Payload|http:ClientError {
+                                               returns @tainted http:Response|http:PayloadTypes|http:ClientError {
         return getUnsupportedError();
     }
 

--- a/http-ballerina-tests/tests/resiliency_unit_circuit_breaker_test.bal
+++ b/http-ballerina-tests/tests/resiliency_unit_circuit_breaker_test.bal
@@ -340,7 +340,7 @@ public client class MockClient {
     }
 
     remote function post(@untainted string path, http:RequestMessage message,
-            http:TargetType targetType = http:Response) returns http:Response|http:PayloadTypes|http:ClientError {
+            http:TargetType targetType = http:Response) returns http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedError();
     }
 
@@ -351,27 +351,27 @@ public client class MockClient {
     }
 
     remote function put(@untainted string path, http:RequestMessage message,
-            http:TargetType targetType = http:Response) returns http:Response|http:PayloadTypes|http:ClientError {
+            http:TargetType targetType = http:Response) returns http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedError();
     }
 
     remote function execute(@untainted string httpVerb, @untainted string path, http:RequestMessage message,
-           http:TargetType targetType = http:Response) returns @tainted http:Response|http:PayloadTypes|http:ClientError {
+           http:TargetType targetType = http:Response) returns @tainted http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedError();
     }
 
     remote function patch(@untainted string path, http:RequestMessage message, http:TargetType targetType = http:Response)
-                                             returns @tainted http:Response|http:PayloadTypes|http:ClientError {
+                                             returns @tainted http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedError();
     }
 
     remote function delete(@untainted string path, http:RequestMessage message = (),
-          http:TargetType targetType = http:Response) returns @tainted http:Response|http:PayloadTypes|http:ClientError {
+          http:TargetType targetType = http:Response) returns @tainted http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedError();
     }
 
     remote function get(@untainted string path, http:RequestMessage message = (),
-           http:TargetType targetType = http:Response) returns @tainted http:Response|http:PayloadTypes|http:ClientError {
+           http:TargetType targetType = http:Response) returns @tainted http:Response|http:PayloadType|http:ClientError {
         http:Request req = buildRequest(message);
         http:Response response = new;
         actualRequestNumber = actualRequestNumber + 1;
@@ -424,13 +424,13 @@ public client class MockClient {
     }
 
     remote function options(@untainted string path, http:RequestMessage message = (),
-           http:TargetType targetType = http:Response) returns @tainted http:Response|http:PayloadTypes|http:ClientError {
+           http:TargetType targetType = http:Response) returns @tainted http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedError();
     }
 
     remote function forward(@untainted string path, http:Request request, http:TargetType targetType =
     http:Response)
-                                               returns @tainted http:Response|http:PayloadTypes|http:ClientError {
+                                               returns @tainted http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedError();
     }
 

--- a/http-ballerina-tests/tests/resiliency_unit_failover_connector_test.bal
+++ b/http-ballerina-tests/tests/resiliency_unit_failover_connector_test.bal
@@ -121,7 +121,7 @@ public client class FoMockClient {
 
     remote function post(string path,
                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message,
-                           http:TargetType targetType = http:Response) returns http:Response|http:PayloadTypes|http:ClientError {
+                           http:TargetType targetType = http:Response) returns http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedFOError();
     }
 
@@ -131,32 +131,32 @@ public client class FoMockClient {
     }
 
     remote function put(string path, http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|()
-            message, http:TargetType targetType = http:Response) returns http:Response|http:PayloadTypes|http:ClientError
+            message, http:TargetType targetType = http:Response) returns http:Response|http:PayloadType|http:ClientError
              {
         return getUnsupportedFOError();
     }
 
     remote function execute(string httpVerb, string path,
                                    http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|()
-                                        message, http:TargetType targetType = http:Response) returns http:Response|http:PayloadTypes|http:ClientError {
+                                        message, http:TargetType targetType = http:Response) returns http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedFOError();
     }
 
     remote function patch(string path,
                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message, http:TargetType targetType = http:Response)
-                                                                                returns http:Response|http:PayloadTypes|http:ClientError {
+                                                                                returns http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedFOError();
     }
 
     remote function delete(string path,
                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message, http:TargetType targetType = http:Response)
-                                                                                returns http:Response|http:PayloadTypes|http:ClientError {
+                                                                                returns http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedFOError();
     }
 
     remote function get(string path,
                             http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message, http:TargetType targetType = http:Response)
-                                                                                returns http:Response|http:PayloadTypes|http:ClientError {
+                                                                                returns http:Response|http:PayloadType|http:ClientError {
         http:Response response = new;
         var result = handleFailoverScenario(counter);
         if (result is http:Response) {
@@ -171,11 +171,11 @@ public client class FoMockClient {
 
     remote function options(string path,
            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message = (), http:TargetType targetType = http:Response)
-                                                                                returns http:Response|http:PayloadTypes|http:ClientError {
+                                                                                returns http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedFOError();
     }
 
-    remote function forward(string path, http:Request req, http:TargetType targetType = http:Response) returns http:Response|http:PayloadTypes|http:ClientError {
+    remote function forward(string path, http:Request req, http:TargetType targetType = http:Response) returns http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedFOError();
     }
 

--- a/http-ballerina-tests/tests/resiliency_unit_failover_connector_test.bal
+++ b/http-ballerina-tests/tests/resiliency_unit_failover_connector_test.bal
@@ -121,7 +121,7 @@ public client class FoMockClient {
 
     remote function post(string path,
                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message,
-                           http:TargetType targetType = http:Response) returns http:Response|http:Payload|http:ClientError {
+                           http:TargetType targetType = http:Response) returns http:Response|http:PayloadTypes|http:ClientError {
         return getUnsupportedFOError();
     }
 
@@ -131,32 +131,32 @@ public client class FoMockClient {
     }
 
     remote function put(string path, http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|()
-            message, http:TargetType targetType = http:Response) returns http:Response|http:Payload|http:ClientError
+            message, http:TargetType targetType = http:Response) returns http:Response|http:PayloadTypes|http:ClientError
              {
         return getUnsupportedFOError();
     }
 
     remote function execute(string httpVerb, string path,
                                    http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|()
-                                        message, http:TargetType targetType = http:Response) returns http:Response|http:Payload|http:ClientError {
+                                        message, http:TargetType targetType = http:Response) returns http:Response|http:PayloadTypes|http:ClientError {
         return getUnsupportedFOError();
     }
 
     remote function patch(string path,
                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message, http:TargetType targetType = http:Response)
-                                                                                returns http:Response|http:Payload|http:ClientError {
+                                                                                returns http:Response|http:PayloadTypes|http:ClientError {
         return getUnsupportedFOError();
     }
 
     remote function delete(string path,
                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message, http:TargetType targetType = http:Response)
-                                                                                returns http:Response|http:Payload|http:ClientError {
+                                                                                returns http:Response|http:PayloadTypes|http:ClientError {
         return getUnsupportedFOError();
     }
 
     remote function get(string path,
                             http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message, http:TargetType targetType = http:Response)
-                                                                                returns http:Response|http:Payload|http:ClientError {
+                                                                                returns http:Response|http:PayloadTypes|http:ClientError {
         http:Response response = new;
         var result = handleFailoverScenario(counter);
         if (result is http:Response) {
@@ -171,11 +171,11 @@ public client class FoMockClient {
 
     remote function options(string path,
            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message = (), http:TargetType targetType = http:Response)
-                                                                                returns http:Response|http:Payload|http:ClientError {
+                                                                                returns http:Response|http:PayloadTypes|http:ClientError {
         return getUnsupportedFOError();
     }
 
-    remote function forward(string path, http:Request req, http:TargetType targetType = http:Response) returns http:Response|http:Payload|http:ClientError {
+    remote function forward(string path, http:Request req, http:TargetType targetType = http:Response) returns http:Response|http:PayloadTypes|http:ClientError {
         return getUnsupportedFOError();
     }
 

--- a/http-ballerina-tests/tests/service_dispatching_data_binding_test.bal
+++ b/http-ballerina-tests/tests/service_dispatching_data_binding_test.bal
@@ -35,17 +35,17 @@ type Stock record {|
 
 service /echo on dataBindingEP {
 
-    resource function 'default body1(http:Caller caller, @http:Payload string person, http:Request req) {
+    resource function 'default body1(http:Caller caller, @http:Payload {} string person, http:Request req) {
         json responseJson = { "Person": person };
         checkpanic caller->respond(<@untainted json> responseJson);
     }
 
-    resource function post body2/[string key](@http:Payload string person, http:Caller caller) {
+    resource function post body2/[string key](@http:Payload {mediaType:"text/plain"} string person, http:Caller caller) {
         json responseJson = { Key: key, Person: person };
         checkpanic caller->respond(<@untainted json> responseJson);
     }
 
-    resource function 'default body3(http:Caller caller, http:Request req, @http:Payload json person) {
+    resource function 'default body3(http:Caller caller, @http:Payload {mediaType:["text/plain"]} json person) {
         json|error val1 = person.name;
         json|error val2 = person.team;
         json name = val1 is json ? val1 : ();
@@ -53,14 +53,14 @@ service /echo on dataBindingEP {
         checkpanic caller->respond(<@untainted> { Key: name, Team: team });
     }
 
-    resource function post body4(@http:Payload @tainted xml person, http:Caller caller, http:Request req) {
+    resource function post body4(@http:Payload {} @tainted xml person, http:Caller caller, http:Request req) {
         xmllib:Element elem = <xmllib:Element> person;
         string name = <@untainted string> elem.getName();
         string team = <@untainted string> (person/*).toString();
         checkpanic caller->respond({ Key: name, Team: team });
     }
 
-    resource function post body5(http:Caller caller, @tainted @http:Payload byte[] person) {
+    resource function post body5(http:Caller caller, @tainted @http:Payload {} byte[] person) {
         http:Response res = new;
         var name = <@untainted> strings:fromBytes(person);
         if (name is string) {
@@ -72,17 +72,17 @@ service /echo on dataBindingEP {
         checkpanic caller->respond(res);
     }
 
-    resource function post body6(http:Caller caller, http:Request req, @http:Payload Person person) {
+    resource function post body6(http:Caller caller, http:Request req, @http:Payload {} Person person) {
         string name = <@untainted string> person.name;
         int age = <@untainted int> person.age;
         checkpanic caller->respond({ Key: name, Age: age });
     }
 
-    resource function post body7(http:Caller caller, http:Request req, @http:Payload Stock person) {
+    resource function post body7(http:Caller caller, http:Request req, @http:Payload {} Stock person) {
         checkpanic caller->respond();
     }
 
-    resource function post body8(http:Caller caller, @http:Payload Person[] persons) {
+    resource function post body8(http:Caller caller, @http:Payload {} Person[] persons) {
         var jsonPayload = persons.cloneWithType(json);
         if (jsonPayload is json) {
             checkpanic caller->respond(<@untainted json> jsonPayload);
@@ -109,13 +109,13 @@ service /echo on dataBindingEP {
 }
 
 http:Service multipleAnnot1 = service object {
-    resource function get annot(@http:Payload @http:CallerInfo string payload) {
+    resource function get annot(@http:Payload {} @http:CallerInfo string payload) {
         //...
     }
 };
 
 http:Service multipleAnnot2 = service object {
-    resource function get annot(@http:Payload string payload1, @http:Payload string payload2) {
+    resource function get annot(@http:Payload {} string payload1, @http:Payload {} string payload2) {
         //...
     }
 };

--- a/http-ballerina-tests/tests/service_dispatching_data_binding_test.bal
+++ b/http-ballerina-tests/tests/service_dispatching_data_binding_test.bal
@@ -109,7 +109,7 @@ service /echo on dataBindingEP {
 }
 
 http:Service multipleAnnot1 = service object {
-    resource function get annot(@http:Payload {} @http:CallerInfo string payload) {
+    resource function get annot(@http:Payload {} @http:CallerInfo {} string payload) {
         //...
     }
 };

--- a/http-ballerina-tests/tests/service_dispatching_data_binding_test.bal
+++ b/http-ballerina-tests/tests/service_dispatching_data_binding_test.bal
@@ -33,31 +33,19 @@ type Stock record {|
     float price;
 |};
 
-service echo on dataBindingEP {
+service /echo on dataBindingEP {
 
-    @http:ResourceConfig {
-        body: "person"
-    }
-    resource function body1(http:Caller caller, http:Request req, string person) {
+    resource function 'default body1(http:Caller caller, @http:Payload string person, http:Request req) {
         json responseJson = { "Person": person };
         checkpanic caller->respond(<@untainted json> responseJson);
     }
 
-    @http:ResourceConfig {
-        methods: ["POST"],
-        path: "/body2/{key}",
-        body: "person"
-    }
-    resource function body2(http:Caller caller, http:Request req, string key, string person) {
+    resource function post body2/[string key](@http:Payload string person, http:Caller caller) {
         json responseJson = { Key: key, Person: person };
         checkpanic caller->respond(<@untainted json> responseJson);
     }
 
-    @http:ResourceConfig {
-        methods: ["GET", "POST"],
-        body: "person"
-    }
-    resource function body3(http:Caller caller, http:Request req, json person) {
+    resource function 'default body3(http:Caller caller, http:Request req, @http:Payload json person) {
         json|error val1 = person.name;
         json|error val2 = person.team;
         json name = val1 is json ? val1 : ();
@@ -65,22 +53,14 @@ service echo on dataBindingEP {
         checkpanic caller->respond(<@untainted> { Key: name, Team: team });
     }
 
-    @http:ResourceConfig {
-        methods: ["POST"],
-        body: "person"
-    }
-    resource function body4(http:Caller caller, http:Request req, xml person) {
+    resource function post body4(@http:Payload xml person, http:Caller caller, http:Request req) {
         xmllib:Element elem = <xmllib:Element> person;
         string name = <@untainted string> elem.getName();
         string team = <@untainted string> (person/*).toString();
         checkpanic caller->respond({ Key: name, Team: team });
     }
 
-    @http:ResourceConfig {
-        methods: ["POST"],
-        body: "person"
-    }
-    resource function body5(http:Caller caller, http:Request req, byte[] person) {
+    resource function post body5(http:Caller caller, @http:Payload byte[] person) {
         http:Response res = new;
         var name = <@untainted> strings:fromBytes(person);
         if (name is string) {
@@ -92,29 +72,17 @@ service echo on dataBindingEP {
         checkpanic caller->respond(res);
     }
 
-    @http:ResourceConfig {
-        methods: ["POST"],
-        body: "person"
-    }
-    resource function body6(http:Caller caller, http:Request req, Person person) {
+    resource function post body6(http:Caller caller, http:Request req, @http:Payload Person person) {
         string name = <@untainted string> person.name;
         int age = <@untainted int> person.age;
         checkpanic caller->respond({ Key: name, Age: age });
     }
 
-    @http:ResourceConfig {
-        methods: ["POST"],
-        body: "person"
-    }
-    resource function body7(http:Caller caller, http:Request req, Stock person) {
+    resource function post body7(http:Caller caller, http:Request req, @http:Payload Stock person) {
         checkpanic caller->respond();
     }
 
-    @http:ResourceConfig {
-        methods: ["POST"],
-        body: "persons"
-    }
-    resource function body8(http:Caller caller, http:Request req, Person[] persons) {
+    resource function post body8(http:Caller caller, @http:Payload Person[] persons) {
         var jsonPayload = persons.cloneWithType(json);
         if (jsonPayload is json) {
             checkpanic caller->respond(<@untainted json> jsonPayload);

--- a/http-ballerina-tests/tests/service_dispatching_uri_template_matching.bal
+++ b/http-ballerina-tests/tests/service_dispatching_uri_template_matching.bal
@@ -369,6 +369,15 @@ service /encodedUri on utmTestEP {
     }
 }
 
+service /restParam on utmTestEP {
+    resource function 'default test/[int... aaa](http:Caller caller) {
+        http:Response res = new;
+        json responseJson = {aaa:aaa};
+        res.setJsonPayload(<@untainted json> responseJson);
+        checkpanic caller->respond(res);
+    }
+}
+
 //Test dispatching with URL. /hello/world/echo2?regid=abc
 @test:Config {}
 function testMostSpecificMatchWithQueryParam() {
@@ -978,6 +987,23 @@ function testEncodedPathParams() {
     if (response is http:Response) {
         assertJsonValue(response.getJsonPayload(), "xxx", "123");
         assertJsonValue(response.getJsonPayload(), "yyy", "456");
+    } else if (response is error) {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}
+
+@test:Config {}
+function testMultipleTypedRestParams() {
+    var response = utmClient->get("/restParam/test/345/234/123");
+    if (response is http:Response) {
+        assertJsonValue(response.getJsonPayload(), "aaa", "1/1");
+    } else if (response is error) {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+
+    response = utmClient->get("/restParam/test/12.3/4.56");
+    if (response is http:Response) {
+        assertJsonValue(response.getJsonPayload(), "aaa", "1/1");
     } else if (response is error) {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }

--- a/http-ballerina/caching_http_caching_client.bal
+++ b/http-ballerina/caching_http_caching_client.bal
@@ -62,7 +62,7 @@ public client class HttpCachingClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(string path, RequestMessage message, TargetType targetType = Response)
-            returns Response|Payload|ClientError {
+            returns Response|PayloadTypes|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -98,7 +98,7 @@ public client class HttpCachingClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -121,7 +121,7 @@ public client class HttpCachingClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(string httpMethod, string path, RequestMessage message,
-            TargetType targetType = Response) returns @tainted Response|Payload|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
         Request request = <Request>message;
         setRequestCacheControlHeader(request);
 
@@ -148,7 +148,7 @@ public client class HttpCachingClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -170,7 +170,7 @@ public client class HttpCachingClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -192,7 +192,7 @@ public client class HttpCachingClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
         return getCachedResponse(self.cache, self.httpClient, req, HTTP_GET, path, self.cacheConfig.isShared, false);
@@ -209,7 +209,7 @@ public client class HttpCachingClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -230,7 +230,7 @@ public client class HttpCachingClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(string path, @tainted Request request, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         if (request.method == HTTP_GET || request.method == HTTP_HEAD) {
             return getCachedResponse(self.cache, self.httpClient, request, request.method, path,
                                      self.cacheConfig.isShared, true);
@@ -371,7 +371,7 @@ function getCachedResponse(HttpCache cache, HttpClient httpClient, @tainted Requ
             cache.put(<@untainted> getCacheKey(httpMethod, path), <@untainted> req.cacheControl, <@untainted> response);
         }
         return response;
-    } else if (response is Payload) {
+    } else if (response is PayloadTypes) {
         panic getIllegalDataBindingStateError();
     } else {
         return response;
@@ -402,7 +402,7 @@ isolated function invalidateResponses(HttpCache httpCache, Response inboundRespo
 }
 
 function sendNewRequest(HttpClient httpClient, Request request, string path, string httpMethod, boolean forwardRequest)
-                                                                returns @tainted Response|Payload|ClientError {
+                                                                returns @tainted Response|PayloadTypes|ClientError {
     if (forwardRequest) {
         return httpClient->forward(path, request);
     }

--- a/http-ballerina/caching_http_caching_client.bal
+++ b/http-ballerina/caching_http_caching_client.bal
@@ -62,7 +62,7 @@ public client class HttpCachingClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(string path, RequestMessage message, TargetType targetType = Response)
-            returns Response|PayloadTypes|ClientError {
+            returns Response|PayloadType|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -98,7 +98,7 @@ public client class HttpCachingClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -121,7 +121,7 @@ public client class HttpCachingClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(string httpMethod, string path, RequestMessage message,
-            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadType|ClientError {
         Request request = <Request>message;
         setRequestCacheControlHeader(request);
 
@@ -148,7 +148,7 @@ public client class HttpCachingClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -170,7 +170,7 @@ public client class HttpCachingClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -192,7 +192,7 @@ public client class HttpCachingClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
         return getCachedResponse(self.cache, self.httpClient, req, HTTP_GET, path, self.cacheConfig.isShared, false);
@@ -209,7 +209,7 @@ public client class HttpCachingClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = <Request>message;
         setRequestCacheControlHeader(req);
 
@@ -230,7 +230,7 @@ public client class HttpCachingClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(string path, @tainted Request request, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         if (request.method == HTTP_GET || request.method == HTTP_HEAD) {
             return getCachedResponse(self.cache, self.httpClient, request, request.method, path,
                                      self.cacheConfig.isShared, true);
@@ -371,7 +371,7 @@ function getCachedResponse(HttpCache cache, HttpClient httpClient, @tainted Requ
             cache.put(<@untainted> getCacheKey(httpMethod, path), <@untainted> req.cacheControl, <@untainted> response);
         }
         return response;
-    } else if (response is PayloadTypes) {
+    } else if (response is PayloadType) {
         panic getIllegalDataBindingStateError();
     } else {
         return response;
@@ -402,7 +402,7 @@ isolated function invalidateResponses(HttpCache httpCache, Response inboundRespo
 }
 
 function sendNewRequest(HttpClient httpClient, Request request, string path, string httpMethod, boolean forwardRequest)
-                                                                returns @tainted Response|PayloadTypes|ClientError {
+                                                                returns @tainted Response|PayloadType|ClientError {
     if (forwardRequest) {
         return httpClient->forward(path, request);
     }

--- a/http-ballerina/cookie_http_client.bal
+++ b/http-ballerina/cookie_http_client.bal
@@ -57,7 +57,7 @@ public client class CookieClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->get(path, message = request);
@@ -75,7 +75,7 @@ public client class CookieClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(string path, RequestMessage message, TargetType targetType = Response)
-            returns Response|Payload|ClientError {
+            returns Response|PayloadTypes|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->post(path, request);
@@ -113,7 +113,7 @@ public client class CookieClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->put(path, request);
@@ -130,7 +130,7 @@ public client class CookieClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(string path, Request request, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->forward(path, request);
         return addCookiesInResponseToStore(inboundResponse, self.cookieStore, self.cookieConfig, self.url, path);
@@ -148,7 +148,7 @@ public client class CookieClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(string httpVerb, string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->execute(httpVerb, path, request);
@@ -166,7 +166,7 @@ public client class CookieClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse =  self.httpClient->patch(path, request);
@@ -184,7 +184,7 @@ public client class CookieClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse =  self.httpClient->delete(path, request);
@@ -202,7 +202,7 @@ public client class CookieClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse =  self.httpClient->options(path, message = request);
@@ -277,8 +277,8 @@ function addStoredCookiesToRequest(string url, string path, CookieStore? cookieS
 }
 
 // Gets the cookies from the inbound response, adds them to the cookies store, and returns the response.
-function addCookiesInResponseToStore(Response|Payload|ClientError inboundResponse, @tainted CookieStore?
-        cookieStore, CookieConfig cookieConfig, string url, string path) returns Response|Payload|ClientError {
+function addCookiesInResponseToStore(Response|PayloadTypes|ClientError inboundResponse, @tainted CookieStore?
+        cookieStore, CookieConfig cookieConfig, string url, string path) returns Response|PayloadTypes|ClientError {
     if (cookieStore is CookieStore && inboundResponse is Response) {
         Cookie[] cookiesInResponse = inboundResponse.getCookies();
         cookieStore.addCookies(cookiesInResponse, cookieConfig, url, path );

--- a/http-ballerina/cookie_http_client.bal
+++ b/http-ballerina/cookie_http_client.bal
@@ -57,7 +57,7 @@ public client class CookieClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->get(path, message = request);
@@ -75,7 +75,7 @@ public client class CookieClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(string path, RequestMessage message, TargetType targetType = Response)
-            returns Response|PayloadTypes|ClientError {
+            returns Response|PayloadType|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->post(path, request);
@@ -113,7 +113,7 @@ public client class CookieClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->put(path, request);
@@ -130,7 +130,7 @@ public client class CookieClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(string path, Request request, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->forward(path, request);
         return addCookiesInResponseToStore(inboundResponse, self.cookieStore, self.cookieConfig, self.url, path);
@@ -148,7 +148,7 @@ public client class CookieClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(string httpVerb, string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse = self.httpClient->execute(httpVerb, path, request);
@@ -166,7 +166,7 @@ public client class CookieClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse =  self.httpClient->patch(path, request);
@@ -184,7 +184,7 @@ public client class CookieClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse =  self.httpClient->delete(path, request);
@@ -202,7 +202,7 @@ public client class CookieClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request request = <Request>message;
         addStoredCookiesToRequest(self.url, path, self.cookieStore, request);
         var inboundResponse =  self.httpClient->options(path, message = request);
@@ -277,8 +277,8 @@ function addStoredCookiesToRequest(string url, string path, CookieStore? cookieS
 }
 
 // Gets the cookies from the inbound response, adds them to the cookies store, and returns the response.
-function addCookiesInResponseToStore(Response|PayloadTypes|ClientError inboundResponse, @tainted CookieStore?
-        cookieStore, CookieConfig cookieConfig, string url, string path) returns Response|PayloadTypes|ClientError {
+function addCookiesInResponseToStore(Response|PayloadType|ClientError inboundResponse, @tainted CookieStore?
+        cookieStore, CookieConfig cookieConfig, string url, string path) returns Response|PayloadType|ClientError {
     if (cookieStore is CookieStore && inboundResponse is Response) {
         Cookie[] cookiesInResponse = inboundResponse.getCookies();
         cookieStore.addCookies(cookiesInResponse, cookieConfig, url, path );

--- a/http-ballerina/http_annotation.bal
+++ b/http-ballerina/http_annotation.bal
@@ -160,11 +160,8 @@ public type HttpPayload record {|
 public annotation HttpPayload Payload on parameter;
 
 # Configures the typing details type of the Caller resource signature parameter.
-#
-# + respondType - Specifies the allowed media types of the corresponding payload type
-public type CallerInfo record {|
-    string respondType;
+public type HttpCallerInfo record {|
 |};
 
-# The annotation which is used to configure the Caller resource signature parameter.
-public annotation CallerInfo on parameter;
+# The annotation which is used to configure the type of the response.
+public annotation HttpCallerInfo CallerInfo on parameter;

--- a/http-ballerina/http_annotation.bal
+++ b/http-ballerina/http_annotation.bal
@@ -152,12 +152,12 @@ annotation HttpParamOrderConfig ParamOrderConfig on object function;
 # Defines the Payload resource signature parameter and return parameter.
 #
 # + mediaType - Specifies the allowed media types of the corresponding payload type
-public type Payload record {|
-    string[] mediaType = [];
+public type HttpPayload record {|
+    string|string[] mediaType = "";
 |};
 
 # The annotation which is used to define the Payload resource signature parameter and return parameter.
-public annotation Payload on parameter;
+public annotation HttpPayload Payload on parameter;
 
 # Configures the typing details type of the Caller resource signature parameter.
 #

--- a/http-ballerina/http_annotation.bal
+++ b/http-ballerina/http_annotation.bal
@@ -150,7 +150,7 @@ type HttpParamOrderConfig record {|
 annotation HttpParamOrderConfig ParamOrderConfig on object function;
 
 public type PayloadParam record {|
-    string mediaType;
+    string[] mediaType;
 |};
 
 # The annotation which is used to define the entity body parameter.

--- a/http-ballerina/http_annotation.bal
+++ b/http-ballerina/http_annotation.bal
@@ -149,9 +149,22 @@ type HttpParamOrderConfig record {|
 //# The annotation which is used to configure an path param order.
 annotation HttpParamOrderConfig ParamOrderConfig on object function;
 
-public type PayloadParam record {|
-    string[] mediaType;
+# Defines the Payload resource signature parameter and return parameter.
+#
+# + mediaType - Specifies the allowed media types of the corresponding payload type
+public type Payload record {|
+    string[] mediaType = [];
 |};
 
-# The annotation which is used to define the entity body parameter.
-public annotation PayloadParam on parameter;
+# The annotation which is used to define the Payload resource signature parameter and return parameter.
+public annotation Payload on parameter;
+
+# Configures the typing details type of the Caller resource signature parameter.
+#
+# + respondType - Specifies the allowed media types of the corresponding payload type
+public type CallerInfo record {|
+    string respondType;
+|};
+
+# The annotation which is used to configure the Caller resource signature parameter.
+public annotation CallerInfo on parameter;

--- a/http-ballerina/http_client.bal
+++ b/http-ballerina/http_client.bal
@@ -48,7 +48,7 @@ public client class HttpClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(@untainted string path, RequestMessage message, TargetType targetType = Response)
-                returns Response|PayloadTypes|ClientError {
+                returns Response|PayloadType|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_POST);
     }
 
@@ -73,7 +73,7 @@ public client class HttpClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(@untainted string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_PUT);
     }
 
@@ -88,7 +88,7 @@ public client class HttpClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(@untainted string httpVerb, @untainted string path, RequestMessage message,
-            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadType|ClientError {
         return externExecute(self, httpVerb, path, <Request>message);
     }
 
@@ -102,7 +102,7 @@ public client class HttpClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(@untainted string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_PATCH);
     }
 
@@ -116,7 +116,7 @@ public client class HttpClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(@untainted string path, RequestMessage message = (),
-            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadType|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_DELETE);
     }
 
@@ -130,7 +130,7 @@ public client class HttpClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(@untainted string path, RequestMessage message = (),
-            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadType|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_GET);
     }
 
@@ -144,7 +144,7 @@ public client class HttpClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(@untainted string path, RequestMessage message = (),
-            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadType|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_OPTIONS);
     }
 
@@ -157,7 +157,7 @@ public client class HttpClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(@untainted string path, Request request, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         return externForward(self, path, request);
     }
 

--- a/http-ballerina/http_client.bal
+++ b/http-ballerina/http_client.bal
@@ -48,7 +48,7 @@ public client class HttpClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(@untainted string path, RequestMessage message, TargetType targetType = Response)
-                returns Response|Payload|ClientError {
+                returns Response|PayloadTypes|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_POST);
     }
 
@@ -73,7 +73,7 @@ public client class HttpClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(@untainted string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_PUT);
     }
 
@@ -88,7 +88,7 @@ public client class HttpClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(@untainted string httpVerb, @untainted string path, RequestMessage message,
-            TargetType targetType = Response) returns @tainted Response|Payload|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
         return externExecute(self, httpVerb, path, <Request>message);
     }
 
@@ -102,7 +102,7 @@ public client class HttpClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(@untainted string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_PATCH);
     }
 
@@ -116,7 +116,7 @@ public client class HttpClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(@untainted string path, RequestMessage message = (),
-            TargetType targetType = Response) returns @tainted Response|Payload|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_DELETE);
     }
 
@@ -130,7 +130,7 @@ public client class HttpClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(@untainted string path, RequestMessage message = (),
-            TargetType targetType = Response) returns @tainted Response|Payload|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_GET);
     }
 
@@ -144,7 +144,7 @@ public client class HttpClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(@untainted string path, RequestMessage message = (),
-            TargetType targetType = Response) returns @tainted Response|Payload|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
         return externExecuteClientAction(self, path, <Request>message, HTTP_OPTIONS);
     }
 
@@ -157,7 +157,7 @@ public client class HttpClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(@untainted string path, Request request, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         return externForward(self, path, request);
     }
 

--- a/http-ballerina/http_client_endpoint.bal
+++ b/http-ballerina/http_client_endpoint.bal
@@ -72,11 +72,11 @@ public client class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(@untainted string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         // TODO improve signature once issue https://github.com/ballerina-platform/ballerina-spec/issues/386 is resolved
         // Dependently typed function signature support for ballerina function is required.
         Request req = buildRequest(message);
-        Response|PayloadTypes|ClientError response = self.httpClient->post(path, req);
+        Response|PayloadType|ClientError response = self.httpClient->post(path, req);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, HTTP_POST, response.statusCode, self.url);
         }
@@ -109,9 +109,9 @@ public client class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(@untainted string path, RequestMessage message, TargetType targetType = Response) 
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
-        Response|PayloadTypes|ClientError response = self.httpClient->put(path, req);
+        Response|PayloadType|ClientError response = self.httpClient->put(path, req);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, HTTP_PUT, response.statusCode, self.url);
         }
@@ -129,9 +129,9 @@ public client class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(@untainted string httpVerb, @untainted string path, RequestMessage message,
-            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
-        Response|PayloadTypes|ClientError response = self.httpClient->execute(httpVerb, path, req);
+        Response|PayloadType|ClientError response = self.httpClient->execute(httpVerb, path, req);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, httpVerb, response.statusCode, self.url);
         }
@@ -148,9 +148,9 @@ public client class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(@untainted string path, RequestMessage message, TargetType targetType = Response) 
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
-        Response|PayloadTypes|ClientError response = self.httpClient->patch(path, req);
+        Response|PayloadType|ClientError response = self.httpClient->patch(path, req);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, HTTP_PATCH, response.statusCode, self.url);
         }
@@ -167,9 +167,9 @@ public client class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(@untainted string path, RequestMessage message = (), 
-            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
-        Response|PayloadTypes|ClientError response = self.httpClient->delete(path, req);
+        Response|PayloadType|ClientError response = self.httpClient->delete(path, req);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, HTTP_DELETE, response.statusCode, self.url);
         }
@@ -186,9 +186,9 @@ public client class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(@untainted string path, RequestMessage message = (),
-            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
-        Response|PayloadTypes|ClientError response = self.httpClient->get(path, message = req);
+        Response|PayloadType|ClientError response = self.httpClient->get(path, message = req);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, HTTP_GET, response.statusCode, self.url);
         }
@@ -205,9 +205,9 @@ public client class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(@untainted string path, RequestMessage message = (),
-            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
-        Response|PayloadTypes|ClientError response = self.httpClient->options(path, message = req);
+        Response|PayloadType|ClientError response = self.httpClient->options(path, message = req);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, HTTP_OPTIONS, response.statusCode, self.url);
         }
@@ -223,8 +223,8 @@ public client class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(@untainted string path, Request request,
-            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
-        Response|PayloadTypes|ClientError response = self.httpClient->forward(path, request);
+            TargetType targetType = Response) returns @tainted Response|PayloadType|ClientError {
+        Response|PayloadType|ClientError response = self.httpClient->forward(path, request);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, request.method, response.statusCode, self.url);
         }
@@ -617,8 +617,8 @@ function createDefaultClient(string url, ClientConfiguration configuration) retu
     return createHttpSecureClient(url, configuration);
 }
 
-function processResponse(Response|PayloadTypes|ClientError result, TargetType targetType) returns @tainted
-        Response|PayloadTypes|ClientError {
+function processResponse(Response|PayloadType|ClientError result, TargetType targetType) returns @tainted
+        Response|PayloadType|ClientError {
     if (targetType is typedesc<Response> || result is ClientError) {
         return result;
     }
@@ -637,7 +637,7 @@ function processResponse(Response|PayloadTypes|ClientError result, TargetType ta
     return performDataBinding(response, targetType);
 }
 
-function performDataBinding(Response response, TargetType targetType) returns @tainted PayloadTypes|ClientError {
+function performDataBinding(Response response, TargetType targetType) returns @tainted PayloadType|ClientError {
     if (targetType is typedesc<string>) {
         return response.getTextPayload();
     } else if (targetType is typedesc<xml>) {

--- a/http-ballerina/http_client_endpoint.bal
+++ b/http-ballerina/http_client_endpoint.bal
@@ -72,11 +72,11 @@ public client class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(@untainted string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         // TODO improve signature once issue https://github.com/ballerina-platform/ballerina-spec/issues/386 is resolved
         // Dependently typed function signature support for ballerina function is required.
         Request req = buildRequest(message);
-        Response|Payload|ClientError response = self.httpClient->post(path, req);
+        Response|PayloadTypes|ClientError response = self.httpClient->post(path, req);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, HTTP_POST, response.statusCode, self.url);
         }
@@ -109,9 +109,9 @@ public client class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(@untainted string path, RequestMessage message, TargetType targetType = Response) 
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
-        Response|Payload|ClientError response = self.httpClient->put(path, req);
+        Response|PayloadTypes|ClientError response = self.httpClient->put(path, req);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, HTTP_PUT, response.statusCode, self.url);
         }
@@ -129,9 +129,9 @@ public client class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(@untainted string httpVerb, @untainted string path, RequestMessage message,
-            TargetType targetType = Response) returns @tainted Response|Payload|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
-        Response|Payload|ClientError response = self.httpClient->execute(httpVerb, path, req);
+        Response|PayloadTypes|ClientError response = self.httpClient->execute(httpVerb, path, req);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, httpVerb, response.statusCode, self.url);
         }
@@ -148,9 +148,9 @@ public client class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(@untainted string path, RequestMessage message, TargetType targetType = Response) 
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
-        Response|Payload|ClientError response = self.httpClient->patch(path, req);
+        Response|PayloadTypes|ClientError response = self.httpClient->patch(path, req);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, HTTP_PATCH, response.statusCode, self.url);
         }
@@ -167,9 +167,9 @@ public client class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(@untainted string path, RequestMessage message = (), 
-            TargetType targetType = Response) returns @tainted Response|Payload|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
-        Response|Payload|ClientError response = self.httpClient->delete(path, req);
+        Response|PayloadTypes|ClientError response = self.httpClient->delete(path, req);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, HTTP_DELETE, response.statusCode, self.url);
         }
@@ -186,9 +186,9 @@ public client class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(@untainted string path, RequestMessage message = (),
-            TargetType targetType = Response) returns @tainted Response|Payload|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
-        Response|Payload|ClientError response = self.httpClient->get(path, message = req);
+        Response|PayloadTypes|ClientError response = self.httpClient->get(path, message = req);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, HTTP_GET, response.statusCode, self.url);
         }
@@ -205,9 +205,9 @@ public client class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(@untainted string path, RequestMessage message = (),
-            TargetType targetType = Response) returns @tainted Response|Payload|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
-        Response|Payload|ClientError response = self.httpClient->options(path, message = req);
+        Response|PayloadTypes|ClientError response = self.httpClient->options(path, message = req);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, HTTP_OPTIONS, response.statusCode, self.url);
         }
@@ -223,8 +223,8 @@ public client class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(@untainted string path, Request request,
-            TargetType targetType = Response) returns @tainted Response|Payload|ClientError {
-        Response|Payload|ClientError response = self.httpClient->forward(path, request);
+            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
+        Response|PayloadTypes|ClientError response = self.httpClient->forward(path, request);
         if (observabilityEnabled && response is Response) {
             addObservabilityInformation(path, request.method, response.statusCode, self.url);
         }
@@ -617,8 +617,8 @@ function createDefaultClient(string url, ClientConfiguration configuration) retu
     return createHttpSecureClient(url, configuration);
 }
 
-function processResponse(Response|Payload|ClientError result, TargetType targetType) returns @tainted
-        Response|Payload|ClientError {
+function processResponse(Response|PayloadTypes|ClientError result, TargetType targetType) returns @tainted
+        Response|PayloadTypes|ClientError {
     if (targetType is typedesc<Response> || result is ClientError) {
         return result;
     }
@@ -637,7 +637,7 @@ function processResponse(Response|Payload|ClientError result, TargetType targetT
     return performDataBinding(response, targetType);
 }
 
-function performDataBinding(Response response, TargetType targetType) returns @tainted Payload|ClientError {
+function performDataBinding(Response response, TargetType targetType) returns @tainted PayloadTypes|ClientError {
     if (targetType is typedesc<string>) {
         return response.getTextPayload();
     } else if (targetType is typedesc<xml>) {

--- a/http-ballerina/http_commons.bal
+++ b/http-ballerina/http_commons.bal
@@ -269,7 +269,7 @@ isolated function getIllegalDataBindingStateError() returns IllegalDataBindingSt
     return payloadRetrievalErr;
 }
 
-isolated function getResponseOrError(Response|Payload|ClientError result) returns HttpResponse|ClientError {
+isolated function getResponseOrError(Response|PayloadTypes|ClientError result) returns HttpResponse|ClientError {
     if (result is HttpResponse|ClientError) {
         return result;
     } else {

--- a/http-ballerina/http_commons.bal
+++ b/http-ballerina/http_commons.bal
@@ -269,7 +269,7 @@ isolated function getIllegalDataBindingStateError() returns IllegalDataBindingSt
     return payloadRetrievalErr;
 }
 
-isolated function getResponseOrError(Response|PayloadTypes|ClientError result) returns HttpResponse|ClientError {
+isolated function getResponseOrError(Response|PayloadType|ClientError result) returns HttpResponse|ClientError {
     if (result is HttpResponse|ClientError) {
         return result;
     } else {

--- a/http-ballerina/http_secure_client.bal
+++ b/http-ballerina/http_secure_client.bal
@@ -54,7 +54,7 @@ public client class HttpSecureClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(string path, RequestMessage message, TargetType targetType = Response)
-            returns Response|Payload|ClientError {
+            returns Response|PayloadTypes|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         var result = check self.httpClient->post(path, req);
@@ -96,7 +96,7 @@ public client class HttpSecureClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         var result = check self.httpClient->put(path, req);
@@ -120,7 +120,7 @@ public client class HttpSecureClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(string httpVerb, string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         var result = check self.httpClient->execute(httpVerb, path, req);
@@ -143,7 +143,7 @@ public client class HttpSecureClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         var result = check self.httpClient->patch(path, req);
@@ -166,7 +166,7 @@ public client class HttpSecureClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         var result = check self.httpClient->delete(path, req);
@@ -189,7 +189,7 @@ public client class HttpSecureClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         var result = check self.httpClient->get(path, message = req);
@@ -212,7 +212,7 @@ public client class HttpSecureClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         var result = check self.httpClient->options(path, message = req);
@@ -234,7 +234,7 @@ public client class HttpSecureClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(string path, Request request, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = request;
         req = check prepareSecureRequest(request, self.config);
         var result = check self.httpClient->forward(path, request);

--- a/http-ballerina/http_secure_client.bal
+++ b/http-ballerina/http_secure_client.bal
@@ -54,7 +54,7 @@ public client class HttpSecureClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(string path, RequestMessage message, TargetType targetType = Response)
-            returns Response|PayloadTypes|ClientError {
+            returns Response|PayloadType|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         var result = check self.httpClient->post(path, req);
@@ -96,7 +96,7 @@ public client class HttpSecureClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         var result = check self.httpClient->put(path, req);
@@ -120,7 +120,7 @@ public client class HttpSecureClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(string httpVerb, string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         var result = check self.httpClient->execute(httpVerb, path, req);
@@ -143,7 +143,7 @@ public client class HttpSecureClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         var result = check self.httpClient->patch(path, req);
@@ -166,7 +166,7 @@ public client class HttpSecureClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         var result = check self.httpClient->delete(path, req);
@@ -189,7 +189,7 @@ public client class HttpSecureClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         var result = check self.httpClient->get(path, message = req);
@@ -212,7 +212,7 @@ public client class HttpSecureClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = <Request>message;
         req = check prepareSecureRequest(req, self.config);
         var result = check self.httpClient->options(path, message = req);
@@ -234,7 +234,7 @@ public client class HttpSecureClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(string path, Request request, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = request;
         req = check prepareSecureRequest(request, self.config);
         var result = check self.httpClient->forward(path, request);

--- a/http-ballerina/http_types.bal
+++ b/http-ballerina/http_types.bal
@@ -34,10 +34,10 @@ public type Service service object {
 type CustomRecordType record {| anydata...; |};
 
 # The types of the response payload that are returned by the HTTP `client` after the data binding operation
-public type Payload string|xml|json|map<json>|byte[]|CustomRecordType|CustomRecordType[];
+public type PayloadTypes string|xml|json|map<json>|byte[]|CustomRecordType|CustomRecordType[];
 
 # The types of data values that are expected by the HTTP `client` to return after the data binding operation
-public type TargetType typedesc<Response|Payload>;
+public type TargetType typedesc<Response|PayloadTypes>;
 
 # Defines the HTTP operations related to circuit breaker, failover and load balancer.
 #

--- a/http-ballerina/http_types.bal
+++ b/http-ballerina/http_types.bal
@@ -34,10 +34,10 @@ public type Service service object {
 type CustomRecordType record {| anydata...; |};
 
 # The types of the response payload that are returned by the HTTP `client` after the data binding operation
-public type PayloadTypes string|xml|json|map<json>|byte[]|CustomRecordType|CustomRecordType[];
+public type PayloadType string|xml|json|map<json>|byte[]|CustomRecordType|CustomRecordType[];
 
 # The types of data values that are expected by the HTTP `client` to return after the data binding operation
-public type TargetType typedesc<Response|PayloadTypes>;
+public type TargetType typedesc<Response|PayloadType>;
 
 # Defines the HTTP operations related to circuit breaker, failover and load balancer.
 #

--- a/http-ballerina/redirect_http_client.bal
+++ b/http-ballerina/redirect_http_client.bal
@@ -53,7 +53,7 @@ public client class RedirectClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_GET);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -73,7 +73,7 @@ public client class RedirectClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         var result =  performRedirectIfEligible(self, path, <Request>message, HTTP_POST);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -110,7 +110,7 @@ public client class RedirectClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_PUT);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -128,7 +128,7 @@ public client class RedirectClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(string path, Request request, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         return self.httpClient->forward(path, request);
     }
 
@@ -144,7 +144,7 @@ public client class RedirectClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(string httpVerb, string path, RequestMessage message,
-            TargetType targetType = Response) returns @tainted Response|Payload|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
         Request request = <Request>message;
         //Redirection is performed only for HTTP methods
         if (HTTP_NONE == extractHttpOperation(httpVerb)) {
@@ -170,7 +170,7 @@ public client class RedirectClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_PATCH);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -190,7 +190,7 @@ public client class RedirectClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_DELETE);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -210,7 +210,7 @@ public client class RedirectClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_OPTIONS);
         if (result is HttpFuture) {
             return getInvalidTypeError();

--- a/http-ballerina/redirect_http_client.bal
+++ b/http-ballerina/redirect_http_client.bal
@@ -53,7 +53,7 @@ public client class RedirectClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_GET);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -73,7 +73,7 @@ public client class RedirectClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         var result =  performRedirectIfEligible(self, path, <Request>message, HTTP_POST);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -110,7 +110,7 @@ public client class RedirectClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_PUT);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -128,7 +128,7 @@ public client class RedirectClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(string path, Request request, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         return self.httpClient->forward(path, request);
     }
 
@@ -144,7 +144,7 @@ public client class RedirectClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(string httpVerb, string path, RequestMessage message,
-            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadType|ClientError {
         Request request = <Request>message;
         //Redirection is performed only for HTTP methods
         if (HTTP_NONE == extractHttpOperation(httpVerb)) {
@@ -170,7 +170,7 @@ public client class RedirectClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_PATCH);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -190,7 +190,7 @@ public client class RedirectClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_DELETE);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -210,7 +210,7 @@ public client class RedirectClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_OPTIONS);
         if (result is HttpFuture) {
             return getInvalidTypeError();

--- a/http-ballerina/resiliency_failover_client.bal
+++ b/http-ballerina/resiliency_failover_client.bal
@@ -80,7 +80,7 @@ public client class FailoverClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(@untainted string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_POST, self);
         if (result is HttpFuture) {
@@ -117,7 +117,7 @@ public client class FailoverClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_PATCH, self);
         if (result is HttpFuture) {
@@ -137,7 +137,7 @@ public client class FailoverClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_PUT, self);
         if (result is HttpFuture) {
@@ -157,7 +157,7 @@ public client class FailoverClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_OPTIONS, self);
         if (result is HttpFuture) {
@@ -176,7 +176,7 @@ public client class FailoverClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(string path, Request request, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         var result = performFailoverAction(path, request, HTTP_FORWARD, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -196,7 +196,7 @@ public client class FailoverClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(string httpVerb, string path, RequestMessage message,
-            TargetType targetType = Response) returns @tainted Response|Payload|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
         var result = performExecuteAction(path, req, httpVerb, self);
         if (result is HttpFuture) {
@@ -216,7 +216,7 @@ public client class FailoverClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_DELETE, self);
         if (result is HttpFuture) {
@@ -236,7 +236,7 @@ public client class FailoverClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_GET, self);
         if (result is HttpFuture) {

--- a/http-ballerina/resiliency_failover_client.bal
+++ b/http-ballerina/resiliency_failover_client.bal
@@ -80,7 +80,7 @@ public client class FailoverClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(@untainted string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_POST, self);
         if (result is HttpFuture) {
@@ -117,7 +117,7 @@ public client class FailoverClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_PATCH, self);
         if (result is HttpFuture) {
@@ -137,7 +137,7 @@ public client class FailoverClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_PUT, self);
         if (result is HttpFuture) {
@@ -157,7 +157,7 @@ public client class FailoverClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_OPTIONS, self);
         if (result is HttpFuture) {
@@ -176,7 +176,7 @@ public client class FailoverClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(string path, Request request, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         var result = performFailoverAction(path, request, HTTP_FORWARD, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -196,7 +196,7 @@ public client class FailoverClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(string httpVerb, string path, RequestMessage message,
-            TargetType targetType = Response) returns @tainted Response|PayloadTypes|ClientError {
+            TargetType targetType = Response) returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
         var result = performExecuteAction(path, req, httpVerb, self);
         if (result is HttpFuture) {
@@ -216,7 +216,7 @@ public client class FailoverClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_DELETE, self);
         if (result is HttpFuture) {
@@ -236,7 +236,7 @@ public client class FailoverClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
         var result = performFailoverAction(path, req, HTTP_GET, self);
         if (result is HttpFuture) {

--- a/http-ballerina/resiliency_http_circuit_breaker.bal
+++ b/http-ballerina/resiliency_http_circuit_breaker.bal
@@ -163,7 +163,7 @@ public client class CircuitBreakerClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(string path, RequestMessage message, TargetType targetType = Response)
-            returns Response|PayloadTypes|ClientError {
+            returns Response|PayloadType|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -208,7 +208,7 @@ public client class CircuitBreakerClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -233,7 +233,7 @@ public client class CircuitBreakerClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(string httpVerb, string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -257,7 +257,7 @@ public client class CircuitBreakerClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -281,7 +281,7 @@ public client class CircuitBreakerClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -305,7 +305,7 @@ public client class CircuitBreakerClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -329,7 +329,7 @@ public client class CircuitBreakerClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -352,7 +352,7 @@ public client class CircuitBreakerClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(string path, Request request, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -509,7 +509,7 @@ isolated function updateCircuitState(CircuitHealth circuitHealth, CircuitState c
     }
 }
 
-isolated function updateCircuitHealthAndRespond(Response|PayloadTypes|ClientError serviceResponse, CircuitHealth circuitHealth,
+isolated function updateCircuitHealthAndRespond(Response|PayloadType|ClientError serviceResponse, CircuitHealth circuitHealth,
                                CircuitBreakerInferredConfig circuitBreakerInferredConfig) returns Response|ClientError {
     if (serviceResponse is Response) {
         if (circuitBreakerInferredConfig.statusCodes[serviceResponse.statusCode]) {

--- a/http-ballerina/resiliency_http_circuit_breaker.bal
+++ b/http-ballerina/resiliency_http_circuit_breaker.bal
@@ -163,7 +163,7 @@ public client class CircuitBreakerClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(string path, RequestMessage message, TargetType targetType = Response)
-            returns Response|Payload|ClientError {
+            returns Response|PayloadTypes|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -208,7 +208,7 @@ public client class CircuitBreakerClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -233,7 +233,7 @@ public client class CircuitBreakerClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(string httpVerb, string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -257,7 +257,7 @@ public client class CircuitBreakerClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -281,7 +281,7 @@ public client class CircuitBreakerClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -305,7 +305,7 @@ public client class CircuitBreakerClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -329,7 +329,7 @@ public client class CircuitBreakerClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -352,7 +352,7 @@ public client class CircuitBreakerClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(string path, Request request, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         CircuitBreakerInferredConfig cbic = self.circuitBreakerInferredConfig;
         self.currentCircuitState = updateCircuitState(self.circuitHealth, self.currentCircuitState, cbic);
 
@@ -509,7 +509,7 @@ isolated function updateCircuitState(CircuitHealth circuitHealth, CircuitState c
     }
 }
 
-isolated function updateCircuitHealthAndRespond(Response|Payload|ClientError serviceResponse, CircuitHealth circuitHealth,
+isolated function updateCircuitHealthAndRespond(Response|PayloadTypes|ClientError serviceResponse, CircuitHealth circuitHealth,
                                CircuitBreakerInferredConfig circuitBreakerInferredConfig) returns Response|ClientError {
     if (serviceResponse is Response) {
         if (circuitBreakerInferredConfig.statusCodes[serviceResponse.statusCode]) {

--- a/http-ballerina/resiliency_http_retry_client.bal
+++ b/http-ballerina/resiliency_http_retry_client.bal
@@ -72,7 +72,7 @@ public client class RetryClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_POST, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -109,7 +109,7 @@ public client class RetryClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_PUT, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -128,7 +128,7 @@ public client class RetryClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(string path, Request request, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         var result = performRetryAction(path, request, HTTP_FORWARD, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -150,7 +150,7 @@ public client class RetryClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(string httpVerb, string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         var result = performRetryClientExecuteAction(path, <Request>message, httpVerb, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -170,7 +170,7 @@ public client class RetryClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_PATCH, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -190,7 +190,7 @@ public client class RetryClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_DELETE, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -210,7 +210,7 @@ public client class RetryClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_GET, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -230,7 +230,7 @@ public client class RetryClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_OPTIONS, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();

--- a/http-ballerina/resiliency_http_retry_client.bal
+++ b/http-ballerina/resiliency_http_retry_client.bal
@@ -72,7 +72,7 @@ public client class RetryClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_POST, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -109,7 +109,7 @@ public client class RetryClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_PUT, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -128,7 +128,7 @@ public client class RetryClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(string path, Request request, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         var result = performRetryAction(path, request, HTTP_FORWARD, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -150,7 +150,7 @@ public client class RetryClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(string httpVerb, string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         var result = performRetryClientExecuteAction(path, <Request>message, httpVerb, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -170,7 +170,7 @@ public client class RetryClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_PATCH, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -190,7 +190,7 @@ public client class RetryClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_DELETE, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -210,7 +210,7 @@ public client class RetryClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_GET, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -230,7 +230,7 @@ public client class RetryClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         var result = performRetryAction(path, <Request>message, HTTP_OPTIONS, self);
         if (result is HttpFuture) {
             return getInvalidTypeError();

--- a/http-ballerina/resiliency_load_balance_client.bal
+++ b/http-ballerina/resiliency_load_balance_client.bal
@@ -60,7 +60,7 @@ public client class LoadBalanceClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(@untainted string path, RequestMessage message, TargetType targetType = Response)
-                returns @tainted Response|PayloadTypes|ClientError {
+                returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_POST);
     }
@@ -87,7 +87,7 @@ public client class LoadBalanceClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_PATCH);
     }
@@ -102,7 +102,7 @@ public client class LoadBalanceClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_PUT);
     }
@@ -117,7 +117,7 @@ public client class LoadBalanceClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_OPTIONS);
     }
@@ -131,7 +131,7 @@ public client class LoadBalanceClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(string path, Request request, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         return performLoadBalanceAction(self, path, request, HTTP_FORWARD);
     }
 
@@ -147,7 +147,7 @@ public client class LoadBalanceClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(string httpVerb, string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceExecuteAction(self, path, req, httpVerb);
     }
@@ -162,7 +162,7 @@ public client class LoadBalanceClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_DELETE);
     }
@@ -177,7 +177,7 @@ public client class LoadBalanceClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|PayloadTypes|ClientError {
+            returns @tainted Response|PayloadType|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_GET);
     }

--- a/http-ballerina/resiliency_load_balance_client.bal
+++ b/http-ballerina/resiliency_load_balance_client.bal
@@ -60,7 +60,7 @@ public client class LoadBalanceClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function post(@untainted string path, RequestMessage message, TargetType targetType = Response)
-                returns @tainted Response|Payload|ClientError {
+                returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_POST);
     }
@@ -87,7 +87,7 @@ public client class LoadBalanceClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_PATCH);
     }
@@ -102,7 +102,7 @@ public client class LoadBalanceClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_PUT);
     }
@@ -117,7 +117,7 @@ public client class LoadBalanceClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_OPTIONS);
     }
@@ -131,7 +131,7 @@ public client class LoadBalanceClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function forward(string path, Request request, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         return performLoadBalanceAction(self, path, request, HTTP_FORWARD);
     }
 
@@ -147,7 +147,7 @@ public client class LoadBalanceClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function execute(string httpVerb, string path, RequestMessage message, TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceExecuteAction(self, path, req, httpVerb);
     }
@@ -162,7 +162,7 @@ public client class LoadBalanceClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_DELETE);
     }
@@ -177,7 +177,7 @@ public client class LoadBalanceClient {
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
     #            establish the communication with the upstream server or a data binding failure
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
-            returns @tainted Response|Payload|ClientError {
+            returns @tainted Response|PayloadTypes|ClientError {
         Request req = buildRequest(message);
         return performLoadBalanceAction(self, path, req, HTTP_GET);
     }

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -141,7 +141,7 @@ public class HttpConstants {
     public static final BString ANN_FIELD_PATH_PARAM_ORDER = StringUtils.fromString("pathParamOrder");
     public static final BString ANN_FIELD_ALL_PARAM_ORDER = StringUtils.fromString("allParamOrder");
     public static final String ANN_NAME_PAYLOAD = "Payload";
-    public static final String ANN_NAME_CALLER = "Caller";
+    public static final String ANN_NAME_CALLER_INFO = "CallerInfo";
     public static final String DIRTY_RESPONSE = "dirtyResponse";
 
     public static final String VALUE_ATTRIBUTE = "value";

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -140,6 +140,8 @@ public class HttpConstants {
     public static final String ANN_NAME_PARAM_ORDER_CONFIG = "ParamOrderConfig";
     public static final BString ANN_FIELD_PATH_PARAM_ORDER = StringUtils.fromString("pathParamOrder");
     public static final BString ANN_FIELD_ALL_PARAM_ORDER = StringUtils.fromString("allParamOrder");
+    public static final String ANN_NAME_PAYLOAD = "Payload";
+    public static final String ANN_NAME_CALLER = "Caller";
     public static final String DIRTY_RESPONSE = "dirtyResponse";
 
     public static final String VALUE_ATTRIBUTE = "value";
@@ -181,6 +183,7 @@ public class HttpConstants {
     public static final String CLOSE_CURL_IDENTIFIER = "}";
     public static final String DOT_IDENTIFIER = ".";
     public static final String QUERY_PARAM = "query";
+    public static final String PAYLOAD_PARAM = "payload";
 
     /* Annotations */
     public static final String ANNOTATION_NAME_SOURCE = "Source";

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpDispatcher.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpDispatcher.java
@@ -37,6 +37,7 @@ import org.ballerinalang.net.http.signature.AllQueryParams;
 import org.ballerinalang.net.http.signature.NonRecurringParam;
 import org.ballerinalang.net.http.signature.ParamHandler;
 import org.ballerinalang.net.http.signature.Parameter;
+import org.ballerinalang.net.http.signature.PayloadParam;
 import org.ballerinalang.net.http.signature.QueryParam;
 import org.ballerinalang.net.transport.message.HttpCarbonMessage;
 import org.ballerinalang.net.uri.URIUtil;
@@ -50,6 +51,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.ballerina.runtime.api.TypeTags.ARRAY_TAG;
+import static io.ballerina.runtime.api.TypeTags.BOOLEAN_TAG;
+import static io.ballerina.runtime.api.TypeTags.DECIMAL_TAG;
+import static io.ballerina.runtime.api.TypeTags.FLOAT_TAG;
+import static io.ballerina.runtime.api.TypeTags.INT_TAG;
+import static io.ballerina.runtime.api.TypeTags.STRING_TAG;
+import static org.ballerinalang.mime.util.MimeConstants.REQUEST_ENTITY_FIELD;
 import static org.ballerinalang.net.http.HttpConstants.DEFAULT_HOST;
 
 /**
@@ -158,11 +166,11 @@ public class HttpDispatcher {
 
     public static Object[] getSignatureParameters(HttpResource httpResource, HttpCarbonMessage httpCarbonMessage,
                                                   BMap<BString, Object> endpointConfig) {
-        ParamHandler signatureParams = httpResource.getSignatureParams();
+        BObject inRequest = null;
+        ParamHandler paramHandler = httpResource.getParamHandler();
         int sigParamCount = httpResource.getBalResource().getParameterTypes().length;
         Object[] paramFeed = new Object[sigParamCount * 2];
-
-        int pathParamCount = signatureParams.getPathParamTokens().length;
+        int pathParamCount = paramHandler.getPathParamTokens().length;
         // Path params are located initially in the signature before the other user provided signature params
         if (pathParamCount != 0) {
             // populate path params
@@ -172,7 +180,7 @@ public class HttpDispatcher {
             populatePathParams(httpResource, paramFeed, resourceArgumentValues, pathParamCount);
         }
         // Following was written assuming that they are validated
-        for (Parameter param : signatureParams.getOtherParamList()) {
+        for (Parameter param : paramHandler.getOtherParamList()) {
             String typeName = param.getTypeName();
             switch (typeName) {
                 case HttpConstants.CALLER:
@@ -181,39 +189,32 @@ public class HttpDispatcher {
                     paramFeed[index] = true;
                     break;
                 case HttpConstants.REQUEST:
+                    if (inRequest == null) {
+                        inRequest = createRequest(httpCarbonMessage);
+                    }
                     index = ((NonRecurringParam) param).getIndex();
-                    paramFeed[index++] = createRequest(httpCarbonMessage);
+                    paramFeed[index++] = inRequest;
                     paramFeed[index] = true;
                     break;
                 case HttpConstants.QUERY_PARAM:
-                    populateQueryParams(httpCarbonMessage, signatureParams, paramFeed, (AllQueryParams) param);
+                    populateQueryParams(httpCarbonMessage, paramHandler, paramFeed, (AllQueryParams) param);
+                    break;
+                case HttpConstants.PAYLOAD_PARAM:
+                    if (inRequest == null) {
+                        inRequest = createRequest(httpCarbonMessage);
+                    }
+                    populatePayloadParam(inRequest, httpCarbonMessage, paramFeed, (PayloadParam) param);
                     break;
                 default:
                     break;
             }
         }
-
-//        if (signatureParams.getParamCount() == COMPULSORY_PARAM_COUNT) {
-//            return paramFeed;
-//        }
-//
-//        if (signatureParams.getEntityBody() == null) {
-//            return paramFeed;
-//        }
-//        try {
-//            paramFeed[paramFeed.length - 2] = populateAndGetEntityBody(inRequest, inRequestEntity,
-//                                                                   signatureParams.getEntityBody());
-//            paramFeed[paramFeed.length - 1] = true;
-//        } catch (Exception ex) {
-//            httpCarbonMessage.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
-//            throw new BallerinaConnectorException("data binding failed: " + ex.getMessage());
-//        }
         return paramFeed;
     }
 
-    private static void populateQueryParams(HttpCarbonMessage httpCarbonMessage, ParamHandler signatureParams,
+    private static void populateQueryParams(HttpCarbonMessage httpCarbonMessage, ParamHandler paramHandler,
                                             Object[] paramFeed, AllQueryParams queryParams) {
-        BMap<BString, Object> urlQueryParams = signatureParams
+        BMap<BString, Object> urlQueryParams = paramHandler
                 .getQueryParams(httpCarbonMessage.getProperty(HttpConstants.RAW_QUERY_STR));
         for (QueryParam queryParam : queryParams.getAllQueryParams()) {
             String token = queryParam.getToken();
@@ -232,31 +233,31 @@ public class HttpDispatcher {
             try {
                 BArray queryValueArr = (BArray) queryValue;
                 switch (queryParam.getTypeTag()) {
-                    case TypeTags.INT_TAG:
+                    case INT_TAG:
                         String value = queryValueArr.getBString(0).getValue();
                         paramFeed[index++] = Long.parseLong(value);
                         break;
-                    case TypeTags.FLOAT_TAG:
+                    case FLOAT_TAG:
                         value = queryValueArr.getBString(0).getValue();
                         paramFeed[index++] = Double.parseDouble(value);
                         break;
-                    case TypeTags.BOOLEAN_TAG:
+                    case BOOLEAN_TAG:
                         value = queryValueArr.getBString(0).getValue();
                         paramFeed[index++] = Boolean.parseBoolean(value);
                         break;
-                    case TypeTags.DECIMAL_TAG:
+                    case DECIMAL_TAG:
                         value = queryValueArr.getBString(0).getValue();
                         paramFeed[index++] = ValueCreator.createDecimalValue(value);
                         break;
-                    case TypeTags.ARRAY_TAG:
+                    case ARRAY_TAG:
                         int elementTypeTag = ((ArrayType) queryParam.getType()).getElementType().getTag();
-                        if (elementTypeTag == TypeTags.INT_TAG) {
+                        if (elementTypeTag == INT_TAG) {
                             paramFeed[index++] = getBArray(queryValueArr, INT_ARRAY, elementTypeTag);
-                        } else if (elementTypeTag == TypeTags.FLOAT_TAG) {
+                        } else if (elementTypeTag == FLOAT_TAG) {
                             paramFeed[index++] = getBArray(queryValueArr, FLOAT_ARRAY, elementTypeTag);
-                        } else if (elementTypeTag == TypeTags.BOOLEAN_TAG) {
+                        } else if (elementTypeTag == BOOLEAN_TAG) {
                             paramFeed[index++] = getBArray(queryValueArr, BOOLEAN_ARRAY, elementTypeTag);
-                        } else if (elementTypeTag == TypeTags.DECIMAL_TAG) {
+                        } else if (elementTypeTag == DECIMAL_TAG) {
                             paramFeed[index++] = getBArray(queryValueArr, DECIMAL_ARRAY, elementTypeTag);
                         } else {
                             paramFeed[index++] = queryValueArr;
@@ -278,16 +279,16 @@ public class HttpDispatcher {
         int index = 0;
         for (String element : queryValueArr.getStringArray()) {
             switch (elementTypeTag) {
-                case TypeTags.INT_TAG:
+                case INT_TAG:
                     arrayValue.add(index++, Long.parseLong(element));
                     break;
-                case TypeTags.FLOAT_TAG:
+                case FLOAT_TAG:
                     arrayValue.add(index++, Double.parseDouble(element));
                     break;
-                case TypeTags.BOOLEAN_TAG:
+                case BOOLEAN_TAG:
                     arrayValue.add(index++, Boolean.parseBoolean(element));
                     break;
-                case TypeTags.DECIMAL_TAG:
+                case DECIMAL_TAG:
                     arrayValue.add(index++, ValueCreator.createDecimalValue(element));
                     break;
                 default:
@@ -329,20 +330,20 @@ public class HttpDispatcher {
             Type signatureParamType = httpResource.getBalResource().getParameterTypes()[actualSignatureParamIndex++];
             try {
                 switch (signatureParamType.getTag()) {
-                    case TypeTags.INT_TAG:
+                    case INT_TAG:
                         paramFeed[paramIndex++] = Long.parseLong(argumentValue);
                         break;
-                    case TypeTags.FLOAT_TAG:
+                    case FLOAT_TAG:
                         paramFeed[paramIndex++] = Double.parseDouble(argumentValue);
                         break;
-                    case TypeTags.BOOLEAN_TAG:
+                    case BOOLEAN_TAG:
                         paramFeed[paramIndex++] = Boolean.parseBoolean(argumentValue);
                         break;
-                    case TypeTags.DECIMAL_TAG:
+                    case DECIMAL_TAG:
                         paramFeed[paramIndex++] = ValueCreator.createDecimalValue(argumentValue);
                         break;
-                    case TypeTags.ARRAY_TAG:
-                        if (((ArrayType) signatureParamType).getElementType().getTag() == TypeTags.STRING_TAG) {
+                    case ARRAY_TAG:
+                        if (((ArrayType) signatureParamType).getElementType().getTag() == STRING_TAG) {
                             String[] segments = argumentValue.substring(1).split(HttpConstants.SINGLE_SLASH);
                             paramFeed[paramIndex++] = StringUtils.fromStringArray(segments);
                         }
@@ -365,44 +366,53 @@ public class HttpDispatcher {
         arguments.putIfAbsent(wildcardToken, wildcardPathSegment);
     }
 
-    private static Object populateAndGetEntityBody(BObject inRequest, BObject inRequestEntity,
-                                                   io.ballerina.runtime.api.types.Type entityBodyType)
-            throws IOException {
+    private static void populatePayloadParam(BObject inRequest,
+                                             HttpCarbonMessage httpCarbonMessage,
+                                             Object[] paramFeed, PayloadParam payloadParam) {
+        BObject inRequestEntity = (BObject) inRequest.get(REQUEST_ENTITY_FIELD);
         HttpUtil.populateEntityBody(inRequest, inRequestEntity, true, true);
+        int index = payloadParam.getIndex();
+        Type payloadType = payloadParam.getType();
         try {
-            switch (entityBodyType.getTag()) {
-                case TypeTags.STRING_TAG:
+            switch (payloadType.getTag()) {
+                case STRING_TAG:
                     BString stringDataSource = EntityBodyHandler.constructStringDataSource(inRequestEntity);
                     EntityBodyHandler.addMessageDataSource(inRequestEntity, stringDataSource);
-                    return stringDataSource;
+                    paramFeed[index++] = stringDataSource;
+                    break;
                 case TypeTags.JSON_TAG:
                     Object bjson = EntityBodyHandler.constructJsonDataSource(inRequestEntity);
                     EntityBodyHandler.addJsonMessageDataSource(inRequestEntity, bjson);
-                    return bjson;
+                    paramFeed[index++] = bjson;
+                    break;
                 case TypeTags.XML_TAG:
                     BXml bxml = EntityBodyHandler.constructXmlDataSource(inRequestEntity);
                     EntityBodyHandler.addMessageDataSource(inRequestEntity, bxml);
-                    return bxml;
-                case TypeTags.ARRAY_TAG:
-                    if (((ArrayType) entityBodyType).getElementType().getTag() == TypeTags.BYTE_TAG) {
+                    paramFeed[index++] = bxml;
+                    break;
+                case ARRAY_TAG:
+                    if (((ArrayType) payloadType).getElementType().getTag() == TypeTags.BYTE_TAG) {
                         BArray blobDataSource = EntityBodyHandler.constructBlobDataSource(inRequestEntity);
                         EntityBodyHandler.addMessageDataSource(inRequestEntity, blobDataSource);
-                        return blobDataSource;
-                    } else if (((ArrayType) entityBodyType).getElementType().getTag() == TypeTags.RECORD_TYPE_TAG) {
-                        return getRecordEntity(inRequestEntity, entityBodyType);
+                        paramFeed[index++] = blobDataSource;
+                    } else if (((ArrayType) payloadType).getElementType().getTag() == TypeTags.RECORD_TYPE_TAG) {
+                        paramFeed[index++] = getRecordEntity(inRequestEntity, payloadType);
                     } else {
                         throw new BallerinaConnectorException("Incompatible Element type found inside an array " +
-                                ((ArrayType) entityBodyType).getElementType().getName());
+                                        ((ArrayType) payloadType).getElementType().getName());
                     }
+                    break;
                 case TypeTags.RECORD_TYPE_TAG:
-                    return getRecordEntity(inRequestEntity, entityBodyType);
+                    paramFeed[index++] = getRecordEntity(inRequestEntity, payloadType);
+                    break;
                 default:
                         //Do nothing
             }
-        } catch (BError ex) {
-            throw new BallerinaConnectorException(ex.toString());
+            paramFeed[index] = true;
+        } catch (BError | IOException ex) {
+            httpCarbonMessage.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
+            throw new BallerinaConnectorException("data binding failed: " + ex.toString());
         }
-        return null;
     }
 
     private static Object getRecordEntity(BObject inRequestEntity, Type entityBodyType) {
@@ -442,7 +452,7 @@ public class HttpDispatcher {
     }
 
     public static boolean shouldDiffer(HttpResource httpResource) {
-        return (httpResource != null && httpResource.getSignatureParams().getEntityBody() != null);
+        return (httpResource != null && httpResource.getParamHandler().isPayloadBindingRequired());
     }
 
     private HttpDispatcher() {

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpResource.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpResource.java
@@ -66,7 +66,7 @@ public class HttpResource {
     private List<String> produces;
     private List<String> producesSubTypes;
     private CorsHeaders corsHeaders;
-    private ParamHandler signatureParams;
+    private ParamHandler paramHandler;
     private HttpService parentService;
     private boolean transactionInfectable = true; //default behavior
     private boolean transactionAnnotated = false;
@@ -95,8 +95,8 @@ public class HttpResource {
         return balResource.getParentObjectType().getName();
     }
 
-    public ParamHandler getSignatureParams() {
-        return signatureParams;
+    public ParamHandler getParamHandler() {
+        return paramHandler;
     }
 
     public HttpService getParentService() {
@@ -278,7 +278,7 @@ public class HttpResource {
     }
 
     private void prepareAndValidateSignatureParams() {
-        signatureParams = new ParamHandler(this, this.pathParamCount);
+        paramHandler = new ParamHandler(getBalResource(), this.pathParamCount);
     }
 
     String getWildcardToken() {

--- a/http-native/src/main/java/org/ballerinalang/net/http/signature/PayloadParam.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/signature/PayloadParam.java
@@ -25,6 +25,9 @@ import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpErrorType;
 import org.ballerinalang.net.http.HttpUtil;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * {@code {@link PayloadParam }} represents a payload parameter details.
  *
@@ -32,11 +35,17 @@ import org.ballerinalang.net.http.HttpUtil;
  */
 public class PayloadParam implements Parameter {
 
-    private final int index;
-    private final Type type;
-    private final int typeTag;
+    private int index;
+    private Type type;
+    private int typeTag;
+    private final String token;
+    private List<String> mediaTypes = new ArrayList<>();
 
-    PayloadParam(Type type, int index) {
+    PayloadParam(String token) {
+        this.token = token;
+    }
+
+    public void init(Type type, int index) {
         this.type = type;
         this.typeTag = type.getTag();
         this.index = index;
@@ -67,6 +76,14 @@ public class PayloadParam implements Parameter {
     }
 
     public Type getType() {
-        return type;
+        return this.type;
+    }
+
+    public String getToken() {
+        return this.token;
+    }
+
+    List<String> getMediaTypes() {
+        return mediaTypes;
     }
 }

--- a/http-native/src/main/java/org/ballerinalang/net/http/signature/PayloadParam.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/signature/PayloadParam.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.net.http.signature;
+
+import io.ballerina.runtime.api.TypeTags;
+import io.ballerina.runtime.api.types.ArrayType;
+import io.ballerina.runtime.api.types.Type;
+import org.ballerinalang.net.http.HttpConstants;
+import org.ballerinalang.net.http.HttpErrorType;
+import org.ballerinalang.net.http.HttpUtil;
+
+/**
+ * {@code {@link PayloadParam }} represents a payload parameter details.
+ *
+ * @since slp8
+ */
+public class PayloadParam implements Parameter {
+
+    private final int index;
+    private final Type type;
+    private final int typeTag;
+
+    PayloadParam(Type type, int index) {
+        this.type = type;
+        this.typeTag = type.getTag();
+        this.index = index;
+        validatePayloadParam();
+    }
+
+    @Override
+    public String getTypeName() {
+        return HttpConstants.PAYLOAD_PARAM;
+    }
+
+    public int getIndex() {
+        return this.index * 2;
+    }
+
+    private void validatePayloadParam() {
+        if (typeTag == TypeTags.RECORD_TYPE_TAG || typeTag == TypeTags.JSON_TAG || typeTag == TypeTags.XML_TAG ||
+                typeTag == TypeTags.STRING_TAG || (typeTag == TypeTags.ARRAY_TAG && validArrayType())) {
+            return;
+        }
+        throw HttpUtil.createHttpError("incompatible payload parameter type : '" + type.getName() + "'",
+                                       HttpErrorType.GENERIC_LISTENER_ERROR);
+    }
+
+    private boolean validArrayType() {
+        return ((ArrayType) type).getElementType().getTag() == TypeTags.BYTE_TAG ||
+                ((ArrayType) type).getElementType().getTag() == TypeTags.RECORD_TYPE_TAG;
+    }
+
+    public Type getType() {
+        return type;
+    }
+}

--- a/http-native/src/main/java/org/ballerinalang/net/http/signature/QueryParam.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/signature/QueryParam.java
@@ -43,7 +43,6 @@ public class QueryParam {
         this.token = token;
         this.index = index;
         this.nilable = nilable;
-        //TODO remove this after resource typing
         validateQueryParamType();
     }
 
@@ -52,7 +51,7 @@ public class QueryParam {
                 ((ArrayType) type).getElementType().getTag()))) {
             return;
         }
-        throw HttpUtil.createHttpError("incompatible query param type: '" + type.getName() + "'",
+        throw HttpUtil.createHttpError("incompatible query parameter type: '" + type.getName() + "'",
                                        HttpErrorType.GENERIC_LISTENER_ERROR);
     }
 


### PR DESCRIPTION
## Purpose
> Use param annotation to specify payload param in the resource signature
> Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/594

## Sample
```ballerina
resource function post body2/[string key](@http:Payload {} string person, http:Caller caller) {
    json responseJson = { Key: key, Person: person };
    checkpanic caller->respond(<@untainted json> responseJson);
}
```