### PR TITLE
Move encode/decode APIs from encoding module

### DIFF
--- a/http-ballerina-tests/tests/url_encoding_decoding_test.bal
+++ b/http-ballerina-tests/tests/url_encoding_decoding_test.bal
@@ -1,0 +1,171 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@test:Config {}
+isolated function testEncode() {
+    string[] urls = [
+        "http://localhost:9090",
+        "http://localhost:9090/echoService/hello world/",
+        "http://localhost:9090/echoService?type=string&value=hello world",
+        "http://localhost:9090/echoService#abc",
+        "http://localhost:9090/echoService:abc",
+        "http://localhost:9090/echoService+abc",
+        "http://localhost:9090/echoService*abc",
+        "http://localhost:9090/echoService%abc",
+        "http://localhost:9090/echoService~abc"
+    ];
+
+    foreach var url in urls {
+        string|Error result = encode(url, "UTF-8");
+        if (result is string) {
+            test:assertFalse(result.includes(" "), msg = "Unexpected character.");
+            test:assertFalse(result.includes("*"), msg = "Unexpected character.");
+            test:assertFalse(result.includes("+"), msg = "Unexpected character.");
+            test:assertFalse(result.includes("%7E"), msg = "Unexpected character.");
+        } else {
+            test:assertFail(msg = "Error while encode. " + result.message());
+        }
+    }
+}
+
+@test:Config {}
+isolated function testInvalidEncode() {
+    string url = "http://localhost:9090/echoService#abc";
+    string|Error result = encode(url, "abc");
+    if (result is Error) {
+        string expectedErrMsg = "Error occurred while encoding the URL component. abc";
+        test:assertEquals(result.message(), expectedErrMsg, "Unexpected error message.");
+    } else {
+        test:assertFail(msg = "Expected error not found.");
+    }
+}
+
+@test:Config {}
+isolated function testSimpleUrlDecode() {
+    string encodedUrlValue = "http%3A%2F%2Flocalhost%3A9090";
+    string|Error result = decode(encodedUrlValue, "UTF-8");
+    if (result is string) {
+        string expectedUrl = "http://localhost:9090";
+        test:assertEquals(result, expectedUrl, msg = "Decoded URL string is not correct.");
+    } else {
+        test:assertFail(msg = "Error in decode. " + result.message());
+    }
+}
+
+@test:Config {}
+isolated function testUrlDecodeWithSpaces() {
+    string encodedUrlValue = "http%3A%2F%2Flocalhost%3A9090%2FechoService%2Fhello%20world%2F";
+    string|Error result = decode(encodedUrlValue, "UTF-8");
+    if (result is string) {
+        string expectedUrl = "http://localhost:9090/echoService/hello world/";
+        test:assertEquals(result, expectedUrl, msg = "Decoded URL string is not correct.");
+        test:assertTrue(result.includes(" "), msg = "Decoded URL string doesn't contain spaces.");
+    } else {
+        test:assertFail(msg = "Error in decode. " + result.message());
+    }
+}
+
+@test:Config {}
+isolated function testUrlDecodeWithHashSign() {
+    string encodedUrlValue = "http%3A%2F%2Flocalhost%3A9090%2FechoService%23abc";
+    string|Error result = decode(encodedUrlValue, "UTF-8");
+    if (result is string) {
+        string expectedUrl = "http://localhost:9090/echoService#abc";
+        test:assertEquals(result, expectedUrl, msg = "Decoded URL string is not correct.");
+        test:assertTrue(result.includes("#"), msg = "Decoded URL string doesn't contain # character.");
+    } else {
+        test:assertFail(msg = "Error in decode. " + result.message());
+    }
+}
+
+@test:Config {}
+isolated function testUrlDecodeWithColon() {
+    string encodedUrlValue = "http%3A%2F%2Flocalhost%3A9090%2FechoService%3Aabc";
+    string|Error result = decode(encodedUrlValue, "UTF-8");
+    if (result is string) {
+        string expectedUrl = "http://localhost:9090/echoService:abc";
+        test:assertEquals(result, expectedUrl, msg = "Decoded URL string is not correct.");
+        test:assertTrue(result.includes(":"), msg = "Decoded URL string doesn't contain : character.");
+    } else {
+        test:assertFail(msg = "Error in decode. " + result.message());
+    }
+}
+
+@test:Config {}
+isolated function testUrlDecodeWithPlusSign() {
+    string encodedUrlValue = "http%3A%2F%2Flocalhost%3A9090%2FechoService%2Babc";
+    string|Error result = decode(encodedUrlValue, "UTF-8");
+    if (result is string) {
+        string expectedUrl = "http://localhost:9090/echoService+abc";
+        test:assertEquals(result, expectedUrl, msg = "Decoded URL string is not correct.");
+        test:assertTrue(result.includes("+"), msg = "Decoded URL string doesn't contain + character.");
+    } else {
+        test:assertFail(msg = "Error in decode. " + result.message());
+    }
+}
+
+@test:Config {}
+isolated function testUrlDecodeWithAsterisk() {
+    string encodedUrlValue = "http%3A%2F%2Flocalhost%3A9090%2FechoService%2Aabc";
+    string|Error result = decode(encodedUrlValue, "UTF-8");
+    if (result is string) {
+        string expectedUrl = "http://localhost:9090/echoService*abc";
+        test:assertEquals(result, expectedUrl, msg = "Decoded URL string is not correct.");
+        test:assertTrue(result.includes("*"), msg = "Decoded URL string doesn't contain * character.");
+    } else {
+        test:assertFail(msg = "Error in decode. " + result.message());
+    }
+}
+
+@test:Config {}
+isolated function testUrlDecodeWithPercentageMark() {
+    string encodedUrlValue = "http%3A%2F%2Flocalhost%3A9090%2FechoService%25abc";
+    string|Error result = decode(encodedUrlValue, "UTF-8");
+    if (result is string) {
+        string expectedUrl = "http://localhost:9090/echoService%abc";
+        test:assertEquals(result, expectedUrl, msg = "Decoded URL string is not correct.");
+        test:assertTrue(result.includes("%"), msg = "Decoded URL string doesn't contain % character.");
+    } else {
+        test:assertFail(msg = "Error in decode. " + result.message());
+    }
+}
+
+@test:Config {}
+isolated function testUrlDecodeWithTilde() {
+    string encodedUrlValue = "http%3A%2F%2Flocalhost%3A9090%2FechoService~abc";
+    string|Error result = decode(encodedUrlValue, "UTF-8");
+    if (result is string) {
+        string expectedUrl = "http://localhost:9090/echoService~abc";
+        test:assertEquals(result, expectedUrl, msg = "Decoded URL string is not correct.");
+        test:assertTrue(result.includes("~"), msg = "Decoded URL string doesn't contain ~ character.");
+    } else {
+        test:assertFail(msg = "Error in decode. " + result.message());
+    }
+}
+
+@test:Config {}
+isolated function testInvalidDecode() {
+    string url = "http%3A%2F%2Flocalhost%3A9090%2FechoService~abc";
+    string|Error result = decode(url, "abc");
+    if (result is Error) {
+        string expectedErrMsg = "Error occurred while decoding the URL component. abc";
+        test:assertEquals(result.message(), expectedErrMsg, "Unexpected error message.");
+    } else {
+        test:assertFail(msg = "Expected error not found.");
+    }
+}

--- a/http-ballerina-tests/tests/url_encoding_decoding_test.bal
+++ b/http-ballerina-tests/tests/url_encoding_decoding_test.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/http;
 import ballerina/test;
 
 @test:Config {}
@@ -31,7 +32,7 @@ isolated function testEncode() {
     ];
 
     foreach var url in urls {
-        string|Error result = encode(url, "UTF-8");
+        string|http:Error result = http:encode(url, "UTF-8");
         if (result is string) {
             test:assertFalse(result.includes(" "), msg = "Unexpected character.");
             test:assertFalse(result.includes("*"), msg = "Unexpected character.");
@@ -46,8 +47,8 @@ isolated function testEncode() {
 @test:Config {}
 isolated function testInvalidEncode() {
     string url = "http://localhost:9090/echoService#abc";
-    string|Error result = encode(url, "abc");
-    if (result is Error) {
+    string|http:Error result = http:encode(url, "abc");
+    if (result is http:Error) {
         string expectedErrMsg = "Error occurred while encoding the URL component. abc";
         test:assertEquals(result.message(), expectedErrMsg, "Unexpected error message.");
     } else {
@@ -58,7 +59,7 @@ isolated function testInvalidEncode() {
 @test:Config {}
 isolated function testSimpleUrlDecode() {
     string encodedUrlValue = "http%3A%2F%2Flocalhost%3A9090";
-    string|Error result = decode(encodedUrlValue, "UTF-8");
+    string|http:Error result = http:decode(encodedUrlValue, "UTF-8");
     if (result is string) {
         string expectedUrl = "http://localhost:9090";
         test:assertEquals(result, expectedUrl, msg = "Decoded URL string is not correct.");
@@ -70,7 +71,7 @@ isolated function testSimpleUrlDecode() {
 @test:Config {}
 isolated function testUrlDecodeWithSpaces() {
     string encodedUrlValue = "http%3A%2F%2Flocalhost%3A9090%2FechoService%2Fhello%20world%2F";
-    string|Error result = decode(encodedUrlValue, "UTF-8");
+    string|http:Error result = http:decode(encodedUrlValue, "UTF-8");
     if (result is string) {
         string expectedUrl = "http://localhost:9090/echoService/hello world/";
         test:assertEquals(result, expectedUrl, msg = "Decoded URL string is not correct.");
@@ -83,7 +84,7 @@ isolated function testUrlDecodeWithSpaces() {
 @test:Config {}
 isolated function testUrlDecodeWithHashSign() {
     string encodedUrlValue = "http%3A%2F%2Flocalhost%3A9090%2FechoService%23abc";
-    string|Error result = decode(encodedUrlValue, "UTF-8");
+    string|http:Error result = http:decode(encodedUrlValue, "UTF-8");
     if (result is string) {
         string expectedUrl = "http://localhost:9090/echoService#abc";
         test:assertEquals(result, expectedUrl, msg = "Decoded URL string is not correct.");
@@ -96,7 +97,7 @@ isolated function testUrlDecodeWithHashSign() {
 @test:Config {}
 isolated function testUrlDecodeWithColon() {
     string encodedUrlValue = "http%3A%2F%2Flocalhost%3A9090%2FechoService%3Aabc";
-    string|Error result = decode(encodedUrlValue, "UTF-8");
+    string|http:Error result = http:decode(encodedUrlValue, "UTF-8");
     if (result is string) {
         string expectedUrl = "http://localhost:9090/echoService:abc";
         test:assertEquals(result, expectedUrl, msg = "Decoded URL string is not correct.");
@@ -109,7 +110,7 @@ isolated function testUrlDecodeWithColon() {
 @test:Config {}
 isolated function testUrlDecodeWithPlusSign() {
     string encodedUrlValue = "http%3A%2F%2Flocalhost%3A9090%2FechoService%2Babc";
-    string|Error result = decode(encodedUrlValue, "UTF-8");
+    string|http:Error result = http:decode(encodedUrlValue, "UTF-8");
     if (result is string) {
         string expectedUrl = "http://localhost:9090/echoService+abc";
         test:assertEquals(result, expectedUrl, msg = "Decoded URL string is not correct.");
@@ -122,7 +123,7 @@ isolated function testUrlDecodeWithPlusSign() {
 @test:Config {}
 isolated function testUrlDecodeWithAsterisk() {
     string encodedUrlValue = "http%3A%2F%2Flocalhost%3A9090%2FechoService%2Aabc";
-    string|Error result = decode(encodedUrlValue, "UTF-8");
+    string|http:Error result = http:decode(encodedUrlValue, "UTF-8");
     if (result is string) {
         string expectedUrl = "http://localhost:9090/echoService*abc";
         test:assertEquals(result, expectedUrl, msg = "Decoded URL string is not correct.");
@@ -135,7 +136,7 @@ isolated function testUrlDecodeWithAsterisk() {
 @test:Config {}
 isolated function testUrlDecodeWithPercentageMark() {
     string encodedUrlValue = "http%3A%2F%2Flocalhost%3A9090%2FechoService%25abc";
-    string|Error result = decode(encodedUrlValue, "UTF-8");
+    string|http:Error result = http:decode(encodedUrlValue, "UTF-8");
     if (result is string) {
         string expectedUrl = "http://localhost:9090/echoService%abc";
         test:assertEquals(result, expectedUrl, msg = "Decoded URL string is not correct.");
@@ -148,7 +149,7 @@ isolated function testUrlDecodeWithPercentageMark() {
 @test:Config {}
 isolated function testUrlDecodeWithTilde() {
     string encodedUrlValue = "http%3A%2F%2Flocalhost%3A9090%2FechoService~abc";
-    string|Error result = decode(encodedUrlValue, "UTF-8");
+    string|http:Error result = http:decode(encodedUrlValue, "UTF-8");
     if (result is string) {
         string expectedUrl = "http://localhost:9090/echoService~abc";
         test:assertEquals(result, expectedUrl, msg = "Decoded URL string is not correct.");
@@ -161,8 +162,8 @@ isolated function testUrlDecodeWithTilde() {
 @test:Config {}
 isolated function testInvalidDecode() {
     string url = "http%3A%2F%2Flocalhost%3A9090%2FechoService~abc";
-    string|Error result = decode(url, "abc");
-    if (result is Error) {
+    string|http:Error result = http:decode(url, "abc");
+    if (result is http:Error) {
         string expectedErrMsg = "Error occurred while decoding the URL component. abc";
         test:assertEquals(result.message(), expectedErrMsg, "Unexpected error message.");
     } else {

--- a/http-ballerina/http_commons.bal
+++ b/http-ballerina/http_commons.bal
@@ -46,7 +46,7 @@ public isolated function parseHeader(string headerValue) returns [string, map<an
 # + return - The `string` value of the encoded URL or an `http:Error` that occurred during encoding
 public isolated function encode(string url, string charset) returns string|Error = @java:Method {
     name: "encode",
-    'class: "org.ballerinalang.net.uri.nativeimpl.Encode",
+    'class: "org.ballerinalang.net.uri.nativeimpl.Encode"
 } external;
 
 # Decodes the given URL into a `string` using the provided charset.
@@ -60,7 +60,7 @@ public isolated function encode(string url, string charset) returns string|Error
 # + return - The `string` value of the decoded URL or an `http:Error` that occurred during decoding
 public isolated function decode(string url, string charset) returns string|Error = @java:Method {
     name: "decode",
-    'class: "org.ballerinalang.net.uri.nativeimpl.Decode",
+    'class: "org.ballerinalang.net.uri.nativeimpl.Decode"
 } external;
 
 isolated function buildRequest(RequestMessage message) returns Request {

--- a/http-ballerina/http_commons.bal
+++ b/http-ballerina/http_commons.bal
@@ -44,7 +44,7 @@ public isolated function parseHeader(string headerValue) returns [string, map<an
 # + url - URL to be encoded
 # + charset - Character set to be used in encoding the URL
 # + return - The `string` value of the encoded URL or an `http:Error` that occurred during encoding
-public isolated function encode(string url, string charset) returns string|ClientError = @java:Method {
+public isolated function encode(string url, string charset) returns string|Error = @java:Method {
     name: "encode",
     'class: "org.ballerinalang.net.uri.nativeimpl.Encode",
 } external;
@@ -58,7 +58,7 @@ public isolated function encode(string url, string charset) returns string|Clien
 # + url - URL to be decoded
 # + charset - Character set to be used in decoding the URL
 # + return - The `string` value of the decoded URL or an `http:Error` that occurred during decoding
-public isolated function decode(string url, string charset) returns string|ClientError = @java:Method {
+public isolated function decode(string url, string charset) returns string|Error = @java:Method {
     name: "decode",
     'class: "org.ballerinalang.net.uri.nativeimpl.Decode",
 } external;

--- a/http-ballerina/http_commons.bal
+++ b/http-ballerina/http_commons.bal
@@ -35,6 +35,34 @@ public isolated function parseHeader(string headerValue) returns [string, map<an
     name: "parseHeader"
 } external;
 
+# Encodes the given URL into a `string` using the provided charset.
+# ```ballerina
+# string url = "https://www.example.com/?param1=http://xyz.com/?a=12&b=55¶m2=99";
+# string|http:Error encodedUrl = http:encode(url, "UTF-8");
+# ```
+#
+# + url - URL to be encoded
+# + charset - Character set to be used in encoding the URL
+# + return - The `string` value of the encoded URL or an `http:Error` that occurred during encoding
+public isolated function encode(string url, string charset) returns string|ClientError = @java:Method {
+    name: "encode",
+    'class: "org.ballerinalang.net.uri.nativeimpl.Encode",
+} external;
+
+# Decodes the given URL into a `string` using the provided charset.
+# ```ballerina
+# string encodedUrl = "https://www.example.com/?param1=http%3A%2F%2Fxyz.com%2F%3Fa%3D12%26b%3D55¶m2=99";
+# string|http:Error decodedUrl = http:decode(encodedUrl, "UTF-8");
+# ```
+#
+# + url - URL to be decoded
+# + charset - Character set to be used in decoding the URL
+# + return - The `string` value of the decoded URL or an `http:Error` that occurred during decoding
+public isolated function decode(string url, string charset) returns string|ClientError = @java:Method {
+    name: "decode",
+    'class: "org.ballerinalang.net.uri.nativeimpl.Decode",
+} external;
+
 isolated function buildRequest(RequestMessage message) returns Request {
     Request request = new;
     if (message is ()) {

--- a/http-ballerina/http_errors.bal
+++ b/http-ballerina/http_errors.bal
@@ -163,3 +163,6 @@ public type ClientError ResiliencyError|ClientAuthError|OutboundRequestError|
 
 # Defines the possible listener error types
 public type ListenerError GenericListenerError|InboundRequestError|OutboundResponseError;
+
+# Represents a generic error
+public type Error distinct error;

--- a/http-native/src/main/java/org/ballerinalang/net/uri/nativeimpl/Decode.java
+++ b/http-native/src/main/java/org/ballerinalang/net/uri/nativeimpl/Decode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.net.uri.nativeimpl;
+
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BString;
+import org.ballerinalang.net.http.HttpUtil;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+/**
+ * Decodes a given URL.
+ *
+ * @since 2.0.0
+ */
+public class Decode {
+
+    public static Object decode(BString url, BString charset) {
+        try {
+            return StringUtils.fromString(URLDecoder.decode(url.getValue(), charset.getValue()));
+        } catch (UnsupportedEncodingException e) {
+            return HttpUtil.createHttpError("Error occurred while decoding the URL. " + e.getMessage());
+        }
+    }
+}

--- a/http-native/src/main/java/org/ballerinalang/net/uri/nativeimpl/Encode.java
+++ b/http-native/src/main/java/org/ballerinalang/net/uri/nativeimpl/Encode.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.net.uri.nativeimpl;
+
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BString;
+import org.ballerinalang.net.http.HttpUtil;
+
+import java.net.URLEncoder;
+
+/**
+ * Encodes a given URL.
+ *
+ * @since 2.0.0
+ */
+public class Encode {
+
+    public static Object encode(BString url, BString charset) {
+        try {
+            String encoded = URLEncoder.encode(url.getValue(), charset.getValue());
+            StringBuilder buf = new StringBuilder(encoded.length());
+            char focus;
+            for (int i = 0; i < encoded.length(); i++) {
+                focus = encoded.charAt(i);
+                if (focus == '*') {
+                    buf.append("%2A");
+                } else if (focus == '+') {
+                    buf.append("%20");
+                } else if (focus == '%' && (i + 1) < encoded.length() && encoded.charAt(i + 1) == '7'
+                        && encoded.charAt(i + 2) == 'E') {
+                    buf.append('~');
+                    i += 2;
+                } else {
+                    buf.append(focus);
+                }
+            }
+            return StringUtils.fromString(buf.toString());
+        } catch (Throwable e) {
+            return HttpUtil.createHttpError("Error occurred while encoding the URL. " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
This PR moves the following 2 APIs of `ballerina/encoding` module,
```ballerina
public function encodeUriComponent(string uriComponent, string charset) returns string|Error {}
public function decodeUriComponent(string uriComponent, string charset) returns string|Error {}
```
into `ballerina/http` module as,
```ballerina
public function encode(string url, string charset) returns string|Error {}
public function decode(string url, string charset) returns string|Error {}
```

Related to: https://github.com/ballerina-platform/ballerina-standard-library/issues/907

Related to: https://github.com/ballerina-platform/ballerina-standard-library/issues/584