### PR TITLE
Add support to retry secure client when OAuth2 client failed

### DIFF
--- a/http-ballerina/auth_client_oauth2_handler.bal
+++ b/http-ballerina/auth_client_oauth2_handler.bal
@@ -19,16 +19,19 @@ import ballerina/oauth2;
 # Represents OAuth2 client credentials grant configurations for OAuth2 authentication.
 public type OAuth2ClientCredentialsGrantConfig record {|
     *oauth2:ClientCredentialsGrantConfig;
+    int inspectStatusCode = STATUS_UNAUTHORIZED;
 |};
 
 # Represents OAuth2 password grant configurations for OAuth2 authentication.
 public type OAuth2PasswordGrantConfig record {|
     *oauth2:PasswordGrantConfig;
+    int inspectStatusCode = STATUS_UNAUTHORIZED;
 |};
 
 # Represents OAuth2 direct token configurations for OAuth2 authentication.
 public type OAuth2DirectTokenConfig record {|
     *oauth2:DirectTokenConfig;
+    int inspectStatusCode = STATUS_UNAUTHORIZED;
 |};
 
 # Represents OAuth2 grant configurations for OAuth2 authentication.
@@ -38,12 +41,14 @@ public type OAuth2GrantConfig OAuth2ClientCredentialsGrantConfig|OAuth2PasswordG
 public client class ClientOAuth2Handler {
 
     oauth2:ClientOAuth2Provider provider;
+    int inspectStatusCode;
 
     # Initializes the `http:ClientOAuth2Handler` object.
     #
     # + config - The `http:OAuth2GrantConfig` instance
     public isolated function init(OAuth2GrantConfig config) {
         self.provider = new(config);
+        self.inspectStatusCode = config.inspectStatusCode;
     }
 
     # Enrich the request with the relevant authentication requirements.
@@ -57,5 +62,21 @@ public client class ClientOAuth2Handler {
         }
         req.setHeader(AUTH_HEADER, AUTH_SCHEME_BEARER + " " + checkpanic result);
         return req;
+    }
+
+    # Inspect the request with the relevant authentication requirements.
+    #
+    # + req - The `http:Request` instance
+    # + res - The `http:Response` instance
+    # + return - The updated `http:Request` instance or else an `http:ClientAuthError` in case of an error
+    remote isolated function inspect(Request req, Response res) returns Request|ClientAuthError {
+        if (res.statusCode == self.inspectStatusCode) {
+            string|oauth2:Error result = self.provider.refreshToken();
+            if (result is oauth2:Error) {
+                return prepareClientAuthError("Failed to inspect response with OAuth2 token.", result);
+            }
+            req.setHeader(AUTH_HEADER, AUTH_SCHEME_BEARER + " " + checkpanic result);
+            return req;
+        }
     }
 }

--- a/http-ballerina/auth_client_oauth2_handler.bal
+++ b/http-ballerina/auth_client_oauth2_handler.bal
@@ -17,18 +17,24 @@
 import ballerina/oauth2;
 
 # Represents OAuth2 client credentials grant configurations for OAuth2 authentication.
+#
+# + inspectStatusCode - The status code of the `http:Response` which should used to decide to inspect
 public type OAuth2ClientCredentialsGrantConfig record {|
     *oauth2:ClientCredentialsGrantConfig;
     int inspectStatusCode = STATUS_UNAUTHORIZED;
 |};
 
 # Represents OAuth2 password grant configurations for OAuth2 authentication.
+#
+# + inspectStatusCode - The status code of the `http:Response` which should used to decide to inspect
 public type OAuth2PasswordGrantConfig record {|
     *oauth2:PasswordGrantConfig;
     int inspectStatusCode = STATUS_UNAUTHORIZED;
 |};
 
 # Represents OAuth2 direct token configurations for OAuth2 authentication.
+#
+# + inspectStatusCode - The status code of the `http:Response` which should used to decide to inspect
 public type OAuth2DirectTokenConfig record {|
     *oauth2:DirectTokenConfig;
     int inspectStatusCode = STATUS_UNAUTHORIZED;
@@ -69,7 +75,7 @@ public client class ClientOAuth2Handler {
     # + req - The `http:Request` instance
     # + res - The `http:Response` instance
     # + return - The updated `http:Request` instance or else an `http:ClientAuthError` in case of an error
-    remote isolated function inspect(Request req, Response res) returns Request|ClientAuthError {
+    remote isolated function inspect(Request req, Response res) returns Request|ClientAuthError? {
         if (res.statusCode == self.inspectStatusCode) {
             string|oauth2:Error result = self.provider.refreshToken();
             if (result is oauth2:Error) {

--- a/http-ballerina/http_filter.bal
+++ b/http-ballerina/http_filter.bal
@@ -26,7 +26,7 @@ public type RequestFilter object {
     # + request - An inbound HTTP request message
     # + context - A filter context
     # + return - `true` if the filter succeeds, `false` otherwise
-    public function filterRequest(Caller caller, Request request, FilterContext context) returns boolean;
+    public isolated function filterRequest(Caller caller, Request request, FilterContext context) returns boolean;
 };
 
 # The representation of a HTTP Response Filter object type.

--- a/http-ballerina/http_secure_client.bal
+++ b/http-ballerina/http_secure_client.bal
@@ -57,7 +57,12 @@ public client class HttpSecureClient {
     remote function post(string path, RequestMessage message, TargetType targetType = Response)
             returns Response|PayloadType|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);
-        return self.httpClient->post(path, req);
+        Response res = check self.httpClient->post(path, req);
+        Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
+        if (inspection is Request) {
+            return self.httpClient->post(path, inspection);
+        }
+        return res;
     }
 
     # This wraps the `HttpSecureClient.head()` function of the underlying HTTP remote functions provider. Add relevant authentication
@@ -70,7 +75,12 @@ public client class HttpSecureClient {
     remote function head(@untainted string path, RequestMessage message = ()) returns @tainted
             Response|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);
-        return self.httpClient->head(path, message = req);
+        Response res = check self.httpClient->head(path, message = req);
+        Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
+        if (inspection is Request) {
+            return self.httpClient->head(path, message = inspection);
+        }
+        return res;
     }
 
     # This wraps the `HttpSecureClient.put()` function of the underlying HTTP remote functions provider. Add relevant authentication
@@ -86,7 +96,12 @@ public client class HttpSecureClient {
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
             returns @tainted Response|PayloadType|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);
-        return self.httpClient->put(path, req);
+        Response res = check self.httpClient->put(path, req);
+        Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
+        if (inspection is Request) {
+            return self.httpClient->put(path, inspection);
+        }
+        return res;
     }
 
     # This wraps the `HttpSecureClient.execute()` function of the underlying HTTP remote functions provider. Add relevant authentication
@@ -103,7 +118,12 @@ public client class HttpSecureClient {
     remote function execute(string httpVerb, string path, RequestMessage message, TargetType targetType = Response)
             returns @tainted Response|PayloadType|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);
-        return self.httpClient->execute(httpVerb, path, req);
+        Response res = check self.httpClient->execute(httpVerb, path, req);
+        Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
+        if (inspection is Request) {
+            return self.httpClient->execute(httpVerb, path, inspection);
+        }
+        return res;
     }
 
     # This wraps the `HttpSecureClient.patch()` function of the underlying HTTP remote functions provider. Add relevant authentication
@@ -119,7 +139,12 @@ public client class HttpSecureClient {
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
             returns @tainted Response|PayloadType|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);
-        return self.httpClient->patch(path, req);
+        Response res = check self.httpClient->patch(path, req);
+        Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
+        if (inspection is Request) {
+            return self.httpClient->patch(path, inspection);
+        }
+        return res;
     }
 
     # This wraps the `HttpSecureClient.delete()` function of the underlying HTTP remote functions provider. Add relevant authentication
@@ -135,7 +160,12 @@ public client class HttpSecureClient {
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
             returns @tainted Response|PayloadType|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);
-        return self.httpClient->delete(path, req);
+        Response res = check self.httpClient->delete(path, req);
+        Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
+        if (inspection is Request) {
+            return self.httpClient->delete(path, inspection);
+        }
+        return res;
     }
 
     # This wraps the `HttpSecureClient.get()` function of the underlying HTTP remote functions provider. Add relevant authentication
@@ -151,7 +181,12 @@ public client class HttpSecureClient {
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
             returns @tainted Response|PayloadType|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);
-        return self.httpClient->get(path, message = req);
+        Response res = check self.httpClient->get(path, message = req);
+        Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
+        if (inspection is Request) {
+            return self.httpClient->get(path, message = inspection);
+        }
+        return res;
     }
 
     # This wraps the `HttpSecureClient.options()` function of the underlying HTTP remote functions provider. Add relevant authentication
@@ -167,7 +202,12 @@ public client class HttpSecureClient {
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
             returns @tainted Response|PayloadType|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);
-        return self.httpClient->options(path, message = req);
+        Response res = check self.httpClient->options(path, message = req);
+        Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
+        if (inspection is Request) {
+            return self.httpClient->options(path, message = inspection);
+        }
+        return res;
     }
 
     # This wraps the `HttpSecureClient.forward()` function of the underlying HTTP remote functions provider. Add relevant authentication
@@ -182,7 +222,12 @@ public client class HttpSecureClient {
     remote function forward(string path, Request request, TargetType targetType = Response)
             returns @tainted Response|PayloadType|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, request);
-        return self.httpClient->forward(path, req);
+        Response res = check self.httpClient->forward(path, req);
+        Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
+        if (inspection is Request) {
+            return self.httpClient->forward(path, inspection);
+        }
+        return res;
     }
 
     # This wraps the `HttpSecureClient.submit()` function of the underlying HTTP remote functions provider. Add relevant authentication
@@ -195,7 +240,12 @@ public client class HttpSecureClient {
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation, or else an `http:ClientError` if the submission fails
     remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);
-        return self.httpClient->submit(httpVerb, path, req);
+        Response res = check self.httpClient->submit(httpVerb, path, req);
+        Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
+        if (inspection is Request) {
+            return self.httpClient->submit(httpVerb, path, inspection);
+        }
+        return res;
     }
 
     # This just passes the request to the actual network call.
@@ -264,6 +314,13 @@ isolated function enrichRequest(ClientAuthHandler clientAuthHandler, Request req
     } else {
         // Here, `clientAuthHandler` is `ClientOAuth2Handler`
         return clientAuthHandler->enrich(req);
+    }
+}
+
+// Inspect the request using the relevant client auth handler.
+function inspectRequest(ClientAuthHandler clientAuthHandler, Request req, Response res) returns Request|ClientAuthError? {
+    if (clientAuthHandler is ClientOAuth2Handler) {
+        return clientAuthHandler->inspect(req, res);
     }
 }
 

--- a/http-ballerina/http_secure_client.bal
+++ b/http-ballerina/http_secure_client.bal
@@ -57,7 +57,7 @@ public client class HttpSecureClient {
     remote function post(string path, RequestMessage message, TargetType targetType = Response)
             returns Response|PayloadType|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);
-        Response res = check self.httpClient->post(path, req);
+        Response|PayloadType res = check self.httpClient->post(path, req);
         Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
         if (inspection is Request) {
             return self.httpClient->post(path, inspection);
@@ -96,7 +96,7 @@ public client class HttpSecureClient {
     remote function put(string path, RequestMessage message, TargetType targetType = Response)
             returns @tainted Response|PayloadType|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);
-        Response res = check self.httpClient->put(path, req);
+        Response|PayloadType res = check self.httpClient->put(path, req);
         Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
         if (inspection is Request) {
             return self.httpClient->put(path, inspection);
@@ -118,7 +118,7 @@ public client class HttpSecureClient {
     remote function execute(string httpVerb, string path, RequestMessage message, TargetType targetType = Response)
             returns @tainted Response|PayloadType|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);
-        Response res = check self.httpClient->execute(httpVerb, path, req);
+        Response|PayloadType res = check self.httpClient->execute(httpVerb, path, req);
         Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
         if (inspection is Request) {
             return self.httpClient->execute(httpVerb, path, inspection);
@@ -139,7 +139,7 @@ public client class HttpSecureClient {
     remote function patch(string path, RequestMessage message, TargetType targetType = Response)
             returns @tainted Response|PayloadType|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);
-        Response res = check self.httpClient->patch(path, req);
+        Response|PayloadType res = check self.httpClient->patch(path, req);
         Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
         if (inspection is Request) {
             return self.httpClient->patch(path, inspection);
@@ -160,7 +160,7 @@ public client class HttpSecureClient {
     remote function delete(string path, RequestMessage message = (), TargetType targetType = Response)
             returns @tainted Response|PayloadType|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);
-        Response res = check self.httpClient->delete(path, req);
+        Response|PayloadType res = check self.httpClient->delete(path, req);
         Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
         if (inspection is Request) {
             return self.httpClient->delete(path, inspection);
@@ -181,7 +181,7 @@ public client class HttpSecureClient {
     remote function get(string path, RequestMessage message = (), TargetType targetType = Response)
             returns @tainted Response|PayloadType|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);
-        Response res = check self.httpClient->get(path, message = req);
+        Response|PayloadType res = check self.httpClient->get(path, message = req);
         Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
         if (inspection is Request) {
             return self.httpClient->get(path, message = inspection);
@@ -202,7 +202,7 @@ public client class HttpSecureClient {
     remote function options(string path, RequestMessage message = (), TargetType targetType = Response)
             returns @tainted Response|PayloadType|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);
-        Response res = check self.httpClient->options(path, message = req);
+        Response|PayloadType res = check self.httpClient->options(path, message = req);
         Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
         if (inspection is Request) {
             return self.httpClient->options(path, message = inspection);
@@ -222,7 +222,7 @@ public client class HttpSecureClient {
     remote function forward(string path, Request request, TargetType targetType = Response)
             returns @tainted Response|PayloadType|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, request);
-        Response res = check self.httpClient->forward(path, req);
+        Response|PayloadType res = check self.httpClient->forward(path, req);
         Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
         if (inspection is Request) {
             return self.httpClient->forward(path, inspection);
@@ -240,12 +240,7 @@ public client class HttpSecureClient {
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation, or else an `http:ClientError` if the submission fails
     remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);
-        Response res = check self.httpClient->submit(httpVerb, path, req);
-        Request? inspection = check inspectRequest(self.clientAuthHandler, req, res);
-        if (inspection is Request) {
-            return self.httpClient->submit(httpVerb, path, inspection);
-        }
-        return res;
+        return self.httpClient->submit(httpVerb, path, req);
     }
 
     # This just passes the request to the actual network call.
@@ -318,8 +313,9 @@ isolated function enrichRequest(ClientAuthHandler clientAuthHandler, Request req
 }
 
 // Inspect the request using the relevant client auth handler.
-function inspectRequest(ClientAuthHandler clientAuthHandler, Request req, Response res) returns Request|ClientAuthError? {
-    if (clientAuthHandler is ClientOAuth2Handler) {
+isolated function inspectRequest(ClientAuthHandler clientAuthHandler, Request req, Response|PayloadType res)
+                                 returns Request|ClientAuthError? {
+    if (clientAuthHandler is ClientOAuth2Handler && res is Response) {
         return clientAuthHandler->inspect(req, res);
     }
 }


### PR DESCRIPTION
## Purpose
This PR add capability to retry the HTTP client automatically if it receives an 401 response while it is secured with OAuth2. Further, the response code also can be configured.

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/17

Related to https://github.com/ballerina-platform/module-ballerina-oauth2/pull/52
Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/584