### PR TITLE
Send optional parameters to introspection endpoint

### DIFF
--- a/http-ballerina/auth_listener_oauth2_handler.bal
+++ b/http-ballerina/auth_listener_oauth2_handler.bal
@@ -42,13 +42,13 @@ public client class ListenerOAuth2Handler {
     #
     # + data - The `http:Request` instance or `string` Authorization header
     # + expectedScopes - The expected scopes as `string` or `string[]`
-    # + customParams - Map of custom parameters that need to be sent to introspection endpoint
+    # + optionalParams - Map of optional parameters that need to be sent to introspection endpoint
     # + return - The `oauth2:IntrospectionResponse` instance or else `Unauthorized` or `Forbidden` type in case of an error
     remote isolated function authorize(Request|string data, string|string[]? expectedScopes = (),
-                                       map<string>? customParams = ())
+                                       map<string>? optionalParams = ())
                                        returns oauth2:IntrospectionResponse|Unauthorized|Forbidden {
         string credential = extractCredential(data);
-        oauth2:IntrospectionResponse|oauth2:Error details = self.provider.authorize(credential);
+        oauth2:IntrospectionResponse|oauth2:Error details = self.provider.authorize(credential, optionalParams);
         if (details is oauth2:Error || !details.active) {
             Unauthorized unauthorized = {};
             return unauthorized;


### PR DESCRIPTION
## Purpose
This PR support to add optional/custom parameters in OAuth2 introspection request.

Example: Support to add optional parameters like `client_id` and `client_certificate_thumbprint`
```
POST /oauth2/introspect 
HTTP/1.1Host: www.sample.com
Content-Type: application/x-www-form-urlencoded

Authorization: Basic some-token

client_id="some-value"&client_certificate_thumbprint=another-value&token=sample-token&token_type_hint=access_token
```

RFC: https://tools.ietf.org/html/rfc7662#section-2.1

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/23

Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/584