### PR TITLE
Disable basic auth file user store support

### DIFF
--- a/http-ballerina-tests/tests/auth_listener_auth_handler_test.bal
+++ b/http-ballerina-tests/tests/auth_listener_auth_handler_test.bal
@@ -16,7 +16,6 @@
 
 // NOTE: All the tokens/credentials used in this test are dummy tokens/credentials and used only for testing purposes.
 
-import ballerina/auth;
 import ballerina/http;
 import ballerina/jwt;
 import ballerina/oauth2;

--- a/http-ballerina-tests/tests/auth_listener_auth_handler_test.bal
+++ b/http-ballerina-tests/tests/auth_listener_auth_handler_test.bal
@@ -22,6 +22,9 @@ import ballerina/jwt;
 import ballerina/oauth2;
 import ballerina/test;
 
+// TODO: Enable these tests once the configurable features supports for map data types.
+// https://github.com/ballerina-platform/ballerina-standard-library/issues/862
+
 //@test:Config {}
 //isolated function testListenerFileUserStoreBasicAuthHandlerAuthSuccess() {
 //    http:ListenerFileUserStoreBasicAuthHandler handler = new;

--- a/http-ballerina-tests/tests/auth_listener_auth_handler_test.bal
+++ b/http-ballerina-tests/tests/auth_listener_auth_handler_test.bal
@@ -22,88 +22,88 @@ import ballerina/jwt;
 import ballerina/oauth2;
 import ballerina/test;
 
-@test:Config {}
-isolated function testListenerFileUserStoreBasicAuthHandlerAuthSuccess() {
-    http:ListenerFileUserStoreBasicAuthHandler handler = new;
-    string basicAuthToken = "YWxpY2U6eHh4";
-    string headerValue = http:AUTH_SCHEME_BASIC + " " + basicAuthToken;
-    http:Request request = createSecureRequest(headerValue);
-    auth:UserDetails|http:Unauthorized authn1 = handler.authenticate(request);
-    if (authn1 is auth:UserDetails) {
-        test:assertEquals(authn1.username, "alice");
-        test:assertEquals(authn1.scopes, ["write", "update"]);
-    } else {
-        test:assertFail(msg = "Test Failed!");
-    }
-
-    auth:UserDetails|http:Unauthorized authn2 = handler.authenticate(headerValue);
-    if (authn2 is auth:UserDetails) {
-        test:assertEquals(authn2.username, "alice");
-        test:assertEquals(authn2.scopes, ["write", "update"]);
-    } else {
-        test:assertFail(msg = "Test Failed!");
-    }
-
-    http:Forbidden? authz1 = handler.authorize(<auth:UserDetails>authn1, "write");
-    if (authz1 is http:Forbidden) {
-        test:assertFail(msg = "Test Failed!");
-    }
-
-    http:Forbidden? authz2 = handler.authorize(<auth:UserDetails>authn2, "update");
-    if (authz2 is http:Forbidden) {
-        test:assertFail(msg = "Test Failed!");
-    }
-}
-
-@test:Config {}
-isolated function testListenerFileUserStoreBasicAuthHandlerAuthzFailure() {
-    http:ListenerFileUserStoreBasicAuthHandler handler = new;
-    string basicAuthToken = "YWxpY2U6eHh4";
-    string headerValue = http:AUTH_SCHEME_BASIC + " " + basicAuthToken;
-    http:Request request = createSecureRequest(headerValue);
-    auth:UserDetails|http:Unauthorized authn1 = handler.authenticate(request);
-    if (authn1 is auth:UserDetails) {
-        test:assertEquals(authn1.username, "alice");
-        test:assertEquals(authn1.scopes, ["write", "update"]);
-    } else {
-        test:assertFail(msg = "Test Failed!");
-    }
-
-    auth:UserDetails|http:Unauthorized authn2 = handler.authenticate(headerValue);
-    if (authn2 is auth:UserDetails) {
-        test:assertEquals(authn2.username, "alice");
-        test:assertEquals(authn2.scopes, ["write", "update"]);
-    } else {
-        test:assertFail(msg = "Test Failed!");
-    }
-
-    http:Forbidden? authz1 = handler.authorize(<auth:UserDetails>authn1, "read");
-    if (authz1 is ()) {
-        test:assertFail(msg = "Test Failed!");
-    }
-
-    http:Forbidden? authz2 = handler.authorize(<auth:UserDetails>authn2, "read");
-    if (authz2 is ()) {
-        test:assertFail(msg = "Test Failed!");
-    }
-}
-
-@test:Config {}
-isolated function testListenerFileUserStoreBasicAuthHandlerAuthnFailure() {
-    http:ListenerFileUserStoreBasicAuthHandler handler = new;
-    string basicAuthToken = "YWxpY2U6aW52YWxpZA==";
-    string headerValue = http:AUTH_SCHEME_BASIC + " " + basicAuthToken;
-    http:Request request = createSecureRequest(headerValue);
-    auth:UserDetails|http:Unauthorized authn1 = handler.authenticate(request);
-    if (authn1 is auth:UserDetails) {
-        test:assertFail(msg = "Test Failed!");
-    }
-
-    auth:UserDetails|http:Unauthorized authn2 = handler.authenticate(headerValue);
-    if (authn2 is auth:UserDetails) {
-        test:assertFail(msg = "Test Failed!");
-    }
-}
+//@test:Config {}
+//isolated function testListenerFileUserStoreBasicAuthHandlerAuthSuccess() {
+//    http:ListenerFileUserStoreBasicAuthHandler handler = new;
+//    string basicAuthToken = "YWxpY2U6eHh4";
+//    string headerValue = http:AUTH_SCHEME_BASIC + " " + basicAuthToken;
+//    http:Request request = createSecureRequest(headerValue);
+//    auth:UserDetails|http:Unauthorized authn1 = handler.authenticate(request);
+//    if (authn1 is auth:UserDetails) {
+//        test:assertEquals(authn1.username, "alice");
+//        test:assertEquals(authn1.scopes, ["write", "update"]);
+//    } else {
+//        test:assertFail(msg = "Test Failed!");
+//    }
+//
+//    auth:UserDetails|http:Unauthorized authn2 = handler.authenticate(headerValue);
+//    if (authn2 is auth:UserDetails) {
+//        test:assertEquals(authn2.username, "alice");
+//        test:assertEquals(authn2.scopes, ["write", "update"]);
+//    } else {
+//        test:assertFail(msg = "Test Failed!");
+//    }
+//
+//    http:Forbidden? authz1 = handler.authorize(<auth:UserDetails>authn1, "write");
+//    if (authz1 is http:Forbidden) {
+//        test:assertFail(msg = "Test Failed!");
+//    }
+//
+//    http:Forbidden? authz2 = handler.authorize(<auth:UserDetails>authn2, "update");
+//    if (authz2 is http:Forbidden) {
+//        test:assertFail(msg = "Test Failed!");
+//    }
+//}
+//
+//@test:Config {}
+//isolated function testListenerFileUserStoreBasicAuthHandlerAuthzFailure() {
+//    http:ListenerFileUserStoreBasicAuthHandler handler = new;
+//    string basicAuthToken = "YWxpY2U6eHh4";
+//    string headerValue = http:AUTH_SCHEME_BASIC + " " + basicAuthToken;
+//    http:Request request = createSecureRequest(headerValue);
+//    auth:UserDetails|http:Unauthorized authn1 = handler.authenticate(request);
+//    if (authn1 is auth:UserDetails) {
+//        test:assertEquals(authn1.username, "alice");
+//        test:assertEquals(authn1.scopes, ["write", "update"]);
+//    } else {
+//        test:assertFail(msg = "Test Failed!");
+//    }
+//
+//    auth:UserDetails|http:Unauthorized authn2 = handler.authenticate(headerValue);
+//    if (authn2 is auth:UserDetails) {
+//        test:assertEquals(authn2.username, "alice");
+//        test:assertEquals(authn2.scopes, ["write", "update"]);
+//    } else {
+//        test:assertFail(msg = "Test Failed!");
+//    }
+//
+//    http:Forbidden? authz1 = handler.authorize(<auth:UserDetails>authn1, "read");
+//    if (authz1 is ()) {
+//        test:assertFail(msg = "Test Failed!");
+//    }
+//
+//    http:Forbidden? authz2 = handler.authorize(<auth:UserDetails>authn2, "read");
+//    if (authz2 is ()) {
+//        test:assertFail(msg = "Test Failed!");
+//    }
+//}
+//
+//@test:Config {}
+//isolated function testListenerFileUserStoreBasicAuthHandlerAuthnFailure() {
+//    http:ListenerFileUserStoreBasicAuthHandler handler = new;
+//    string basicAuthToken = "YWxpY2U6aW52YWxpZA==";
+//    string headerValue = http:AUTH_SCHEME_BASIC + " " + basicAuthToken;
+//    http:Request request = createSecureRequest(headerValue);
+//    auth:UserDetails|http:Unauthorized authn1 = handler.authenticate(request);
+//    if (authn1 is auth:UserDetails) {
+//        test:assertFail(msg = "Test Failed!");
+//    }
+//
+//    auth:UserDetails|http:Unauthorized authn2 = handler.authenticate(headerValue);
+//    if (authn2 is auth:UserDetails) {
+//        test:assertFail(msg = "Test Failed!");
+//    }
+//}
 
 @test:Config {}
 isolated function testListenerLdapUserStoreBasicAuthHandler() {

--- a/http-ballerina-tests/tests/auth_listener_declarative_design_test.bal
+++ b/http-ballerina-tests/tests/auth_listener_declarative_design_test.bal
@@ -180,9 +180,18 @@ function testResourceAuthnFailure() {
 @http:ServiceConfig {
     auth: [
         {
-            fileUserStoreConfig: {
-                tableName: "b7a.users",
-                scopeKey: "scopes"
+            oauth2IntrospectionConfig: {
+                url: "https://localhost:" + oauth2AuthorizationServerPort.toString() + "/oauth2/token/introspect",
+                tokenTypeHint: "access_token",
+                scopeKey: "scp",
+                clientConfig: {
+                    secureSocket: {
+                       trustStore: {
+                           path: TRUSTSTORE_PATH,
+                           password: "ballerina"
+                       }
+                    }
+                }
             },
             scopes: ["write", "update"]
         }
@@ -249,13 +258,13 @@ function testServiceResourceAuthnFailure() {
             },
             scopes: ["write", "update"]
         },
-        {
-            fileUserStoreConfig: {
-                tableName: "b7a.users",
-                scopeKey: "scopes"
-            },
-            scopes: ["write", "update"]
-        },
+        //{
+        //    fileUserStoreConfig: {
+        //        tableName: "b7a.users",
+        //        scopeKey: "scopes"
+        //    },
+        //    scopes: ["write", "update"]
+        //},
         {
             jwtValidatorConfig: {
                 issuer: "wso2",
@@ -315,13 +324,13 @@ service /bar on authListener {
                 },
                 scopes: ["write", "update"]
             },
-            {
-                fileUserStoreConfig: {
-                    tableName: "b7a.users",
-                    scopeKey: "scopes"
-                },
-                scopes: ["write", "update"]
-            },
+            //{
+            //    fileUserStoreConfig: {
+            //        tableName: "b7a.users",
+            //        scopeKey: "scopes"
+            //    },
+            //    scopes: ["write", "update"]
+            //},
             {
                 jwtValidatorConfig: {
                     issuer: "wso2",

--- a/http-ballerina-tests/tests/auth_listener_declarative_design_test.bal
+++ b/http-ballerina-tests/tests/auth_listener_declarative_design_test.bal
@@ -258,6 +258,8 @@ function testServiceResourceAuthnFailure() {
             },
             scopes: ["write", "update"]
         },
+        // TODO: Enable these tests once the configurable features supports for map data types.
+        // https://github.com/ballerina-platform/ballerina-standard-library/issues/862
         //{
         //    fileUserStoreConfig: {
         //        tableName: "b7a.users",
@@ -324,6 +326,8 @@ service /bar on authListener {
                 },
                 scopes: ["write", "update"]
             },
+            // TODO: Enable these tests once the configurable features supports for map data types.
+            // https://github.com/ballerina-platform/ballerina-standard-library/issues/862
             //{
             //    fileUserStoreConfig: {
             //        tableName: "b7a.users",

--- a/http-ballerina-tests/tests/datafiles/service_config.conf
+++ b/http-ballerina-tests/tests/datafiles/service_config.conf
@@ -3,15 +3,15 @@
 [hello]
 basePath="/hello"
 
-[b7a.users]
-
-[b7a.users.alice]
-password="xxx"
-scopes="write,update"
-
-[b7a.users.bob]
-password="yyy"
-scopes="read"
-
-[b7a.users.eve]
-password="123"
+# [b7a.users]
+#
+# [b7a.users.alice]
+# password="xxx"
+# scopes="write,update"
+#
+# [b7a.users.bob]
+# password="yyy"
+# scopes="read"
+#
+# [b7a.users.eve]
+# password="123"

--- a/http-ballerina/auth_desugar.bal
+++ b/http-ballerina/auth_desugar.bal
@@ -53,14 +53,14 @@ public isolated function authenticateResource(Service servieRef, string methodNa
 
 isolated function tryAuthenticate(ListenerAuthConfig[] authHandlers, string header) returns Unauthorized|Forbidden? {
     foreach ListenerAuthConfig config in authHandlers {
-        if (config is FileUserStoreConfigWithScopes) {
-            ListenerFileUserStoreBasicAuthHandler handler = new(config.fileUserStoreConfig);
-            auth:UserDetails|Unauthorized authn = handler.authenticate(header);
-            if (authn is auth:UserDetails) {
-                Forbidden? authz = handler.authorize(authn, <string|string[]>config?.scopes);
-                return authz;
-            }
-        } else if (config is LdapUserStoreConfigWithScopes) {
+        //if (config is FileUserStoreConfigWithScopes) {
+        //    ListenerFileUserStoreBasicAuthHandler handler = new(config.fileUserStoreConfig);
+        //    auth:UserDetails|Unauthorized authn = handler.authenticate(header);
+        //    if (authn is auth:UserDetails) {
+        //        Forbidden? authz = handler.authorize(authn, <string|string[]>config?.scopes);
+        //        return authz;
+        //    }
+        if (config is LdapUserStoreConfigWithScopes) {
             ListenerLdapUserStoreBasicAuthProvider handler = new(config.ldapUserStoreConfig);
             auth:UserDetails|Unauthorized authn = handler->authenticate(header);
             if (authn is auth:UserDetails) {

--- a/http-ballerina/auth_desugar.bal
+++ b/http-ballerina/auth_desugar.bal
@@ -53,6 +53,8 @@ public isolated function authenticateResource(Service servieRef, string methodNa
 
 isolated function tryAuthenticate(ListenerAuthConfig[] authHandlers, string header) returns Unauthorized|Forbidden? {
     foreach ListenerAuthConfig config in authHandlers {
+        // TODO: Enable these tests once the configurable features supports for map data types.
+        // https://github.com/ballerina-platform/ballerina-standard-library/issues/862
         //if (config is FileUserStoreConfigWithScopes) {
         //    ListenerFileUserStoreBasicAuthHandler handler = new(config.fileUserStoreConfig);
         //    auth:UserDetails|Unauthorized authn = handler.authenticate(header);

--- a/http-ballerina/auth_listener_file_user_store_basic_auth_handler.bal
+++ b/http-ballerina/auth_listener_file_user_store_basic_auth_handler.bal
@@ -14,6 +14,9 @@
 //// specific language governing permissions and limitations
 //// under the License.
 //
+// TODO: Enable these tests once the configurable features supports for map data types.
+// https://github.com/ballerina-platform/ballerina-standard-library/issues/862
+//
 //import ballerina/auth;
 //
 //# Represents file user store configurations for Basic Auth authentication.

--- a/http-ballerina/auth_listener_file_user_store_basic_auth_handler.bal
+++ b/http-ballerina/auth_listener_file_user_store_basic_auth_handler.bal
@@ -1,66 +1,66 @@
-// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+////
+//// WSO2 Inc. licenses this file to you under the Apache License,
+//// Version 2.0 (the "License"); you may not use this file except
+//// in compliance with the License.
+//// You may obtain a copy of the License at
+////
+//// http://www.apache.org/licenses/LICENSE-2.0
+////
+//// Unless required by applicable law or agreed to in writing,
+//// software distributed under the License is distributed on an
+//// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//// KIND, either express or implied.  See the License for the
+//// specific language governing permissions and limitations
+//// under the License.
 //
-// WSO2 Inc. licenses this file to you under the Apache License,
-// Version 2.0 (the "License"); you may not use this file except
-// in compliance with the License.
-// You may obtain a copy of the License at
+//import ballerina/auth;
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+//# Represents file user store configurations for Basic Auth authentication.
+//public type FileUserStoreConfig record {|
+//    *auth:FileUserStoreConfig;
+//|};
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
-import ballerina/auth;
-
-# Represents file user store configurations for Basic Auth authentication.
-public type FileUserStoreConfig record {|
-    *auth:FileUserStoreConfig;
-|};
-
-# Defines the file store Basic Auth handler for listener authentication.
-public class ListenerFileUserStoreBasicAuthHandler {
-
-    auth:ListenerFileUserStoreBasicAuthProvider provider;
-
-    # Initializes the `http:ListenerFileUserStoreBasicAuthHandler` object.
-    #
-    # + config - The `http:FileUserStoreConfig` instance
-    public isolated function init(FileUserStoreConfig config = {}) {
-        self.provider = new(config);
-    }
-
-    # Authenticates with the relevant authentication requirements.
-    #
-    # + data - The `http:Request` instance or `string` Authorization header
-    # + return - The `auth:UserDetails` instance or else `Unauthorized` type in case of an error
-    public isolated function authenticate(Request|string data) returns auth:UserDetails|Unauthorized {
-        string? credential = extractCredential(data);
-        if (credential is ()) {
-            Unauthorized unauthorized = {};
-            return unauthorized;
-        }
-        auth:UserDetails|auth:Error details = self.provider.authenticate(<string>credential);
-        if (details is auth:Error) {
-            Unauthorized unauthorized = {};
-            return unauthorized;
-        }
-        return checkpanic details;
-    }
-
-    # Authorizes with the relevant authorization requirements.
-    #
-    # + userDetails - The `auth:UserDetails` instance which is received from authentication results
-    # + expectedScopes - The expected scopes as `string` or `string[]`
-    # + return - `()`, if it is successful or else `Forbidden` type in case of an error
-    public isolated function authorize(auth:UserDetails userDetails, string|string[] expectedScopes) returns Forbidden? {
-        string[] actualScopes = userDetails.scopes;
-        boolean matched = matchScopes(actualScopes, expectedScopes);
-        if (!matched) {
-            return {};
-        }
-    }
-}
+//# Defines the file store Basic Auth handler for listener authentication.
+//public class ListenerFileUserStoreBasicAuthHandler {
+//
+//    auth:ListenerFileUserStoreBasicAuthProvider provider;
+//
+//    # Initializes the `http:ListenerFileUserStoreBasicAuthHandler` object.
+//    #
+//    # + config - The `http:FileUserStoreConfig` instance
+//    public isolated function init(FileUserStoreConfig config = {}) {
+//        self.provider = new(config);
+//    }
+//
+//    # Authenticates with the relevant authentication requirements.
+//    #
+//    # + data - The `http:Request` instance or `string` Authorization header
+//    # + return - The `auth:UserDetails` instance or else `Unauthorized` type in case of an error
+//    public isolated function authenticate(Request|string data) returns auth:UserDetails|Unauthorized {
+//        string? credential = extractCredential(data);
+//        if (credential is ()) {
+//            Unauthorized unauthorized = {};
+//            return unauthorized;
+//        }
+//        auth:UserDetails|auth:Error details = self.provider.authenticate(<string>credential);
+//        if (details is auth:Error) {
+//            Unauthorized unauthorized = {};
+//            return unauthorized;
+//        }
+//        return checkpanic details;
+//    }
+//
+//    # Authorizes with the relevant authorization requirements.
+//    #
+//    # + userDetails - The `auth:UserDetails` instance which is received from authentication results
+//    # + expectedScopes - The expected scopes as `string` or `string[]`
+//    # + return - `()`, if it is successful or else `Forbidden` type in case of an error
+//    public isolated function authorize(auth:UserDetails userDetails, string|string[] expectedScopes) returns Forbidden? {
+//        string[] actualScopes = userDetails.scopes;
+//        boolean matched = matchScopes(actualScopes, expectedScopes);
+//        if (!matched) {
+//            return {};
+//        }
+//    }
+//}

--- a/http-ballerina/auth_utils.bal
+++ b/http-ballerina/auth_utils.bal
@@ -33,15 +33,14 @@ public type ClientAuthConfig CredentialsConfig|BearerTokenConfig|JwtIssuerConfig
 type ClientAuthHandler ClientBasicAuthHandler|ClientBearerTokenAuthHandler|ClientSelfSignedJwtAuthHandler|ClientOAuth2Handler;
 
 # Defines the authentication configurations for the HTTP listener.
-public type ListenerAuthConfig FileUserStoreConfigWithScopes|
-                               LdapUserStoreConfigWithScopes|
+public type ListenerAuthConfig LdapUserStoreConfigWithScopes|
                                JwtValidatorConfigWithScopes|
                                OAuth2IntrospectionConfigWithScopes;
 
-public type FileUserStoreConfigWithScopes record {|
-   FileUserStoreConfig fileUserStoreConfig;
-   string|string[] scopes?;
-|};
+//public type FileUserStoreConfigWithScopes record {|
+//   FileUserStoreConfig fileUserStoreConfig;
+//   string|string[] scopes?;
+//|};
 
 public type LdapUserStoreConfigWithScopes record {|
    LdapUserStoreConfig ldapUserStoreConfig;

--- a/http-ballerina/auth_utils.bal
+++ b/http-ballerina/auth_utils.bal
@@ -37,6 +37,8 @@ public type ListenerAuthConfig LdapUserStoreConfigWithScopes|
                                JwtValidatorConfigWithScopes|
                                OAuth2IntrospectionConfigWithScopes;
 
+// TODO: Enable these tests once the configurable features supports for map data types.
+// https://github.com/ballerina-platform/ballerina-standard-library/issues/862
 //public type FileUserStoreConfigWithScopes record {|
 //   FileUserStoreConfig fileUserStoreConfig;
 //   string|string[] scopes?;


### PR DESCRIPTION
## Purpose
Disable "basic auth file user store" support for Swan Lake alpha release due to a limitation of `configurable` feature does not support for mapping types.

Related to: https://github.com/ballerina-platform/ballerina-standard-library/issues/584