### PR TITLE
Remove unwanted Java exception recording

### DIFF
--- a/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
@@ -486,7 +486,6 @@ public abstract class AbstractHTTPAction {
                         ObserveUtils.getObserverContextOfCurrentFrame(context.getEnvironment());
                 if (observerContext != null) {
                     observerContext.addTag(ObservabilityConstants.TAG_KEY_ERROR, ObservabilityConstants.TAG_TRUE_VALUE);
-                    observerContext.addProperty(ObservabilityConstants.PROPERTY_ERROR_MESSAGE, throwable.getMessage());
                 }
             }
             super.onError(throwable);


### PR DESCRIPTION
## Purpose
> The recorded exception is a Java level exception and therefore we should not expose it to the user through Observability. Moreover, when an exception occurs such as IOException, it will return a Ballerina level error to the user which will be automatically recorded by Observability instrumentation. Therefore this need to be removed.

Related to ballerina-platform/ballerina-lang#27966

## Goals
> Remove unwanted Java level exception

## Approach
> The added tag had been removed as this will be automatically recorded by the compiler level instrumentation.
