### PR TITLE
Extend listener auth handler APIs for `http:Headers` class

### DIFF
--- a/http-ballerina-tests/tests/auth_listener_declarative_design_test.bal
+++ b/http-ballerina-tests/tests/auth_listener_declarative_design_test.bal
@@ -19,29 +19,6 @@
 import ballerina/http;
 import ballerina/test;
 
-const string JWT1 = "eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiTlRBeFptTXhORE15WkRnM01UVTFaR00wTXpFek9ESmhaV0k" +
-                    "0TkRObFpEVTFPR0ZrTmpGaU1RIn0.eyJzdWIiOiJhZG1pbiIsICJpc3MiOiJ3c28yIiwgImV4cCI6MTkyNTk1NTcyNCwgIm" +
-                    "p0aSI6IjEwMDA3ODIzNGJhMjMiLCAiYXVkIjpbImJhbGxlcmluYSJdLCAic2NwIjoid3JpdGUifQ.H99ufLvCLFA5i1gfCt" +
-                    "klVdPrBvEl96aobNvtpEaCsO4v6_EgEZYz8Pg0B1Y7yJPbgpuAzXEg_CzowtfCTu3jUFf5FH_6M1fWGko5vpljtCb5Xknt_" +
-                    "YPqvbk5fJbifKeXqbkCGfM9c0GS0uQO5ss8StquQcofxNgvImRV5eEGcDdybkKBNkbA-sJFHd1jEhb8rMdT0M0SZFLnhrPL" +
-                    "8edbFZ-oa-ffLLls0vlEjUA7JiOSpnMbxRmT-ac6QjPxTQgNcndvIZVP2BHueQ1upyNorFKSMv8HZpATYHZjgnJQSpmt3Oa" +
-                    "oFJ6pgzbFuniVNuqYghikCQIizqzQNfC7JUD8wA";
-
-const string JWT2 = "eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiTlRBeFptTXhORE15WkRnM01UVTFaR00wTXpFek9ESmhaV0k" +
-                    "0TkRObFpEVTFPR0ZrTmpGaU1RIn0.eyJzdWIiOiJhZG1pbiIsICJpc3MiOiJ3c28yIiwgImV4cCI6MTkyNTk1NTg3NiwgIm" +
-                    "p0aSI6IjEwMDA3ODIzNGJhMjMiLCAiYXVkIjpbImJhbGxlcmluYSJdLCAic2NwIjoicmVhZCJ9.MVx_bJJpRyQryrTZ1-WC" +
-                    "1BkJdeBulX2CnxYN5Y4r1XbVd0-rgbCQ86jEbWvLZOybQ8Hx7MB9thKaBvidBnctgMM1JzG-ULahl-afoyTCv_qxMCS-5B7" +
-                    "AUA1f-sOQHzq-n7T3b0FKsWtmOEXbGmRxQFv89_v8xwUzIItXtZ6IjkoiZn5GerGrozX0DEBDAeG-2BOj8gSlsFENdPB5Sn" +
-                    "5oEM6-Chrn6KFLXo3GFTwLQELgYkIGjgnMQfbyLLaw5oyJUyOCCsdMZ4oeVLO2rdKZs1L8ZDnolUfcdm5mTxxP9A4mTOTd-" +
-                    "xC404MKwxkRhkgI4EJkcEwMHce2iCInZer10Q";
-
-const string JWT3 = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0Ij" +
-                    "oxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
-
-const string ACCESS_TOKEN_1 = "2YotnFZFEjr1zCsicMWpAA";
-const string ACCESS_TOKEN_2 = "1zCsicMWpAA2YotnFZFEjr";
-const string ACCESS_TOKEN_3 = "invalid-token";
-
 listener http:Listener authListener = new(securedListenerPort, {
     secureSocket: {
         keyStore: {

--- a/http-ballerina-tests/tests/auth_listener_imperative_design_test.bal
+++ b/http-ballerina-tests/tests/auth_listener_imperative_design_test.bal
@@ -1,0 +1,119 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// NOTE: All the tokens/credentials used in this test are dummy tokens/credentials and used only for testing purposes.
+
+import ballerina/http;
+import ballerina/jwt;
+import ballerina/test;
+
+http:ListenerJwtAuthHandler handler = new({
+    issuer: "wso2",
+    audience: "ballerina",
+    signatureConfig: {
+        trustStoreConfig: {
+            trustStore: {
+                path: TRUSTSTORE_PATH,
+                password: "ballerina"
+            },
+            certAlias: "ballerina"
+        }
+    },
+    scopeKey: "scp"
+});
+
+service /imperative on authListener {
+    resource function get foo(http:Request req) returns string|http:Unauthorized|http:Forbidden {
+        jwt:Payload|http:Unauthorized authn = handler.authenticate(req);
+        if (authn is http:Unauthorized) {
+            return authn;
+        }
+        http:Forbidden? authz = handler.authorize(<jwt:Payload> authn, ["write", "update"]);
+        if (authz is http:Forbidden) {
+            return authz;
+        }
+        return "Hello World!";
+    }
+
+    resource function get bar(http:Headers headers) returns string|http:Unauthorized|http:Forbidden {
+        jwt:Payload|http:Unauthorized authn = handler.authenticate(headers);
+        if (authn is http:Unauthorized) {
+            return authn;
+        }
+        http:Forbidden? authz = handler.authorize(<jwt:Payload> authn, ["write", "update"]);
+        if (authz is http:Forbidden) {
+            return authz;
+        }
+        return "Hello World!";
+    }
+
+    resource function get baz(@http:Header { name: "Authorization" } string headers) returns string|http:Unauthorized|http:Forbidden {
+        jwt:Payload|http:Unauthorized authn = handler.authenticate(headers);
+        if (authn is http:Unauthorized) {
+            return authn;
+        }
+        http:Forbidden? authz = handler.authorize(<jwt:Payload> authn, ["write", "update"]);
+        if (authz is http:Forbidden) {
+            return authz;
+        }
+        return "Hello World!";
+    }
+}
+
+@test:Config {}
+function testImperativeAuthSuccess1() {
+    assertSuccess(sendBearerTokenRequest("/imperative/foo", JWT1));
+}
+
+@test:Config {}
+function testImperativeAuthzFailure1() {
+    assertForbidden(sendBearerTokenRequest("/imperative/foo", JWT2));
+}
+
+@test:Config {}
+function testImperativeAuthnFailure1() {
+    assertUnauthorized(sendBearerTokenRequest("/imperative/foo", JWT3));
+}
+
+@test:Config {}
+function testImperativeAuthSuccess2() {
+    assertSuccess(sendBearerTokenRequest("/imperative/bar", JWT1));
+}
+
+@test:Config {}
+function testImperativeAuthzFailure2() {
+    assertForbidden(sendBearerTokenRequest("/imperative/bar", JWT2));
+}
+
+@test:Config {}
+function testImperativeAuthnFailure2() {
+    assertUnauthorized(sendBearerTokenRequest("/imperative/bar", JWT3));
+}
+
+@test:Config {}
+function testImperativeAuthSuccess3() {
+    assertSuccess(sendBearerTokenRequest("/imperative/baz", JWT1));
+}
+
+@test:Config {}
+function testImperativeAuthzFailure3() {
+    assertForbidden(sendBearerTokenRequest("/imperative/baz", JWT2));
+}
+
+@test:Config {}
+function testImperativeAuthnFailure3() {
+    assertUnauthorized(sendBearerTokenRequest("/imperative/baz", JWT3));
+}

--- a/http-ballerina-tests/tests/auth_test_commons.bal
+++ b/http-ballerina-tests/tests/auth_test_commons.bal
@@ -23,6 +23,29 @@ import ballerina/test;
 const string KEYSTORE_PATH = "tests/certsandkeys/ballerinaKeystore.p12";
 const string TRUSTSTORE_PATH = "tests/certsandkeys/ballerinaTruststore.p12";
 
+const string JWT1 = "eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiTlRBeFptTXhORE15WkRnM01UVTFaR00wTXpFek9ESmhaV0k" +
+                    "0TkRObFpEVTFPR0ZrTmpGaU1RIn0.eyJzdWIiOiJhZG1pbiIsICJpc3MiOiJ3c28yIiwgImV4cCI6MTkyNTk1NTcyNCwgIm" +
+                    "p0aSI6IjEwMDA3ODIzNGJhMjMiLCAiYXVkIjpbImJhbGxlcmluYSJdLCAic2NwIjoid3JpdGUifQ.H99ufLvCLFA5i1gfCt" +
+                    "klVdPrBvEl96aobNvtpEaCsO4v6_EgEZYz8Pg0B1Y7yJPbgpuAzXEg_CzowtfCTu3jUFf5FH_6M1fWGko5vpljtCb5Xknt_" +
+                    "YPqvbk5fJbifKeXqbkCGfM9c0GS0uQO5ss8StquQcofxNgvImRV5eEGcDdybkKBNkbA-sJFHd1jEhb8rMdT0M0SZFLnhrPL" +
+                    "8edbFZ-oa-ffLLls0vlEjUA7JiOSpnMbxRmT-ac6QjPxTQgNcndvIZVP2BHueQ1upyNorFKSMv8HZpATYHZjgnJQSpmt3Oa" +
+                    "oFJ6pgzbFuniVNuqYghikCQIizqzQNfC7JUD8wA";
+
+const string JWT2 = "eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiTlRBeFptTXhORE15WkRnM01UVTFaR00wTXpFek9ESmhaV0k" +
+                    "0TkRObFpEVTFPR0ZrTmpGaU1RIn0.eyJzdWIiOiJhZG1pbiIsICJpc3MiOiJ3c28yIiwgImV4cCI6MTkyNTk1NTg3NiwgIm" +
+                    "p0aSI6IjEwMDA3ODIzNGJhMjMiLCAiYXVkIjpbImJhbGxlcmluYSJdLCAic2NwIjoicmVhZCJ9.MVx_bJJpRyQryrTZ1-WC" +
+                    "1BkJdeBulX2CnxYN5Y4r1XbVd0-rgbCQ86jEbWvLZOybQ8Hx7MB9thKaBvidBnctgMM1JzG-ULahl-afoyTCv_qxMCS-5B7" +
+                    "AUA1f-sOQHzq-n7T3b0FKsWtmOEXbGmRxQFv89_v8xwUzIItXtZ6IjkoiZn5GerGrozX0DEBDAeG-2BOj8gSlsFENdPB5Sn" +
+                    "5oEM6-Chrn6KFLXo3GFTwLQELgYkIGjgnMQfbyLLaw5oyJUyOCCsdMZ4oeVLO2rdKZs1L8ZDnolUfcdm5mTxxP9A4mTOTd-" +
+                    "xC404MKwxkRhkgI4EJkcEwMHce2iCInZer10Q";
+
+const string JWT3 = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0Ij" +
+                    "oxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+const string ACCESS_TOKEN_1 = "2YotnFZFEjr1zCsicMWpAA";
+const string ACCESS_TOKEN_2 = "1zCsicMWpAA2YotnFZFEjr";
+const string ACCESS_TOKEN_3 = "invalid-token";
+
 isolated function createDummyRequest() returns http:Request {
     http:Request request = new;
     request.rawPath = "/helloWorld/sayHello";

--- a/http-ballerina/auth_listener_file_user_store_basic_auth_handler.bal
+++ b/http-ballerina/auth_listener_file_user_store_basic_auth_handler.bal
@@ -35,9 +35,9 @@ public class ListenerFileUserStoreBasicAuthHandler {
 
     # Authenticates with the relevant authentication requirements.
     #
-    # + data - The `http:Request` instance or `string` Authorization header
+    # + data - The `http:Request` instance or `http:Headers` instance or `string` Authorization header
     # + return - The `auth:UserDetails` instance or else `Unauthorized` type in case of an error
-    public isolated function authenticate(Request|string data) returns auth:UserDetails|Unauthorized {
+    public isolated function authenticate(Request|Headers|string data) returns auth:UserDetails|Unauthorized {
         string|ListenerAuthError credential = extractCredential(data);
         if (credential is ListenerAuthError) {
             Unauthorized unauthorized = {

--- a/http-ballerina/auth_listener_jwt_auth_handler.bal
+++ b/http-ballerina/auth_listener_jwt_auth_handler.bal
@@ -40,9 +40,9 @@ public class ListenerJwtAuthHandler {
 
     # Authenticates with the relevant authentication requirements.
     #
-    # + data - The `http:Request` instance or `string` Authorization header
+    # + data - The `http:Request` instance or `http:Headers` instance or `string` Authorization header
     # + return - The `jwt:Payload` instance or else `Unauthorized` type in case of an error
-    public isolated function authenticate(Request|string data) returns jwt:Payload|Unauthorized {
+    public isolated function authenticate(Request|Headers|string data) returns jwt:Payload|Unauthorized {
         string|ListenerAuthError credential = extractCredential(data);
         if (credential is ListenerAuthError) {
             Unauthorized unauthorized = {

--- a/http-ballerina/auth_listener_ldap_user_store_basic_auth_provider.bal
+++ b/http-ballerina/auth_listener_ldap_user_store_basic_auth_provider.bal
@@ -35,9 +35,9 @@ public client class ListenerLdapUserStoreBasicAuthProvider {
 
     # Authenticates with the relevant authentication requirements.
     #
-    # + data - The `http:Request` instance or `string` Authorization header
+    # + data - The `http:Request` instance or `http:Headers` instance or `string` Authorization header
     # + return - The `auth:UserDetails` instance or else `Unauthorized` type in case of an error
-    remote isolated function authenticate(Request|string data) returns auth:UserDetails|Unauthorized {
+    remote isolated function authenticate(Request|Headers|string data) returns auth:UserDetails|Unauthorized {
         string|ListenerAuthError credential = extractCredential(data);
         if (credential is ListenerAuthError) {
             Unauthorized unauthorized = {

--- a/http-ballerina/auth_listener_oauth2_handler.bal
+++ b/http-ballerina/auth_listener_oauth2_handler.bal
@@ -40,11 +40,11 @@ public client class ListenerOAuth2Handler {
 
     # Authorizes with the relevant authentication & authorization requirements.
     #
-    # + data - The `http:Request` instance or `string` Authorization header
+    # + data - The `http:Request` instanceor `http:Headers` instance  or `string` Authorization header
     # + expectedScopes - The expected scopes as `string` or `string[]`
     # + optionalParams - Map of optional parameters that need to be sent to introspection endpoint
     # + return - The `oauth2:IntrospectionResponse` instance or else `Unauthorized` or `Forbidden` type in case of an error
-    remote isolated function authorize(Request|string data, string|string[]? expectedScopes = (),
+    remote isolated function authorize(Request|Headers|string data, string|string[]? expectedScopes = (),
                                        map<string>? optionalParams = ())
                                        returns oauth2:IntrospectionResponse|Unauthorized|Forbidden {
         string|ListenerAuthError credential = extractCredential(data);

--- a/http-ballerina/auth_listener_oauth2_handler.bal
+++ b/http-ballerina/auth_listener_oauth2_handler.bal
@@ -40,7 +40,7 @@ public client class ListenerOAuth2Handler {
 
     # Authorizes with the relevant authentication & authorization requirements.
     #
-    # + data - The `http:Request` instanceor `http:Headers` instance  or `string` Authorization header
+    # + data - The `http:Request` instance or `http:Headers` instance or `string` Authorization header
     # + expectedScopes - The expected scopes as `string` or `string[]`
     # + optionalParams - Map of optional parameters that need to be sent to introspection endpoint
     # + return - The `oauth2:IntrospectionResponse` instance or else `Unauthorized` or `Forbidden` type in case of an error

--- a/http-ballerina/auth_utils.bal
+++ b/http-ballerina/auth_utils.bal
@@ -89,22 +89,18 @@ isolated function buildCompleteErrorMessage(error err) returns string {
 
 // Extract the credential from `http:Request`, `http:Headers` or `string` header.
 isolated function extractCredential(Request|Headers|string data) returns string|ListenerAuthError {
-    if (data is Request) {
-        string|HeaderNotFoundError header = data.getHeader(AUTH_HEADER);
-        if (header is string) {
-            return regex:split(header, " ")[1];
-        } else {
-            return prepareListenerAuthError("Authorization header not available.", header);
-        }
-    } else if (data is Headers) {
-        string|HeaderNotFoundError header = data.getHeader(AUTH_HEADER);
-        if (header is string) {
-            return regex:split(header, " ")[1];
-        } else {
-            return prepareListenerAuthError("Authorization header not available.", header);
-        }
-    } else {
+    if (data is string) {
         return regex:split(<string>data, " ")[1];
+    } else {
+        object {
+            public function getHeader() returns string|HeaderNotFoundError;
+        } headers = data;
+        var header = headers.getHeader(AUTH_HEADER);
+        if (header is string) {
+            return regex:split(header, " ")[1];
+        } else {
+            return prepareListenerAuthError("Authorization header not available.", header);
+        }
     }
 }
 

--- a/http-ballerina/auth_utils.bal
+++ b/http-ballerina/auth_utils.bal
@@ -87,17 +87,24 @@ isolated function buildCompleteErrorMessage(error err) returns string {
     return message;
 }
 
-// Extract the credential from `http:Request` or `string` header.
-isolated function extractCredential(Request|string data) returns string|ListenerAuthError {
-    if (data is string) {
-        return regex:split(<string>data, " ")[1];
-    } else {
+// Extract the credential from `http:Request`, `http:Headers` or `string` header.
+isolated function extractCredential(Request|Headers|string data) returns string|ListenerAuthError {
+    if (data is Request) {
         string|HeaderNotFoundError header = data.getHeader(AUTH_HEADER);
         if (header is string) {
             return regex:split(header, " ")[1];
         } else {
             return prepareListenerAuthError("Authorization header not available.", header);
         }
+    } else if (data is Headers) {
+        string|HeaderNotFoundError header = data.getHeader(AUTH_HEADER);
+        if (header is string) {
+            return regex:split(header, " ")[1];
+        } else {
+            return prepareListenerAuthError("Authorization header not available.", header);
+        }
+    } else {
+        return regex:split(<string>data, " ")[1];
     }
 }
 

--- a/http-ballerina/auth_utils.bal
+++ b/http-ballerina/auth_utils.bal
@@ -93,7 +93,7 @@ isolated function extractCredential(Request|Headers|string data) returns string|
         return regex:split(<string>data, " ")[1];
     } else {
         object {
-            public function getHeader() returns string|HeaderNotFoundError;
+            public function getHeader(string headerName) returns string|HeaderNotFoundError;
         } headers = data;
         var header = headers.getHeader(AUTH_HEADER);
         if (header is string) {

--- a/http-ballerina/auth_utils.bal
+++ b/http-ballerina/auth_utils.bal
@@ -93,7 +93,7 @@ isolated function extractCredential(Request|Headers|string data) returns string|
         return regex:split(<string>data, " ")[1];
     } else {
         object {
-            public function getHeader(string headerName) returns string|HeaderNotFoundError;
+            public isolated function getHeader(string headerName) returns string|HeaderNotFoundError;
         } headers = data;
         var header = headers.getHeader(AUTH_HEADER);
         if (header is string) {


### PR DESCRIPTION
## Purpose
This PR extends the listener auth handler APIs for `http:Headers` class.

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1013

Related to: https://github.com/ballerina-platform/ballerina-standard-library/issues/584