### PR TITLE
Introduce byte stream related functionality to request/response

### DIFF
--- a/http-ballerina-tests/tests/http2_client_actions_test.bal
+++ b/http-ballerina-tests/tests/http2_client_actions_test.bal
@@ -14,7 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/io;
 import ballerina/http;
+import ballerina/lang.'string as strings;
 import ballerina/mime;
 import ballerina/test;
 
@@ -27,7 +29,7 @@ service /backEndService on new http:Listener(9122, { httpVersion: "2.0" }) {
         checkpanic caller->respond("Hello");
     }
 
-    // TODO: Enable with new byteStream API
+    // TODO: Enable after the I/O revamp
     // resource function post http2SendByteChannel(http:Caller caller, http:Request req) {
     //     var byteChannel = req.getByteChannel();
     //     if (byteChannel is io:ReadableByteChannel) {
@@ -36,6 +38,15 @@ service /backEndService on new http:Listener(9122, { httpVersion: "2.0" }) {
     //         checkpanic caller->respond(<@untainted> byteChannel.message());
     //     }
     // }
+
+    resource function post http2SendByteStream(http:Caller caller, http:Request req) {
+        var byteStream = req.getByteStream();
+        if (byteStream is stream<byte[], io:Error>) {
+            checkpanic caller->respond(<@untainted> byteStream);
+        } else {
+            checkpanic caller->respond(<@untainted> byteStream.message());
+        }
+    }
 
     resource function post http2PostReply(http:Caller caller, http:Request req) {
         if (req.hasHeader("content-type")) {
@@ -188,7 +199,7 @@ service /testHttp2Service on new http:Listener(9123, { httpVersion: "2.0" }) {
         checkpanic caller->respond(<@untainted> value);
     }
 
-    // TODO: Enable with new byteStream API
+    // TODO: Enable after the I/O revamp
     // resource function post testHttp2PostWithByteChannel(http:Caller caller, http:Request req) {
     //     string value = "";
     //     var byteChannel = req.getByteChannel();
@@ -209,6 +220,79 @@ service /testHttp2Service on new http:Listener(9123, { httpVersion: "2.0" }) {
     //     }
     //     checkpanic caller->respond(<@untainted> value);
     // }
+
+    resource function post testHttp2PostWithTextToStream(http:Caller caller, http:Request req) {
+        string value = "";
+        var text = req.getTextPayload();
+        if (text is string) {
+            var res = http2Client->post("/backEndService/http2SendByteStream", <@untainted> text);
+            if (res is http:Response) {
+                stream<byte[], io:Error>|http:ClientError str = res.getByteStream();
+                if (str is stream<byte[], io:Error>) {
+                    record {|byte[] value;|}|io:Error? arr1 = str.next();
+                    if (arr1 is record {|byte[] value;|}) {
+                        value = checkpanic strings:fromBytes(arr1.value);
+                    } else {
+                        value = "Found unexpected arr1 output type";
+                    }
+                } else {
+                    value = "Found unexpected str output type" + str.message();
+                }
+            } else if (res is error) {
+                value = res.message();
+            }
+        } else {
+            value = text.message();
+        }
+        checkpanic caller->respond(<@untainted> value);
+    }
+
+    resource function post testHttp2PostWithByteStream(http:Caller caller, http:Request req) {
+        string value = "";
+        stream<byte[], io:Error>|http:ClientError byteStream = req.getByteStream();
+        if (byteStream is stream<byte[], io:Error>) {
+            var res = http2Client->post("/backEndService/http2SendByteStream", <@untainted> byteStream);
+            if (res is http:Response) {
+                stream<byte[], io:Error>|error str = res.getByteStream();
+                if (str is stream<byte[], io:Error>) {
+                    record {|byte[] value;|}|io:Error? arr1 = str.next();
+                    if (arr1 is record {|byte[] value;|}) {
+                        value = checkpanic strings:fromBytes(arr1.value);
+                    } else {
+                        value = "Found unexpected arr1 output type";
+                    }
+                } else {
+                    value = "Found unexpected str output type" + str.message();
+                }
+            } else if (res is error) {
+                value = res.message();
+            }
+        } else {
+            value = byteStream.message();
+        }
+        checkpanic caller->respond(<@untainted> value);
+    }
+
+    resource function post testHttp2PostWithByteStreamToText(http:Caller caller, http:Request req) {
+        string value = "";
+        stream<byte[], io:Error>|http:ClientError byteStream = req.getByteStream();
+        if (byteStream is stream<byte[], io:Error>) {
+            var res = http2Client->post("/backEndService/http2SendByteStream", <@untainted> byteStream);
+            if (res is http:Response) {
+                var result = res.getTextPayload();
+                if (result is string) {
+                    value = result;
+                } else {
+                    value = result.message();
+                }
+            } else if (res is error) {
+                value = res.message();
+            }
+        } else {
+            value = byteStream.message();
+        }
+        checkpanic caller->respond(<@untainted> value);
+    }
 }
 
 @test:Config {}
@@ -256,11 +340,44 @@ public function testHttp2PostWithBlob() {
     }
 }
 
-// TODO: Enable with new byteStream API
+// TODO: Enable after the I/O revamp
 @test:Config {enable:false}
 public function testHttp2PostWithByteChannel() {
     http:Client clientEP = checkpanic new("http://localhost:9123");
     var resp = clientEP->post("/testHttp2Service/testHttp2PostWithByteChannel", "Sample Text");
+    if (resp is http:Response) {
+        assertTextPayload(resp.getTextPayload(), "Sample Text");
+    } else if (resp is error) {
+        test:assertFail(msg = "Found unexpected output: " +  resp.message());
+    }
+}
+
+@test:Config {}
+public function testHttp2PostWithTextToStream() {
+    http:Client clientEP = checkpanic new("http://localhost:9123");
+    var resp = clientEP->post("/testHttp2Service/testHttp2PostWithTextToStream", "Sample Text");
+    if (resp is http:Response) {
+        assertTextPayload(resp.getTextPayload(), "Sample Text");
+    } else if (resp is error) {
+        test:assertFail(msg = "Found unexpected output: " +  resp.message());
+    }
+}
+
+@test:Config {}
+public function testHttp2PostWithByteStream() {
+    http:Client clientEP = checkpanic new("http://localhost:9123");
+    var resp = clientEP->post("/testHttp2Service/testHttp2PostWithByteStream", "Sample Text");
+    if (resp is http:Response) {
+        assertTextPayload(resp.getTextPayload(), "Sample Text");
+    } else if (resp is error) {
+        test:assertFail(msg = "Found unexpected output: " +  resp.message());
+    }
+}
+
+@test:Config {}
+public function testHttp2PostWithByteStreamToTextPayloadOfClient() {
+    http:Client clientEP = checkpanic new("http://localhost:9123");
+    var resp = clientEP->post("/testHttp2Service/testHttp2PostWithByteStreamToText", "Sample Text");
     if (resp is http:Response) {
         assertTextPayload(resp.getTextPayload(), "Sample Text");
     } else if (resp is error) {

--- a/http-ballerina-tests/tests/http_client_actions_test.bal
+++ b/http-ballerina-tests/tests/http_client_actions_test.bal
@@ -14,9 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/http;
+import ballerina/io;
+import ballerina/lang.'string as strings;
 import ballerina/mime;
 import ballerina/test;
-import ballerina/http;
 
 listener http:Listener httpClientActionListenerEP1 = new(httpClientActionTestPort1);
 listener http:Listener httpClientActionListenerEP2 = new(httpClientActionTestPort2);
@@ -31,7 +33,7 @@ service /httpClientActionBE on httpClientActionListenerEP1 {
         checkpanic caller->respond("Hello");
     }
 
-    // TODO: Enable with new byteStream API
+    // TODO: Enable after the I/O revamp
     // resource function post byteChannel(http:Caller caller, http:Request req) {
     //     var byteChannel = req.getByteChannel();
     //     if (byteChannel is io:ReadableByteChannel) {
@@ -40,6 +42,15 @@ service /httpClientActionBE on httpClientActionListenerEP1 {
     //         checkpanic caller->respond(<@untainted> byteChannel.message());
     //     }
     // }
+
+    resource function post byteStream(http:Caller caller, http:Request req) {
+        var byteStream = req.getByteStream();
+        if (byteStream is stream<byte[], io:Error>) {
+            checkpanic caller->respond(<@untainted> byteStream);
+        } else {
+            checkpanic caller->respond(<@untainted> byteStream.message());
+        }
+    }
 
     resource function post directPayload(http:Caller caller, http:Request req) {
         if (req.hasHeader("content-type")) {
@@ -258,7 +269,7 @@ service /httpClientActionTestService on httpClientActionListenerEP2 {
       checkpanic caller->respond(<@untainted> backendPayload);
     }
 
-    // TODO: Enable with new byteStream API
+    // TODO: Enable after the I/O revamp
     // resource function post handleByteChannel(http:Caller caller, http:Request req) {
     //     string value = "";
     //     var byteChannel = req.getByteChannel();
@@ -279,6 +290,79 @@ service /httpClientActionTestService on httpClientActionListenerEP2 {
     //     }
     //     checkpanic caller->respond(<@untainted> value);
     // }
+
+    resource function post handleByteStream(http:Caller caller, http:Request req) {
+        string value = "";
+        var byteStream = req.getByteStream();
+        if (byteStream is stream<byte[], io:Error>) {
+            var res = clientEP2->post("/httpClientActionBE/byteStream", <@untainted> byteStream);
+            if (res is http:Response) {
+                stream<byte[], io:Error>|error str = res.getByteStream();
+                if (str is stream<byte[], io:Error>) {
+                    record {|byte[] value;|}|io:Error? arr1 = str.next();
+                    if (arr1 is record {|byte[] value;|}) {
+                        value = checkpanic strings:fromBytes(arr1.value);
+                    } else {
+                        value = "Found unexpected arr1 output type";
+                    }
+                } else {
+                    value = "Found unexpected str output type" + str.message();
+                }
+            } else if (res is error) {
+                value = res.message();
+            }
+        } else {
+            value = byteStream.message();
+        }
+        checkpanic caller->respond(<@untainted> value);
+    }
+
+    resource function post handleByteStreamToText(http:Caller caller, http:Request req) {
+        string value = "";
+        var byteStream = req.getByteStream();
+        if (byteStream is stream<byte[], io:Error>) {
+            var res = clientEP2->post("/httpClientActionBE/byteStream", <@untainted> byteStream);
+            if (res is http:Response) {
+                var result = res.getTextPayload();
+                if (result is string) {
+                    value = result;
+                } else {
+                    value = result.message();
+                }
+            } else if (res is error) {
+                value = res.message();
+            }
+        } else {
+            value = byteStream.message();
+        }
+        checkpanic caller->respond(<@untainted> value);
+    }
+
+    resource function post handleTextToByteStream(http:Caller caller, http:Request req) {
+        string value = "";
+        var text = req.getTextPayload();
+        if (text is string) {
+            var res = clientEP2->post("/httpClientActionBE/_bulk", <@untainted> text);
+            if (res is http:Response) {
+                stream<byte[], io:Error>|error str = res.getByteStream();
+                if (str is stream<byte[], io:Error>) {
+                    record {|byte[] value;|}|io:Error? arr1 = str.next();
+                    if (arr1 is record {|byte[] value;|}) {
+                        value = checkpanic strings:fromBytes(arr1.value);
+                    } else {
+                        value = "Found unexpected arr1 output type";
+                    }
+                } else {
+                    value = "Found unexpected str output type" + str.message();
+                }
+            } else if (res is error) {
+                value = res.message();
+            }
+        } else {
+            value = text.message();
+        }
+        checkpanic caller->respond(<@untainted> value);
+    }
 
     resource function get handleMultiparts(http:Caller caller, http:Request req) {
         string value = "";
@@ -385,10 +469,46 @@ function testPostWithBlob() {
     }
 }
 
-// TODO: Enable with new byteStream API
+// TODO: Enable after the I/O revamp
 @test:Config {enable:false}
 function testPostWithByteChannel() {
     var response = httpClientActionClient->post("/handleByteChannel", "Sample Text");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+        assertTextPayload(response.getTextPayload(), "Sample Text");
+    } else if (response is error) {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}
+
+@test:Config {}
+function testPostWithByteStream() {
+    var response = httpClientActionClient->post("/handleByteStream", "Sample Text");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+        assertTextPayload(response.getTextPayload(), "Sample Text");
+    } else if (response is error) {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}
+
+@test:Config {}
+function testPostWithByteStreamToText() {
+    var response = httpClientActionClient->post("/handleByteStreamToText", "Sample Text");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+        assertTextPayload(response.getTextPayload(), "Sample Text");
+    } else if (response is error) {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}
+
+@test:Config {}
+function testPostWithTextToByteStream() {
+    var response = httpClientActionClient->post("/handleTextToByteStream", "Sample Text");
     if (response is http:Response) {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), TEXT_PLAIN);

--- a/http-ballerina-tests/tests/multipart_response.bal
+++ b/http-ballerina-tests/tests/multipart_response.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/http;
+import ballerina/io;
 import ballerina/mime;
 import ballerina/test;
 
@@ -90,11 +91,10 @@ function testMultipartsInOutResponse() {
             } else {
                test:assertFail(msg = errorMessage + textPart.message());
             }
-            // TODO: Enable with new byteStream API
-            // io:ReadableByteChannel|error filePart = bodyParts[3].getByteChannel();
-            // if (filePart is error) {
-            //    test:assertFail(msg = errorMessage + filePart.message());
-            // }
+            stream<byte[], io:Error>|error filePart = bodyParts[3].getByteStream();
+            if (filePart is error) {
+               test:assertFail(msg = errorMessage + filePart.message());
+            }
         } else {
             test:assertFail(msg = errorMessage + bodyParts.message());
         }

--- a/http-ballerina-tests/tests/resiliency_unit_circuit_breaker_test.bal
+++ b/http-ballerina-tests/tests/resiliency_unit_circuit_breaker_test.bal
@@ -14,8 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/io;
 import ballerina/http;
-import ballerina/mime;
 import ballerina/lang.runtime as runtime;
 import ballerina/test;
 
@@ -343,9 +343,7 @@ public client class MockClient {
         return getUnsupportedError();
     }
 
-    remote function head(string path,
-                           http:Request|string|xml|json|byte[]|mime:Entity[]|() message = ())
-                                                                                returns http:Response|http:ClientError {
+    remote function head(string path, http:RequestMessage message = ()) returns http:Response|http:ClientError {
         return getUnsupportedError();
     }
 
@@ -433,8 +431,7 @@ public client class MockClient {
         return getUnsupportedError();
     }
 
-    remote function submit(string httpVerb, string path,
-                           http:Request|string|xml|json|byte[]|mime:Entity[]|() message)
+    remote function submit(string httpVerb, string path, http:RequestMessage message)
                                                                             returns http:HttpFuture|http:ClientError {
         return getUnsupportedError();
     }
@@ -530,8 +527,7 @@ function getUnsupportedError() returns http:ClientError {
     return error http:GenericClientError("Unsupported function for MockClient");
 }
 
-function buildRequest(http:Request|string|xml|json|byte[]|mime:Entity[]|() message) returns
-http:Request {
+function buildRequest(http:RequestMessage message) returns http:Request {
     http:Request request = new;
     if (message is ()) {
         return request;
@@ -545,6 +541,8 @@ http:Request {
         request.setBinaryPayload(message);
     } else if (message is json) {
         request.setJsonPayload(message);
+    } else if (message is stream<byte[], io:Error>) {
+        request.setByteStream(message);
     } else {
         request.setBodyParts(message);
     }

--- a/http-ballerina-tests/tests/resiliency_unit_failover_connector_test.bal
+++ b/http-ballerina-tests/tests/resiliency_unit_failover_connector_test.bal
@@ -14,10 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/io;
-import ballerina/mime;
-import ballerina/test;
 import ballerina/http;
+import ballerina/test;
 
 int counter = 0;
 
@@ -119,44 +117,37 @@ public client class FoMockClient {
         self.httpClient = simpleClient;
     }
 
-    remote function post(string path,
-                           http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message,
-                           http:TargetType targetType = http:Response) returns http:Response|http:PayloadType|http:ClientError {
+    remote function post(string path, http:RequestMessage message, http:TargetType targetType = http:Response)
+            returns http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedFOError();
     }
 
-    remote function head(string path, http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|()
-            message = ()) returns http:Response|http:ClientError {
+    remote function head(string path, http:RequestMessage message = ()) returns http:Response|http:ClientError {
         return getUnsupportedFOError();
     }
 
-    remote function put(string path, http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|()
-            message, http:TargetType targetType = http:Response) returns http:Response|http:PayloadType|http:ClientError
-             {
+    remote function put(string path, http:RequestMessage message, http:TargetType targetType = http:Response)
+            returns http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedFOError();
     }
 
-    remote function execute(string httpVerb, string path,
-                                   http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|()
-                                        message, http:TargetType targetType = http:Response) returns http:Response|http:PayloadType|http:ClientError {
+    remote function execute(string httpVerb, string path, http:RequestMessage message,
+            http:TargetType targetType = http:Response) returns http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedFOError();
     }
 
-    remote function patch(string path,
-                           http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message, http:TargetType targetType = http:Response)
-                                                                                returns http:Response|http:PayloadType|http:ClientError {
+    remote function patch(string path, http:RequestMessage message, http:TargetType targetType = http:Response)
+            returns http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedFOError();
     }
 
-    remote function delete(string path,
-                           http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message, http:TargetType targetType = http:Response)
-                                                                                returns http:Response|http:PayloadType|http:ClientError {
+    remote function delete(string path, http:RequestMessage message, http:TargetType targetType = http:Response)
+            returns http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedFOError();
     }
 
-    remote function get(string path,
-                            http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message, http:TargetType targetType = http:Response)
-                                                                                returns http:Response|http:PayloadType|http:ClientError {
+    remote function get(string path, http:RequestMessage message, http:TargetType targetType = http:Response)
+            returns http:Response|http:PayloadType|http:ClientError {
         http:Response response = new;
         var result = handleFailoverScenario(counter);
         if (result is http:Response) {
@@ -169,19 +160,18 @@ public client class FoMockClient {
         return response;
     }
 
-    remote function options(string path,
-           http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message = (), http:TargetType targetType = http:Response)
-                                                                                returns http:Response|http:PayloadType|http:ClientError {
+    remote function options(string path, http:RequestMessage message = (), http:TargetType targetType = http:Response)
+            returns http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedFOError();
     }
 
-    remote function forward(string path, http:Request req, http:TargetType targetType = http:Response) returns http:Response|http:PayloadType|http:ClientError {
+    remote function forward(string path, http:Request req, http:TargetType targetType = http:Response)
+            returns http:Response|http:PayloadType|http:ClientError {
         return getUnsupportedFOError();
     }
 
-    remote function submit(string httpVerb, string path,
-                           http:Request|string|xml|json|byte[]|io:ReadableByteChannel|mime:Entity[]|() message)
-                                                                            returns http:HttpFuture|http:ClientError {
+    remote function submit(string httpVerb, string path, http:RequestMessage message)
+            returns http:HttpFuture|http:ClientError {
         return getUnsupportedFOError();
     }
 

--- a/http-ballerina-tests/tests/service_dispatching_data_binding_test.bal
+++ b/http-ballerina-tests/tests/service_dispatching_data_binding_test.bal
@@ -303,9 +303,15 @@ function testDataBindingIncompatibleStructPayload() {
 function testDataBindingWithEmptyJsonPayload() {
     http:Request req = new;
     var response = dataBindingClient->get("/echo/body3");
+    //if (response is http:Response) {
+    //    assertJsonValue(response.getJsonPayload(), "Key", ());
+    //    assertJsonValue(response.getJsonPayload(), "Team", ());
+    //} else if (response is error) {
+    //    test:assertFail(msg = "Found unexpected output type: " + response.message());
+    //}
     if (response is http:Response) {
-        assertJsonValue(response.getJsonPayload(), "Key", ());
-        assertJsonValue(response.getJsonPayload(), "Team", ());
+        test:assertEquals(response.statusCode, 400, msg = "Found unexpected output");
+        assertTextPayload(response.getTextPayload(), "data binding failed: error(\"empty JSON document\")");            
     } else if (response is error) {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }

--- a/http-ballerina-tests/tests/service_native_in_request_function.bal
+++ b/http-ballerina-tests/tests/service_native_in_request_function.bal
@@ -326,7 +326,7 @@ service /requesthello on requestListner {
         checkpanic caller->respond(res);
     }
 
-    // TODO: Enable with new byteStream API
+    // TODO: Enable after the I/O revamp
     // resource function get GetByteChannel(http:Caller caller, http:Request req) {
     //     http:Response res = new;
     //     var returnResult = req.getByteChannel();
@@ -338,6 +338,18 @@ service /requesthello on requestListner {
     //     }
     //     checkpanic caller->respond(res);
     // }
+
+    resource function get GetByteStream(http:Caller caller, http:Request req) {
+        http:Response res = new;
+        var returnResult = req.getByteStream();
+        if (returnResult is error) {
+            res.setTextPayload("Error occurred");
+            res.statusCode = 500;
+        } else {
+            res.setByteStream(returnResult);
+        }
+        checkpanic caller->respond(res);
+    }
 
     resource function get RemoveHeader(http:Caller caller, http:Request inReq) {
         http:Request req = new;
@@ -581,13 +593,32 @@ function testGetRequestURLWithInService() {
     }
 }
 
-// TODO: Enable with new byteStream API
+// TODO: Enable after the I/O revamp
 // Test GetByteChannel function within a service. Send a json content as a request and then get a byte channel from
 // the Request and set that ByteChannel as the response content"
 @test:Config {enable:false}
 function testServiceGetByteChannel() {
     string value = "ballerina";
     string path = "/requesthello/GetByteChannel";
+    json payload = {lang: value };
+    string contentType = "application/json";
+    http:Request req = new;
+    req.setHeader("content-type", contentType);
+    req.setJsonPayload(payload);
+    var response = requestClient->get(path, req);
+    if (response is http:Response) {
+        assertJsonPayload(response.getJsonPayload(), payload);
+    } else if (response is error) {
+        test:assertFail(msg = "Test Failed! " + <string>response.message());
+    }
+}
+
+// Test GetByteStream function within a service. Send a json content as a request and then get a byte Stream from
+// the Request and set that ByteStream as the response content"
+@test:Config {}
+function testServiceGetByteStream() {
+    string value = "ballerina";
+    string path = "/requesthello/GetByteStream";
     json payload = {lang: value };
     string contentType = "application/json";
     http:Request req = new;

--- a/http-ballerina/caching_http_caching_client.bal
+++ b/http-ballerina/caching_http_caching_client.bal
@@ -55,7 +55,7 @@ public client class HttpCachingClient {
     # origin server. Responses received for POST requests invalidate the cached responses for the same resource.
     #
     # + path - Resource path
-    # + message - HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
+    # + message - HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`, `stream<byte[], io:Error>`,
     #             or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
@@ -77,8 +77,8 @@ public client class HttpCachingClient {
     # suitable response cannot be found will the request be directed to the origin server.
     #
     # + path - Resource path
-    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to establish the communication with the upstream server
     remote function head(@untainted string path, RequestMessage message = ()) returns @tainted
             Response|ClientError {
@@ -114,8 +114,8 @@ public client class HttpCachingClient {
     #
     # + httpMethod - HTTP method to be used for the request
     # + path - Resource path
-    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -141,8 +141,8 @@ public client class HttpCachingClient {
     # the origin server. Responses received for PATCH requests invalidate the cached responses for the same resource.
     #
     # + path - Resource path
-    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -163,8 +163,8 @@ public client class HttpCachingClient {
     # origin server. Responses received for DELETE requests invalidate the cached responses for the same resource.
     #
     # + path - Resource path
-    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -185,8 +185,8 @@ public client class HttpCachingClient {
     # response cannot be found will the request be directed to the origin server.
     #
     # + path - Request path
-    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -202,8 +202,8 @@ public client class HttpCachingClient {
     # origin server. Responses received for OPTIONS requests invalidate the cached responses for the same resource.
     #
     # + path - Request path
-    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -247,8 +247,8 @@ public client class HttpCachingClient {
     #
     # + httpVerb - The HTTP verb value
     # + path - The resource path
-    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - An `HttpFuture` that represents an asynchronous service invocation, or an error if the submission fails
     remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         return self.httpClient->submit(httpVerb, path, <Request>message);

--- a/http-ballerina/cookie_http_client.bal
+++ b/http-ballerina/cookie_http_client.bal
@@ -52,8 +52,8 @@ public client class CookieClient {
     # the cookie functionality for a given endpoint.
     #
     # + path - Request path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -70,8 +70,8 @@ public client class CookieClient {
     # the cookie functionality for a given endpoint.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -88,8 +88,8 @@ public client class CookieClient {
     # the cookie functionality for a given endpoint.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to establish the communication with the upstream server
     remote function head(@untainted string path, RequestMessage message = ()) returns @tainted
             Response|ClientError {
@@ -108,8 +108,8 @@ public client class CookieClient {
     # the cookie functionality for a given endpoint.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -143,8 +143,8 @@ public client class CookieClient {
     #
     # + httpVerb - HTTP verb value
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -161,8 +161,8 @@ public client class CookieClient {
     # the cookie functionality for a given endpoint.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -179,8 +179,8 @@ public client class CookieClient {
     # the cookie functionality for a given endpoint.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -197,8 +197,8 @@ public client class CookieClient {
     # the cookie functionality for a given endpoint.
     #
     # + path - Request path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -217,8 +217,8 @@ public client class CookieClient {
     #
     # + httpVerb - The HTTP verb value
     # + path - The resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - An `HttpFuture`, which represents an asynchronous service invocation or else an `http:ClientError` if the submission fails
     remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         Request request = <Request>message;

--- a/http-ballerina/http_client.bal
+++ b/http-ballerina/http_client.bal
@@ -42,8 +42,8 @@ public client class HttpClient {
     # The `HttpClient.post()` function can be used to send HTTP POST requests to HTTP endpoints.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -56,8 +56,8 @@ public client class HttpClient {
     # The `HttpClient.head()` function can be used to send HTTP HEAD requests to HTTP endpoints.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to establish the communication with the upstream server
     remote function head(@untainted string path, RequestMessage message = ()) returns @tainted
             Response|ClientError {
@@ -67,8 +67,8 @@ public client class HttpClient {
     # The `HttpClient.put()` function can be used to send HTTP PUT requests to HTTP endpoints.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -82,8 +82,8 @@ public client class HttpClient {
     #
     # + httpVerb - HTTP verb value
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -96,8 +96,8 @@ public client class HttpClient {
     # The `HttpClient.patch()` function can be used to send HTTP PATCH requests to HTTP endpoints.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -110,8 +110,8 @@ public client class HttpClient {
     # The `HttpClient.delete()` function can be used to send HTTP DELETE requests to HTTP endpoints.
     #
     # + path - Resource path
-    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -124,8 +124,8 @@ public client class HttpClient {
     # The `HttpClient.get()` function can be used to send HTTP GET requests to HTTP endpoints.
     #
     # + path - Request path
-    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -138,8 +138,8 @@ public client class HttpClient {
     # The `HttpClient.options()` function can be used to send HTTP OPTIONS requests to HTTP endpoints.
     #
     # + path - Request path
-    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -168,8 +168,8 @@ public client class HttpClient {
     #
     # + httpVerb - The HTTP verb value
     # + path - The resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation, or else an `http:ClientError` if the submission fails
     remote function submit(@untainted string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         return externSubmit(self, httpVerb, path, <Request>message);

--- a/http-ballerina/http_client_endpoint.bal
+++ b/http-ballerina/http_client_endpoint.bal
@@ -66,8 +66,8 @@ public client class Client {
     # The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -87,8 +87,8 @@ public client class Client {
     # The `Client.head()` function can be used to send HTTP HEAD requests to HTTP endpoints.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to establish the communication with the upstream server
     remote function head(@untainted string path, RequestMessage message = ()) returns @tainted
             Response|ClientError {
@@ -103,8 +103,8 @@ public client class Client {
     # The `Client.put()` function can be used to send HTTP PUT requests to HTTP endpoints.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -123,8 +123,8 @@ public client class Client {
     #
     # + httpVerb - HTTP verb value
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -142,8 +142,8 @@ public client class Client {
     # The `Client.patch()` function can be used to send HTTP PATCH requests to HTTP endpoints.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -161,8 +161,8 @@ public client class Client {
     # The `Client.delete()` function can be used to send HTTP DELETE requests to HTTP endpoints.
     #
     # + path - Resource path
-    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -180,8 +180,8 @@ public client class Client {
     # The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.
     #
     # + path - Request path
-    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -199,8 +199,8 @@ public client class Client {
     # The `Client.options()` function can be used to send HTTP OPTIONS requests to HTTP endpoints.
     #
     # + path - Request path
-    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -238,8 +238,8 @@ public client class Client {
     #
     # + httpVerb - The HTTP verb value
     # + path - The resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission fails
     remote function submit(@untainted string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         Request req = buildRequest(message);

--- a/http-ballerina/http_commons.bal
+++ b/http-ballerina/http_commons.bal
@@ -51,6 +51,8 @@ isolated function buildRequest(RequestMessage message) returns Request {
         request.setBinaryPayload(message);
     } else if (message is json) {
         request.setJsonPayload(message);
+    } else if (message is stream<byte[], io:Error>) {
+        request.setByteStream(message);
     } else {
         request.setBodyParts(message);
     }
@@ -71,6 +73,8 @@ isolated function buildResponse(ResponseMessage message) returns Response {
         response.setBinaryPayload(message);
     } else if (message is json) {
         response.setJsonPayload(message);
+    } else if (message is stream<byte[], io:Error>) {
+        response.setByteStream(message);
     } else {
         response.setBodyParts(message);
     }
@@ -310,4 +314,9 @@ isolated function externGetByteChannel(mime:Entity entity) returns @tainted io:R
 @java:Method {
     'class: "org.ballerinalang.net.http.nativeimpl.ExternHttpDataSourceBuilder",
     name: "getByteChannel"
+} external;
+
+isolated function externPopulateInputStream(mime:Entity entity) = @java:Method {
+    'class: "org.ballerinalang.net.http.nativeimpl.ExternHttpDataSourceBuilder",
+    name: "populateInputStream"
 } external;

--- a/http-ballerina/http_connection.bal
+++ b/http-ballerina/http_connection.bal
@@ -34,7 +34,7 @@ public client class Caller {
     # Sends the outbound response to the caller.
     #
     # + message - The outbound response or any payload of type `string`, `xml`, `json`, `byte[]`,
-    #             `io:ReadableByteChannel`, or `mime:Entity[]`
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - An `http:ListenerError` if failed to respond or else `()`
     remote isolated function respond(ResponseMessage message = ()) returns ListenerError? {
         Response response = buildResponse(message);

--- a/http-ballerina/http_secure_client.bal
+++ b/http-ballerina/http_secure_client.bal
@@ -49,8 +49,8 @@ public client class HttpSecureClient {
     # headers to the request and send the request to actual network call.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -65,8 +65,8 @@ public client class HttpSecureClient {
     # headers to the request and send the request to actual network call.
     #
     # + path - Resource path
-    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to establish the communication with the upstream server
     remote function head(@untainted string path, RequestMessage message = ()) returns @tainted
             Response|ClientError {
@@ -78,8 +78,8 @@ public client class HttpSecureClient {
     # headers to the request and send the request to actual network call.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -95,8 +95,8 @@ public client class HttpSecureClient {
     #
     # + httpVerb - HTTP verb value
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -111,8 +111,8 @@ public client class HttpSecureClient {
     # headers to the request and send the request to actual network call.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -127,8 +127,8 @@ public client class HttpSecureClient {
     # headers to the request and send the request to actual network call.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -143,8 +143,8 @@ public client class HttpSecureClient {
     # headers to the request and send the request to actual network call.
     #
     # + path - Request path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -159,8 +159,8 @@ public client class HttpSecureClient {
     # headers to the request and send the request to actual network call.
     #
     # + path - Request path
-    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -192,7 +192,7 @@ public client class HttpSecureClient {
     # + httpVerb - The HTTP verb value
     # + path - The resource path
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
-    #             `io:ReadableByteChannel`, or `mime:Entity[]`
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation, or else an `http:ClientError` if the submission fails
     remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         Request req = check enrichRequest(self.clientAuthHandler, <Request>message);

--- a/http-ballerina/http_types.bal
+++ b/http-ballerina/http_types.bal
@@ -14,13 +14,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/io;
 import ballerina/mime;
 
 # The types of messages that are accepted by HTTP `client` when sending out the outbound request.
-public type RequestMessage Request|string|xml|json|byte[]|mime:Entity[]|();
+public type RequestMessage Request|string|xml|json|byte[]|mime:Entity[]|stream<byte[], io:Error>|();
 
 # The types of messages that are accepted by HTTP `listener` when sending out the outbound response.
-public type ResponseMessage Response|string|xml|json|byte[]|mime:Entity[]|();
+public type ResponseMessage Response|string|xml|json|byte[]|mime:Entity[]|stream<byte[], io:Error>|();
 
 # The HTTP service type
 public type Service service object {

--- a/http-ballerina/redirect_http_client.bal
+++ b/http-ballerina/redirect_http_client.bal
@@ -49,7 +49,7 @@ public client class RedirectClient {
     #
     # + path - Resource path
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`,
-    #             `byte[]` or `mime:Entity[]`
+    #             `byte[]`, `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -68,8 +68,8 @@ public client class RedirectClient {
     # be performed automatically by this `RedirectClient.post()` function.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -89,7 +89,7 @@ public client class RedirectClient {
     #
     # + path - Resource path
     # + message - An optional HTTP outbound request message or or any payload of type `string`, `xml`, `json`,
-    #             `byte[]` or `mime:Entity[]`
+    #             `byte[]`, `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to establish the communication with the upstream server
     remote function head(@untainted string path, RequestMessage message = ()) returns @tainted
             Response|ClientError {
@@ -105,8 +105,8 @@ public client class RedirectClient {
     # performed automatically by this `RedirectClient.put()` function.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -139,8 +139,8 @@ public client class RedirectClient {
     #
     # + httpVerb - The HTTP verb value
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -165,8 +165,8 @@ public client class RedirectClient {
     # performed automatically by this `RedirectClient.patch()` function.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -185,8 +185,8 @@ public client class RedirectClient {
     # performed automatically by this `RedirectClient.delete()` function.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -205,8 +205,8 @@ public client class RedirectClient {
     # performed automatically by this `RedirectClient.options()` function.
     #
     # + path - Resource path
-    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`
-    #             `byte[]` or `mime:Entity[]`
+    # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`,
+    #             `byte[]`, `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -227,8 +227,8 @@ public client class RedirectClient {
     #
     # + httpVerb - The HTTP verb value
     # + path - The resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission fails
     remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
         return self.httpClient->submit(httpVerb, path, <Request>message);

--- a/http-ballerina/resiliency_failover_client.bal
+++ b/http-ballerina/resiliency_failover_client.bal
@@ -74,8 +74,8 @@ public client class FailoverClient {
     # The POST remote function implementation of the Failover Connector.
     #
     # + path - Resource path
-    # + message - HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -94,8 +94,8 @@ public client class FailoverClient {
     # The HEAD remote function implementation of the Failover Connector.
     #
     # + path - Resource path
-    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to establish the communication with the upstream server
     remote function head(@untainted string path, RequestMessage message = ()) returns @tainted
             Response|ClientError {
@@ -111,8 +111,8 @@ public client class FailoverClient {
     # The PATCH remote function implementation of the Failover Connector.
     #
     # + path - Resource path
-    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -131,8 +131,8 @@ public client class FailoverClient {
     # The PUT remote function  implementation of the Failover Connector.
     #
     # + path - Resource path
-    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -151,8 +151,8 @@ public client class FailoverClient {
     # The OPTIONS remote function implementation of the Failover Connector.
     #
     # + path - Resource path
-    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -190,8 +190,8 @@ public client class FailoverClient {
     #
     # + httpVerb - HTTP method to be used for the request
     # + path - Resource path
-    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -210,8 +210,8 @@ public client class FailoverClient {
     # The DELETE remote function implementation of the Failover Connector.
     #
     # + path - Resource path
-    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -230,8 +230,8 @@ public client class FailoverClient {
     # The GET remote function implementation of the Failover Connector.
     #
     # + path - Resource path
-    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -253,8 +253,8 @@ public client class FailoverClient {
     #
     # + httpVerb - The HTTP verb value
     # + path - The resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission
     #            fails
     remote function submit(string httpVerb, string path, RequestMessage message) returns @tainted HttpFuture|ClientError {

--- a/http-ballerina/resiliency_http_circuit_breaker.bal
+++ b/http-ballerina/resiliency_http_circuit_breaker.bal
@@ -157,8 +157,8 @@ public client class CircuitBreakerClient {
     # function of the underlying HTTP remote functions provider.
     #
     # + path - Resource path
-    # + message - A Request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - A Request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -181,8 +181,8 @@ public client class CircuitBreakerClient {
     # function of the underlying HTTP remote functions provider.
     #
     # + path - Resource path
-    # + message - A Request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - A Request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to establish the communication with the upstream server
     remote function head(@untainted string path, RequestMessage message = ()) returns @tainted
             Response|ClientError {
@@ -202,8 +202,8 @@ public client class CircuitBreakerClient {
     # function of the underlying HTTP remote functions provider.
     #
     # + path - Resource path
-    # + message - A Request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - A Request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -227,8 +227,8 @@ public client class CircuitBreakerClient {
     #
     # + httpVerb - HTTP verb to be used for the request
     # + path - Resource path
-    # + message - A Request or any payload of type `string`, `xml`, `json`, `byte[]` or
-    #             `mime:Entity[]`
+    # + message - A Request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -251,8 +251,8 @@ public client class CircuitBreakerClient {
     # function of the underlying HTTP remote functions provider.
     #
     # + path - Resource path
-    # + message - A Request or any payload of type `string`, `xml`, `json`, `byte[]` or
-    #             `mime:Entity[]`
+    # + message - A Request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -275,8 +275,8 @@ public client class CircuitBreakerClient {
     # function of the underlying HTTP remote functions provider.
     #
     # + path - Resource path
-    # + message - A Request or any payload of type `string`, `xml`, `json`, `byte[]` or
-    #             `mime:Entity[]`
+    # + message - A Request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -299,8 +299,8 @@ public client class CircuitBreakerClient {
     # function of the underlying HTTP remote functions provider.
     #
     # + path - Resource path
-    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -323,8 +323,8 @@ public client class CircuitBreakerClient {
     # function of the underlying HTTP remote functions provider.
     #
     # + path - Resource path
-    # + message - An optional HTTP Request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP Request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -372,8 +372,8 @@ public client class CircuitBreakerClient {
     #
     # + httpVerb - The HTTP verb value
     # + path - The resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission
     #            fails
     remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {

--- a/http-ballerina/resiliency_http_retry_client.bal
+++ b/http-ballerina/resiliency_http_retry_client.bal
@@ -66,8 +66,8 @@ public client class RetryClient {
     # retrying functionality for a given endpoint to recover from network level failures.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -86,8 +86,8 @@ public client class RetryClient {
     # retrying functionality for a given endpoint to recover from network level failures.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to establish the communication with the upstream server
     remote function head(@untainted string path, RequestMessage message = ()) returns @tainted
             Response|ClientError {
@@ -103,8 +103,8 @@ public client class RetryClient {
     # retrying functionality for a given endpoint to recover from network level failures.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -144,8 +144,8 @@ public client class RetryClient {
     #
     # + httpVerb - The HTTP verb value
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -164,8 +164,8 @@ public client class RetryClient {
     # retrying functionality for a given endpoint to recover from network level failures.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -184,8 +184,8 @@ public client class RetryClient {
     # retrying functionality for a given endpoint to recover from network level failures.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -204,8 +204,8 @@ public client class RetryClient {
     # retrying functionality for a given endpoint to recover from network level failures.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -224,8 +224,8 @@ public client class RetryClient {
     # retrying functionality for a given endpoint to recover from network level failures.
     #
     # + path - Resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -246,8 +246,8 @@ public client class RetryClient {
     #
     # + httpVerb - The HTTP verb value
     # + path - The resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission fails
     remote function submit(string httpVerb, string path, RequestMessage message) returns
             @tainted HttpFuture|ClientError {

--- a/http-ballerina/resiliency_load_balance_client.bal
+++ b/http-ballerina/resiliency_load_balance_client.bal
@@ -54,8 +54,8 @@ public client class LoadBalanceClient {
     # The POST remote function implementation of the LoadBalancer Connector.
     #
     # + path - Resource path
-    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -69,8 +69,8 @@ public client class LoadBalanceClient {
     # The HEAD remote function implementation of the LoadBalancer Connector.
     #
     # + path - Resource path
-    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - The response or an `http:ClientError` if failed to establish the communication with the upstream server
     remote function head(@untainted string path, RequestMessage message = ()) returns @tainted
             Response|ClientError {
@@ -81,8 +81,8 @@ public client class LoadBalanceClient {
     # The PATCH remote function implementation of the LoadBalancer Connector.
     #
     # + path - Resource path
-    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -96,8 +96,8 @@ public client class LoadBalanceClient {
     # The PUT remote function implementation of the Load Balance Connector.
     #
     # + path - Resource path
-    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -111,8 +111,8 @@ public client class LoadBalanceClient {
     # The OPTIONS remote function implementation of the LoadBalancer Connector.
     #
     # + path - Resource path
-    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -141,8 +141,8 @@ public client class LoadBalanceClient {
     #
     # + httpVerb - HTTP method to be used for the request
     # + path - Resource path
-    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -156,8 +156,8 @@ public client class LoadBalanceClient {
     # The DELETE remote function implementation of the LoadBalancer Connector.
     #
     # + path - Resource path
-    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -172,7 +172,7 @@ public client class LoadBalanceClient {
 
     # + path - Resource path
     # + message - An optional HTTP request or any payload of type `string`, `xml`, `json`, `byte[]`,
-    #             or `mime:Entity[]`
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + targetType - HTTP response or the payload type (`string`, `xml`, `json`, `byte[]`,`record {| anydata...; |}`, or
     #                `record {| anydata...; |}[]`), which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `http:ClientError` if failed to
@@ -187,8 +187,8 @@ public client class LoadBalanceClient {
     #
     # + httpVerb - The HTTP verb value
     # + path - The resource path
-    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`
-    #             or `mime:Entity[]`
+    # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
+    #             `stream<byte[], io:Error>`, or `mime:Entity[]`
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission
     #            fails
     remote function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {

--- a/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.net.http.actions.httpclient;
 
+import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BError;
@@ -345,9 +346,9 @@ public abstract class AbstractHTTPAction {
         try {
             if (entityObj != null) {
                 if (boundaryString != null) {
-                    serializeMultiparts(entityObj, messageOutputStream, boundaryString);
+                    serializeMultiparts(dataContext.getEnvironment(), entityObj, messageOutputStream, boundaryString);
                 } else {
-                    serializeDataSource(entityObj, messageOutputStream);
+                    serializeDataSource(dataContext.getEnvironment(), entityObj, messageOutputStream);
                 }
             }
         } catch (IOException | EncoderException serializerException) {
@@ -379,44 +380,52 @@ public abstract class AbstractHTTPAction {
      * Serialize multipart entity body. If an array of body parts exist, encode body parts else serialize body content
      * if it exist as a byte channel.
      *
+     * @param env                 Represents the runtime environment
      * @param entityObj           Represents the entity that holds the actual body
-     * @param boundaryString      Boundary string that should be used in encoding body parts
      * @param messageOutputStream Output stream to which the payload is written
+     * @param boundaryString      Boundary string that should be used in encoding body parts
      */
-    private static void serializeMultiparts(BObject entityObj, OutputStream messageOutputStream,
+    private static void serializeMultiparts(Environment env, BObject entityObj, OutputStream messageOutputStream,
                                             String boundaryString) throws IOException {
         BArray bodyParts = EntityBodyHandler.getBodyPartArray(entityObj);
         if (bodyParts != null && bodyParts.size() > 0) {
-            serializeMultipartDataSource(messageOutputStream, boundaryString, entityObj);
-        } else { //If the content is in a byte channel
-            serializeDataSource(entityObj, messageOutputStream);
+            serializeMultipartDataSource(env, messageOutputStream, boundaryString, entityObj);
+        } else {
+            serializeDataSource(env, entityObj, messageOutputStream);
         }
     }
 
     /**
      * Encode body parts with the given boundary and send it across the wire.
      *
+     * @param env                 Represents the runtime environment
      * @param boundaryString      Boundary string of multipart entity
      * @param entityObj           Represent ballerina entity struct
      * @param messageOutputStream Output stream to which the payload is written
      */
-    private static void serializeMultipartDataSource(OutputStream messageOutputStream,
+    private static void serializeMultipartDataSource(Environment env, OutputStream messageOutputStream,
                                                      String boundaryString, BObject entityObj) {
-        MultipartDataSource multipartDataSource = new MultipartDataSource(entityObj, boundaryString);
+        MultipartDataSource multipartDataSource = new MultipartDataSource(env, entityObj, boundaryString);
         multipartDataSource.serialize(messageOutputStream);
         HttpUtil.closeMessageOutputStream(messageOutputStream);
     }
 
-    private static void serializeDataSource(BObject entityObj, OutputStream messageOutputStream)
+    private static void serializeDataSource(Environment env, BObject entityObj, OutputStream messageOutputStream)
             throws IOException {
         Object messageDataSource = EntityBodyHandler.getMessageDataSource(entityObj);
         if (messageDataSource != null) {
             HttpUtil.serializeDataSource(messageDataSource, entityObj, messageOutputStream);
             HttpUtil.closeMessageOutputStream(messageOutputStream);
+        } else if (EntityBodyHandler.getByteStream(entityObj) != null) {
+            //When the entity body is a byte stream and when it is not null
+            EntityBodyHandler.writeByteStreamToOutputStream(env, entityObj, messageOutputStream);
+            HttpUtil.closeMessageOutputStream(messageOutputStream);
         } else if (EntityBodyHandler.getByteChannel(entityObj) != null) {
             //When the entity body is a byte channel and when it is not null
             EntityBodyHandler.writeByteChannelToOutputStream(entityObj, messageOutputStream);
             HttpUtil.closeMessageOutputStream(messageOutputStream);
+        } else {
+            logger.debug("Entity does not have a serializable payload");
         }
     }
 

--- a/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/actions/httpclient/AbstractHTTPAction.java
@@ -378,7 +378,7 @@ public abstract class AbstractHTTPAction {
 
     /**
      * Serialize multipart entity body. If an array of body parts exist, encode body parts else serialize body content
-     * if it exist as a byte channel.
+     * if it exist as a byte channel/stream.
      *
      * @param env                 Represents the runtime environment
      * @param entityObj           Represents the entity that holds the actual body

--- a/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/ExternHttpDataSourceBuilder.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/ExternHttpDataSourceBuilder.java
@@ -141,6 +141,11 @@ public class ExternHttpDataSourceBuilder extends MimeDataSourceBuilder {
     }
 
     public static Object getByteChannel(BObject entityObj) {
+        populateInputStream(entityObj);
+        return MimeEntityBody.getByteChannel(entityObj);
+    }
+
+    public static void populateInputStream(BObject entityObj) {
         HttpCarbonMessage httpCarbonMessage = (HttpCarbonMessage) entityObj.getNativeData(TRANSPORT_MESSAGE);
         if (httpCarbonMessage != null) {
             HttpMessageDataStreamer httpMessageDataStreamer = new HttpMessageDataStreamer(httpCarbonMessage);
@@ -151,7 +156,6 @@ public class ExternHttpDataSourceBuilder extends MimeDataSourceBuilder {
                         new EntityBodyChannel(httpMessageDataStreamer.getInputStream())));
             }
         }
-        return MimeEntityBody.getByteChannel(entityObj);
     }
 
     public static void constructNonBlockingDataSource(Future balFuture, BObject entity,

--- a/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/ConnectionAction.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/ConnectionAction.java
@@ -49,9 +49,9 @@ public abstract class ConnectionAction {
         outResponseStatusFuture.setHttpConnectorListener(outboundResStatusConnectorListener);
     }
 
-    static void serializeMsgDataSource(Object outboundMessageSource, BObject entityStruct,
-                                OutputStream messageOutputStream) {
-        serializeDataSource(outboundMessageSource, entityStruct, messageOutputStream);
+    static void serializeMsgDataSource(DataContext dataContext, Object outboundMessageSource, BObject entityStruct,
+                                       OutputStream messageOutputStream) {
+        serializeDataSource(dataContext.getEnvironment(), outboundMessageSource, entityStruct, messageOutputStream);
     }
 
     static HttpMessageDataStreamer getMessageDataStreamer(HttpCarbonMessage outboundResponse) {

--- a/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/PushPromisedResponse.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/PushPromisedResponse.java
@@ -73,7 +73,7 @@ public class PushPromisedResponse extends ConnectionAction {
         BObject entityObj = extractEntity(outboundResponseObj);
         if (entityObj != null) {
             Object outboundMessageSource = EntityBodyHandler.getMessageDataSource(entityObj);
-            serializeMsgDataSource(outboundMessageSource, entityObj, messageOutputStream);
+            serializeMsgDataSource(dataContext, outboundMessageSource, entityObj, messageOutputStream);
         }
     }
 }

--- a/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/ResponseWriter.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/ResponseWriter.java
@@ -120,28 +120,6 @@ public class ResponseWriter {
     }
 
     /**
-     * Serialize multipart entity body. If an array of body parts exist, encode body parts else serialize body content
-     * if it exist as a byte channel.
-     *
-     * @param env                 Represents the runtime environment
-     * @param boundaryString      Boundary string that should be used in encoding body parts
-     * @param entity              Represents the entity that holds the actual body
-     * @param messageOutputStream Represents the output stream
-     */
-    private static void serializeMultipartss(Environment env, String boundaryString, BObject entity,
-                                            OutputStream messageOutputStream) {
-        BArray bodyParts = EntityBodyHandler.getBodyPartArray(entity);
-        if (bodyParts != null && bodyParts.size() > 0) {
-            MultipartDataSource multipartDataSource = new MultipartDataSource(env, entity, boundaryString);
-            serializeDataSource(env, multipartDataSource, entity, messageOutputStream);
-            HttpUtil.closeMessageOutputStream(messageOutputStream);
-        } else {
-            serializeDataSource(env, EntityBodyHandler.getMessageDataSource(entity), entity,
-                                messageOutputStream);
-        }
-    }
-
-    /**
      * Serialize message datasource.
      *
      * @param env                   Represents the runtime environment


### PR DESCRIPTION
## Purpose
```ballerina
function getByteStream(int arraySize = 8196) returns @tainted stream<byte[], io:Error>|ClientError {}

function setByteStream(stream<byte[], io:Error> byteStream, string contentType = "application/octet-stream")

```
> Subsequent change of https://github.com/ballerina-platform/module-ballerina-mime/pull/59
> Request/Response serialization
> Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/863