### PR TITLE
Marking `cookie.toStringValue()` function public, so the users can directly set cookie object as a header without calling addCookie()

### DIFF
--- a/http-ballerina/cookie.bal
+++ b/http-ballerina/cookie.bal
@@ -121,8 +121,10 @@ public class Cookie {
         return true;
     }
 
-    // Gets the Cookie object in its string representation to be used in the ‘Set-Cookie’ header of the response.
-    function toStringValue() returns string {
+    # Gets the Cookie object in its string representation to be used in the ‘Set-Cookie’ header of the response.
+    #
+    # + return  - The string value of the ‘http:Cookie’
+    public function toStringValue() returns string {
         string setCookieHeaderValue = "";
         var temp1 = self.name;
         var temp2 = self.value;


### PR DESCRIPTION
## Purpose
Marked getting the string value of a cookie function public, so that this can be used in WebSocket-like connections to set the cookie object as a header as we don't expose the http:Response of the initial request to the users to call `addCookie()` function.