### PR TITLE
Redesign HTTP listener/client SecureSocket API

### DIFF
--- a/http-ballerina-tests/tests/auth_listener_declarative_design_test.bal
+++ b/http-ballerina-tests/tests/auth_listener_declarative_design_test.bal
@@ -21,7 +21,7 @@ import ballerina/test;
 
 listener http:Listener authListener = new(securedListenerPort, {
     secureSocket: {
-        keyStore: {
+        key: {
             path: KEYSTORE_PATH,
             password: "ballerina"
         }

--- a/http-ballerina-tests/tests/auth_test_commons.bal
+++ b/http-ballerina-tests/tests/auth_test_commons.bal
@@ -67,7 +67,7 @@ function sendBasicTokenRequest(string path, string username, string password) re
             password: password
         },
         secureSocket: {
-            trustStore: {
+            cert: {
                 path: TRUSTSTORE_PATH,
                 password: "ballerina"
             }
@@ -82,7 +82,7 @@ function sendBearerTokenRequest(string path, string token) returns http:Response
             token: token
         },
         secureSocket: {
-            trustStore: {
+            cert: {
                 path: TRUSTSTORE_PATH,
                 password: "ballerina"
             }
@@ -118,7 +118,7 @@ isolated function assertUnauthorized(http:Response|http:ClientError response) {
 // Mock OAuth2 authorization server implementation, which treats the APIs with successful responses.
 listener http:Listener oauth2Listener = new(oauth2AuthorizationServerPort, {
     secureSocket: {
-        keyStore: {
+        key: {
             path: KEYSTORE_PATH,
             password: "ballerina"
         }

--- a/http-ballerina-tests/tests/http2_disable_ssl_test.bal
+++ b/http-ballerina-tests/tests/http2_disable_ssl_test.bal
@@ -41,7 +41,7 @@ service /hello on sslServerEp {
 
 http:ClientConfiguration sslDisabledConfig = {
     secureSocket: {
-        disable: true
+        enable: false
     },
     httpVersion: "2.0"
 };

--- a/http-ballerina-tests/tests/http2_disable_ssl_test.bal
+++ b/http-ballerina-tests/tests/http2_disable_ssl_test.bal
@@ -20,7 +20,7 @@ import ballerina/test;
 
 http:ListenerConfiguration helloWorldEPConfig = {
     secureSocket: {
-        keyStore: {
+        key: {
             path: "tests/certsandkeys/ballerinaKeystore.p12",
             password: "ballerina"
         }

--- a/http-ballerina-tests/tests/http2_mutual_ssl_test.bal
+++ b/http-ballerina-tests/tests/http2_mutual_ssl_test.bal
@@ -19,20 +19,22 @@ import ballerina/test;
 
 http:ListenerConfiguration http2MutualSslServiceConf = {
     secureSocket: {
-        keyStore: {
+        key: {
             path: "tests/certsandkeys/ballerinaKeystore.p12",
             password: "ballerina"
         },
-        trustStore: {
-            path: "tests/certsandkeys/ballerinaTruststore.p12",
-            password: "ballerina"
+        mutualSsl: {
+            verifyClient: http:REQUIRE,
+            cert: {
+                path: "tests/certsandkeys/ballerinaTruststore.p12",
+                password: "ballerina"
+            }
         },
         protocol: {
-            name: "TLSv1.2",
+            name: http:TLS,
             versions: ["TLSv1.2","TLSv1.1"]
         },
-        ciphers:["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"],
-        sslVerifyClient: "require"
+        ciphers:["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"]
     },
     httpVersion: "2.0"
 };
@@ -76,16 +78,16 @@ service /http2Service on http2Listener {
 
 http:ClientConfiguration http2MutualSslClientConf = {
     secureSocket:{
-        keyStore:{
+        key:{
             path: "tests/certsandkeys/ballerinaKeystore.p12",
             password: "ballerina"
         },
-        trustStore:{
+        cert: {
             path: "tests/certsandkeys/ballerinaTruststore.p12",
             password: "ballerina"
         },
         protocol:{
-            name: "TLSv1.2",
+            name: http:TLS,
             versions: ["TLSv1.2", "TLSv1.1"]
         },
         ciphers: ["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"]

--- a/http-ballerina-tests/tests/http2_mutual_ssl_with_certs_test.bal
+++ b/http-ballerina-tests/tests/http2_mutual_ssl_with_certs_test.bal
@@ -19,10 +19,14 @@ import ballerina/test;
 
 http:ListenerConfiguration sslConf = {
     secureSocket: {
-        keyFile: "tests/certsandkeys/private.key",
-        certFile: "tests/certsandkeys/public.crt",
-        trustedCertFile: "tests/certsandkeys/public.crt",
-        sslVerifyClient: "require"
+        key: {
+            certFile: "tests/certsandkeys/public.crt",
+            keyFile: "tests/certsandkeys/private.key"
+        },
+        mutualSsl: {
+            verifyClient: http:REQUIRE,
+            cert: "tests/certsandkeys/public.crt"
+        }
     },
     httpVersion: "2.0"
 };
@@ -65,9 +69,11 @@ service /mutualSslService on mutualSslistener {
 
 http:ClientConfiguration certsClientConf = {
     secureSocket:{
-        keyFile: "tests/certsandkeys/private.key",
-        certFile: "tests/certsandkeys/public.crt",
-        trustedCertFile: "tests/certsandkeys/public.crt"
+        cert: "tests/certsandkeys/public.crt",
+        key: {
+            keyFile: "tests/certsandkeys/private.key",
+            certFile: "tests/certsandkeys/public.crt"
+        }
     }
 };
 

--- a/http-ballerina-tests/tests/http2_to_http1_fallback_test.bal
+++ b/http-ballerina-tests/tests/http2_to_http1_fallback_test.bal
@@ -22,7 +22,7 @@ listener http:Listener serviceEndpointWithoutSSL = new(9101, { httpVersion: "2.0
 listener http:Listener serviceEndpointWithSSL = new(9105, {
     httpVersion: "2.0",
     secureSocket: {
-        keyStore: {
+        key: {
             path: "tests/certsandkeys/ballerinaKeystore.p12",
             password: "ballerina"
         }
@@ -58,7 +58,7 @@ public function testFallback() {
 public function testFallbackWithSSL() {
     http:Client clientEP = checkpanic new("https://localhost:9105", {
         secureSocket: {
-            trustStore: {
+            cert: {
                 path: "tests/certsandkeys/ballerinaTruststore.p12",
                 password: "ballerina"
             }

--- a/http-ballerina-tests/tests/http_echo_service_sample_test.bal
+++ b/http-ballerina-tests/tests/http_echo_service_sample_test.bal
@@ -26,7 +26,7 @@ http:Client echoServiceClient = check new("http://localhost:" + echoServiceTestP
 
 http:ListenerConfiguration echoHttpsServiceTestListenerEPConfig = {
     secureSocket: {
-        keyStore: {
+        key: {
             path: keystore,
             password: "ballerina"
         }
@@ -37,7 +37,7 @@ listener http:Listener echoHttpsServiceTestListenerEP = new(echoHttpsServiceTest
 
 http:ClientConfiguration echoHttpsServiceClientConfig = {
     secureSocket: {
-        trustStore: {
+        cert: {
             path: truststore,
             password: "ballerina"
         }

--- a/http-ballerina-tests/tests/http_redirects_test.bal
+++ b/http-ballerina-tests/tests/http_redirects_test.bal
@@ -25,7 +25,7 @@ listener http:Listener serviceEndpoint3 = new(9103);
 
 http:ListenerConfiguration httpsEPConfig = {
     secureSocket: {
-        keyStore: {
+        key: {
             path: "tests/certsandkeys/ballerinaKeystore.p12",
             password: "ballerina"
         }
@@ -53,7 +53,7 @@ http:ClientConfiguration endPoint4Config = {
 http:ClientConfiguration endPoint5Config = {
     followRedirects: { enabled: true },
     secureSocket: {
-        trustStore: {
+        cert: {
             path: "tests/certsandkeys/ballerinaTruststore.p12",
             password: "ballerina"
         }

--- a/http-ballerina-tests/tests/ssl_cipher_strength_test.bal
+++ b/http-ballerina-tests/tests/ssl_cipher_strength_test.bal
@@ -19,13 +19,15 @@ import ballerina/test;
 
 http:ListenerConfiguration strongCipherConfig = {
     secureSocket: {
-        keyStore: {
+        key: {
             path: "tests/certsandkeys/ballerinaKeystore.p12",
             password: "ballerina"
         },
-        trustStore: {
-            path: "tests/certsandkeys/ballerinaTruststore.p12",
-            password: "ballerina"
+        mutualSsl: {
+            cert: {
+                path: "tests/certsandkeys/ballerinaTruststore.p12",
+                password: "ballerina"
+            }
         }
         // Service will start with the strong cipher suites. No need to specify.
     }
@@ -44,13 +46,15 @@ service /strongService on strongCipher {
 
 http:ListenerConfiguration weakCipherConfig = {
     secureSocket: {
-        keyStore: {
+        key: {
             path: "tests/certsandkeys/ballerinaKeystore.p12",
             password: "ballerina"
         },
-        trustStore: {
-            path: "tests/certsandkeys/ballerinaTruststore.p12",
-            password: "ballerina"
+        mutualSsl: {
+            cert: {
+                path: "tests/certsandkeys/ballerinaTruststore.p12",
+                password: "ballerina"
+            }
         },
         ciphers: ["TLS_RSA_WITH_AES_128_CBC_SHA"]
     }
@@ -72,11 +76,11 @@ service /weakService on weakCipher {
 public function testWithStrongClientWithWeakService() {
     http:Client clientEP = checkpanic new("https://localhost:9227", {
         secureSocket: {
-            keyStore: {
+            key: {
                 path: "tests/certsandkeys/ballerinaKeystore.p12",
                 password: "ballerina"
             },
-            trustStore: {
+            cert: {
                 path: "tests/certsandkeys/ballerinaTruststore.p12",
                 password: "ballerina"
             },
@@ -96,11 +100,11 @@ public function testWithStrongClientWithWeakService() {
 public function testWithStrongClientWithStrongService() {
     http:Client clientEP = checkpanic new("https://localhost:9226", {
         secureSocket: {
-            keyStore: {
+            key: {
                 path: "tests/certsandkeys/ballerinaKeystore.p12",
                 password: "ballerina"
             },
-            trustStore: {
+            cert: {
                 path: "tests/certsandkeys/ballerinaTruststore.p12",
                 password: "ballerina"
             },

--- a/http-ballerina-tests/tests/ssl_disable_ssl_test.bal
+++ b/http-ballerina-tests/tests/ssl_disable_ssl_test.bal
@@ -19,7 +19,7 @@ import ballerina/test;
 
 http:ListenerConfiguration serviceConf = {
     secureSocket: {
-        keyStore: {
+        key: {
             path: "tests/certsandkeys/ballerinaKeystore.p12",
             password: "ballerina"
         }
@@ -38,8 +38,8 @@ service /httpsService on httpsListener {
 }
 
 http:ClientConfiguration disableSslClientConf = {
-    secureSocket:{
-        disable:true
+    secureSocket: {
+        disable: true
     }
 };
 

--- a/http-ballerina-tests/tests/ssl_disable_ssl_test.bal
+++ b/http-ballerina-tests/tests/ssl_disable_ssl_test.bal
@@ -39,7 +39,7 @@ service /httpsService on httpsListener {
 
 http:ClientConfiguration disableSslClientConf = {
     secureSocket: {
-        disable: true
+        enable: false
     }
 };
 

--- a/http-ballerina-tests/tests/ssl_mutual_ssl_test.bal
+++ b/http-ballerina-tests/tests/ssl_mutual_ssl_test.bal
@@ -19,28 +19,24 @@ import ballerina/test;
 
 http:ListenerConfiguration mutualSslServiceConf = {
     secureSocket: {
-        keyStore: {
+        key: {
             path: "tests/certsandkeys/ballerinaKeystore.p12",
             password: "ballerina"
         },
-        trustStore: {
-            path: "tests/certsandkeys/ballerinaTruststore.p12",
-            password: "ballerina"
+        mutualSsl: {
+            verifyClient: http:REQUIRE,
+            cert: {
+                path: "tests/certsandkeys/ballerinaTruststore.p12",
+                password: "ballerina"
+            }
         },
         protocol: {
             name: "TLS",
             versions: ["TLSv1.1"]
         },
-        ciphers:["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"],
-        sslVerifyClient: "require",
-        certValidation: {
-            enable: false
-        },
-        ocspStapling: {
-            enable: false
-        },
-        handshakeTimeoutInSeconds: 20,
-        sessionTimeoutInSeconds: 30
+        ciphers: ["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"],
+        handshakeTimeout: 20,
+        sessionTimeout: 30
     }
 };
 
@@ -92,25 +88,21 @@ service /echoDummyService15 on echoDummy15 {
 
 http:ClientConfiguration mutualSslClientConf = {
     secureSocket:{
-        keyStore:{
+        key: {
             path: "tests/certsandkeys/ballerinaKeystore.p12",
             password: "ballerina"
         },
-        trustStore:{
+        cert: {
             path: "tests/certsandkeys/ballerinaTruststore.p12",
             password: "ballerina"
         },
-        protocol:{
-            name: "TLS",
+        protocol: {
+            name: http:SSL,
             versions: ["TLSv1.1"]
         },
         ciphers: ["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"],
-        certValidation: {
-            enable: false
-        },
-        ocspStapling: false,
-        handshakeTimeoutInSeconds: 20,
-        sessionTimeoutInSeconds: 30
+        handshakeTimeout: 20,
+        sessionTimeout: 30
     }
 };
 

--- a/http-ballerina-tests/tests/ssl_mutual_ssl_with_certs.bal
+++ b/http-ballerina-tests/tests/ssl_mutual_ssl_with_certs.bal
@@ -19,10 +19,14 @@ import ballerina/test;
 
 http:ListenerConfiguration mutualSslCertServiceConf = {
     secureSocket: {
-        keyFile: "tests/certsandkeys/private.key",
-        certFile: "tests/certsandkeys/public.crt",
-        trustedCertFile: "tests/certsandkeys/public.crt",
-        sslVerifyClient: "require"
+        key: {
+            certFile: "tests/certsandkeys/public.crt",
+            keyFile: "tests/certsandkeys/private.key"
+        },
+        mutualSsl: {
+            verifyClient: http:REQUIRE,
+            cert: "tests/certsandkeys/public.crt"
+        }
     }
 };
 
@@ -64,9 +68,11 @@ service /mutualSSLService on mutualSSLListener {
 
 http:ClientConfiguration mutualSslCertClientConf = {
     secureSocket:{
-        keyFile: "tests/certsandkeys/private.key",
-        certFile: "tests/certsandkeys/public.crt",
-        trustedCertFile: "tests/certsandkeys/public.crt"
+        cert: "tests/certsandkeys/public.crt",
+        key: {
+            keyFile: "tests/certsandkeys/private.key",
+            certFile: "tests/certsandkeys/public.crt"
+        }
     }
 };
 

--- a/http-ballerina-tests/tests/ssl_protocol_test.bal
+++ b/http-ballerina-tests/tests/ssl_protocol_test.bal
@@ -21,11 +21,12 @@ import ballerina/test;
 
 http:ListenerConfiguration sslProtocolServiceConfig = {
     secureSocket: {
-        keyStore: {
+        key: {
             path: "tests/certsandkeys/ballerinaKeystore.p12",
             password: "ballerina"
          },
          protocol: {
+             name: http:TLS,
              versions: ["TLSv1.1"]
          }
     }
@@ -45,11 +46,12 @@ service /protocol on sslProtocolListener {
 
 http:ClientConfiguration sslProtocolClientConfig = {
     secureSocket: {
-        trustStore: {
+        cert: {
             path: "tests/certsandkeys/ballerinaTruststore.p12",
             password: "ballerina"
         },
         protocol: {
+            name: http:TLS,
             versions: ["TLSv1.2"]
         }
     }

--- a/http-ballerina/http_client_endpoint.bal
+++ b/http-ballerina/http_client_endpoint.bal
@@ -424,7 +424,7 @@ public type RetryConfig record {|
 
 # Provides configurations for facilitating secure communication with a remote HTTP endpoint.
 #
-# + disable - Disable ssl validation.
+# + enable - Enable SSL validation
 # + cert - Configurations associated with `crypto:TrustStore` or single certificate file that the client trusts
 # + key - Configurations associated with `crypto:KeyStore` or combination of certificate and private key of the client
 # + protocol - SSL/TLS protocol related options
@@ -436,7 +436,7 @@ public type RetryConfig record {|
 # + handshakeTimeout - SSL handshake time out
 # + sessionTimeout - SSL session time out
 public type ClientSecureSocket record {|
-    boolean disable = false;
+    boolean enable = true;
     crypto:TrustStore|string cert?;
     crypto:KeyStore|CertKey key?;
     record {|

--- a/http-ballerina/http_client_endpoint.bal
+++ b/http-ballerina/http_client_endpoint.bal
@@ -428,7 +428,7 @@ public type RetryConfig record {|
 # + cert - Configurations associated with `crypto:TrustStore` or single certificate file that the client trusts
 # + key - Configurations associated with `crypto:KeyStore` or combination of certificate and private key of the client
 # + protocol - SSL/TLS protocol related options
-# + certValidation - Certificate validation against CRL_OCSP, OCSP_STAPLING related options
+# + certValidation - Certificate validation against OCSP_CRL, OCSP_STAPLING related options
 # + ciphers - List of ciphers to be used
 #             eg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
 # + verifyHostname - Enable/disable host name verification

--- a/http-ballerina/http_client_endpoint.bal
+++ b/http-ballerina/http_client_endpoint.bal
@@ -425,37 +425,34 @@ public type RetryConfig record {|
 # Provides configurations for facilitating secure communication with a remote HTTP endpoint.
 #
 # + disable - Disable ssl validation.
-# + trustStore - Configurations associated with TrustStore
-# + keyStore - Configurations associated with KeyStore
-# + certFile - A file containing the certificate of the client
-# + keyFile - A file containing the private key of the client
-# + keyPassword - Password of the private key if it is encrypted
-# + trustedCertFile - A file containing a list of certificates or a single certificate that the client trusts
+# + cert - Configurations associated with `crypto:TrustStore` or single certificate file that the client trusts
+# + key - Configurations associated with `crypto:KeyStore` or combination of certificate and private key of the client
 # + protocol - SSL/TLS protocol related options
-# + certValidation - Certificate validation against CRL or OCSP related options
+# + certValidation - Certificate validation against CRL_OCSP, OCSP_STAPLING related options
 # + ciphers - List of ciphers to be used
 #             eg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
 # + verifyHostname - Enable/disable host name verification
 # + shareSession - Enable/disable new SSL session creation
-# + ocspStapling - Enable/disable OCSP stapling
-# + handshakeTimeoutInSeconds - SSL handshake time out
-# + sessionTimeoutInSeconds - SSL session time out
+# + handshakeTimeout - SSL handshake time out
+# + sessionTimeout - SSL session time out
 public type ClientSecureSocket record {|
     boolean disable = false;
-    crypto:TrustStore? trustStore = ();
-    crypto:KeyStore? keyStore = ();
-    string certFile = "";
-    string keyFile = "";
-    string keyPassword = "";
-    string trustedCertFile = "";
-    Protocols? protocol = ();
-    ValidateCert? certValidation = ();
-    string[] ciphers = [];
-    boolean verifyHostname = true;
+    crypto:TrustStore|string cert?;
+    crypto:KeyStore|CertKey key?;
+    record {|
+        Protocol name;
+        string[] versions = [];
+    |} protocol?;
+    record {|
+        CertValidationType 'type = OCSP_STAPLING;
+        int cacheSize;
+        int cacheValidityPeriod;
+    |} certValidation?;
+    string[] ciphers?;
+    boolean verifyHostName = true;
     boolean shareSession = true;
-    boolean ocspStapling = false;
-    int handshakeTimeoutInSeconds?;
-    int sessionTimeoutInSeconds?;
+    decimal handshakeTimeout?;
+    decimal sessionTimeout?;
 |};
 
 # Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.

--- a/http-ballerina/http_service_endpoint.bal
+++ b/http-ballerina/http_service_endpoint.bal
@@ -190,7 +190,7 @@ public type RequestLimitConfigs record {|
 # + key - Configurations associated with `crypto:KeyStore` or combination of certificate and private key of the server
 # + mutualSsl - Configures associated with mutual SSL operations
 # + protocol - SSL/TLS protocol related options
-# + certValidation - Certificate validation against CRL_OCSP, OCSP_STAPLING related options
+# + certValidation - Certificate validation against OCSP_CRL, OCSP_STAPLING related options
 # + ciphers - List of ciphers to be used
 #             eg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
 # + shareSession - Enable/Disable new SSL session creation

--- a/http-ballerina/http_service_endpoint.bal
+++ b/http-ballerina/http_service_endpoint.bal
@@ -187,41 +187,69 @@ public type RequestLimitConfigs record {|
 
 # Configures the SSL/TLS options to be used for HTTP service.
 #
-# + trustStore - Configures the trust store to be used
-# + keyStore - Configures the key store to be used
-# + certFile - A file containing the certificate of the server
-# + keyFile - A file containing the private key of the server
-# + keyPassword - Password of the private key if it is encrypted
-# + trustedCertFile - A file containing a list of certificates or a single certificate that the server trusts
+# + key - Configurations associated with `crypto:KeyStore` or combination of certificate and private key of the server
+# + mutualSsl - Configures associated with mutual SSL operations
 # + protocol - SSL/TLS protocol related options
-# + certValidation - Certificate validation against CRL or OCSP related options
-# + ciphers - List of ciphers to be used (e.g.: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-#             TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)
-# + sslVerifyClient - The type of client certificate verification. (e.g.: "require" or "optional")
-# + shareSession - Enable/disable new SSL session creation
-# + handshakeTimeoutInSeconds - SSL handshake time out
-# + sessionTimeoutInSeconds - SSL session time out
-# + ocspStapling - Enable/disable OCSP stapling
+# + certValidation - Certificate validation against CRL_OCSP, OCSP_STAPLING related options
+# + ciphers - List of ciphers to be used
+#             eg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+# + shareSession - Enable/Disable new SSL session creation
+# + handshakeTimeout - SSL handshake time out
+# + sessionTimeout - SSL session time out
 public type ListenerSecureSocket record {|
-    crypto:TrustStore? trustStore = ();
-    crypto:KeyStore? keyStore = ();
-    string certFile = "";
-    string keyFile = "";
-    string keyPassword = "";
-    string trustedCertFile = "";
-    Protocols? protocol = ();
-    ValidateCert? certValidation = ();
+    crypto:KeyStore|CertKey key;
+    record {|
+        VerifyClient verifyClient = REQUIRE;
+        crypto:TrustStore|string cert;
+    |} mutualSsl?;
+    record {|
+        Protocol name;
+        string[] versions = [];
+    |} protocol?;
+    record {|
+        CertValidationType 'type = OCSP_STAPLING;
+        int cacheSize;
+        int cacheValidityPeriod;
+    |} certValidation?;
     string[] ciphers = ["TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
                         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
                         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
                         "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
                         "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"];
-    string sslVerifyClient = "";
     boolean shareSession = true;
-    int? handshakeTimeoutInSeconds = ();
-    int? sessionTimeoutInSeconds = ();
-    ListenerOcspStapling? ocspStapling = ();
+    decimal handshakeTimeout?;
+    decimal sessionTimeout?;
 |};
+
+# Represents combination of certificate, private key and private key password if encrypted.
+#
+# + certFile - A file containing the certificate
+# + keyFile - A file containing the private key
+# + keyPassword - Password of the private key if it is encrypted
+public type CertKey record {|
+   string certFile;
+   string keyFile;
+   string keyPassword?;
+|};
+
+# Represents client verify options.
+public enum VerifyClient {
+   REQUIRE,
+   OPTIONAL
+}
+
+# Represents protocol options.
+public enum Protocol {
+   SSL,
+   TLS,
+   DTLS
+}
+
+# Represents certification validation type options.
+public enum CertValidationType {
+   OCSP_CRL,
+   OCSP_STAPLING
+}
 
 # Defines the possible values for the keep-alive configuration in service and client endpoints.
 public type KeepAlive KEEPALIVE_AUTO|KEEPALIVE_ALWAYS|KEEPALIVE_NEVER;

--- a/http-ballerina/http_types.bal
+++ b/http-ballerina/http_types.bal
@@ -56,37 +56,6 @@ type safeHttpOperation HTTP_GET|HTTP_HEAD|HTTP_OPTIONS;
 // Common type used for HttpFuture and Response used for resiliency clients.
 type HttpResponse Response|HttpFuture;
 
-# A record for configuring SSL/TLS protocol and version to be used.
-#
-# + name - SSL Protocol to be used (e.g.: TLS1.2)
-# + versions - SSL/TLS protocols to be enabled (e.g.: TLSv1,TLSv1.1,TLSv1.2)
-public type Protocols record {|
-    string name = "";
-    string[] versions = [];
-|};
-
-# A record for providing configurations for certificate revocation status checks.
-#
-# + enable - The status of `validateCertEnabled`
-# + cacheSize - Maximum size of the cache
-# + cacheValidityPeriod - The time period for which a cache entry is valid
-public type ValidateCert record {|
-    boolean enable = false;
-    int cacheSize = 0;
-    int cacheValidityPeriod = 0;
-|};
-
-# A record for providing configurations for certificate revocation status checks.
-#
-# + enable - The status of OCSP stapling
-# + cacheSize - Maximum size of the cache
-# + cacheValidityPeriod - The time period for which a cache entry is valid
-public type ListenerOcspStapling record {|
-    boolean enable = false;
-    int cacheSize = 0;
-    int cacheValidityPeriod = 0;
-|};
-
 # A record for providing configurations for content compression.
 #
 # + enable - The status of compression

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -354,34 +354,33 @@ public class HttpConstants {
     public static final String ENABLE_PIPELINING = "enable";
     public static final BString PIPELINING_REQUEST_LIMIT = StringUtils.fromString("maxPipelinedRequests");
 
-    public static final BString ENDPOINT_CONFIG_SECURE_SOCKET = StringUtils.fromString("secureSocket");
-
-    public static final BString ENDPOINT_CONFIG_TRUST_STORE = StringUtils.fromString("trustStore");
-    public static final BString FILE_PATH = StringUtils.fromString("path");
-    public static final BString PASSWORD = StringUtils.fromString("password");
-    public static final BString SSL_PROTOCOL_VERSION = StringUtils.fromString("name");
-    public static final BString ENABLED_PROTOCOLS = StringUtils.fromString("versions");
-    public static final BString ENABLE = StringUtils.fromString("enable");
-    public static final BString ENDPOINT_CONFIG_OCSP_STAPLING = StringUtils.fromString("ocspStapling");
-    public static final BString ENDPOINT_CONFIG_KEY_STORE = StringUtils.fromString("keyStore");
-    public static final BString ENDPOINT_CONFIG_PROTOCOLS = StringUtils.fromString("protocol");
-    public static final BString ENDPOINT_CONFIG_VALIDATE_CERT = StringUtils.fromString("certValidation");
-    public static final BString ENDPOINT_CONFIG_CERTIFICATE = StringUtils.fromString("certFile");
-    public static final BString ENDPOINT_CONFIG_KEY = StringUtils.fromString("keyFile");
-    public static final BString ENDPOINT_CONFIG_KEY_PASSWORD = StringUtils.fromString("keyPassword");
-    public static final BString ENDPOINT_CONFIG_TRUST_CERTIFICATES = StringUtils.fromString("trustedCertFile");
-    public static final BString ENDPOINT_CONFIG_HANDSHAKE_TIMEOUT =
-            StringUtils.fromString("handshakeTimeoutInSeconds");
-    public static final BString ENDPOINT_CONFIG_SESSION_TIMEOUT = StringUtils.fromString("sessionTimeoutInSeconds");
-    public static final BString ENDPOINT_CONFIG_DISABLE_SSL = StringUtils.fromString("disable");
-
-    //SslConfiguration indexes
-    public static final BString SSL_CONFIG_SSL_VERIFY_CLIENT = StringUtils.fromString("sslVerifyClient");
-    public static final BString SSL_CONFIG_CIPHERS = StringUtils.fromString("ciphers");
-    public static final BString SSL_CONFIG_CACHE_SIZE = StringUtils.fromString("cacheSize");
-    public static final BString SSL_CONFIG_CACHE_VALIDITY_PERIOD = StringUtils.fromString("cacheValidityPeriod");
-    public static final BString SSL_CONFIG_HOST_NAME_VERIFICATION_ENABLED = StringUtils.fromString("verifyHostname");
-    public static final BString SSL_CONFIG_ENABLE_SESSION_CREATION = StringUtils.fromString("shareSession");
+    public static final BString ENDPOINT_CONFIG_SECURESOCKET = StringUtils.fromString("secureSocket");
+    public static final BString SECURESOCKET_CONFIG_DISABLE_SSL = StringUtils.fromString("disable");
+    public static final BString SECURESOCKET_CONFIG_CERT = StringUtils.fromString("cert");
+    public static final BString SECURESOCKET_CONFIG_TRUSTSTORE_FILE_PATH = StringUtils.fromString("path");
+    public static final BString SECURESOCKET_CONFIG_TRUSTSTORE_PASSWORD = StringUtils.fromString("password");
+    public static final BString SECURESOCKET_CONFIG_KEY = StringUtils.fromString("key");
+    public static final BString SECURESOCKET_CONFIG_CERTKEY_CERT_FILE = StringUtils.fromString("certFile");
+    public static final BString SECURESOCKET_CONFIG_CERTKEY_KEY_FILE = StringUtils.fromString("keyFile");
+    public static final BString SECURESOCKET_CONFIG_CERTKEY_KEY_PASSWORD = StringUtils.fromString("keyPassword");
+    public static final BString SECURESOCKET_CONFIG_KEYSTORE_FILE_PATH = StringUtils.fromString("path");
+    public static final BString SECURESOCKET_CONFIG_KEYSTORE_PASSWORD = StringUtils.fromString("password");
+    public static final BString SECURESOCKET_CONFIG_PROTOCOL = StringUtils.fromString("protocol");
+    public static final BString SECURESOCKET_CONFIG_PROTOCOL_NAME = StringUtils.fromString("name");
+    public static final BString SECURESOCKET_CONFIG_PROTOCOL_VERSIONS = StringUtils.fromString("versions");
+    public static final BString SECURESOCKET_CONFIG_CERT_VALIDATION = StringUtils.fromString("certValidation");
+    public static final BString SECURESOCKET_CONFIG_CERT_VALIDATION_TYPE = StringUtils.fromString("cacheSize");
+    public static final BString SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_SIZE = StringUtils.fromString("cacheSize");
+    public static final BString SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_VALIDITY_PERIOD =
+            StringUtils.fromString("cacheValidityPeriod");
+    public static final BString SECURESOCKET_CONFIG_CIPHERS = StringUtils.fromString("ciphers");
+    public static final BString SECURESOCKET_CONFIG_HOST_NAME_VERIFICATION_ENABLED =
+            StringUtils.fromString("verifyHostname");
+    public static final BString SECURESOCKET_CONFIG_SHARE_SESSION = StringUtils.fromString("shareSession");
+    public static final BString SECURESOCKET_CONFIG_HANDSHAKE_TIMEOUT = StringUtils.fromString("handshakeTimeout");
+    public static final BString SECURESOCKET_CONFIG_SESSION_TIMEOUT = StringUtils.fromString("sessionTimeout");
+    public static final BString SECURESOCKET_CONFIG_MUTUAL_SSL = StringUtils.fromString("mutualSsl");
+    public static final BString SECURESOCKET_CONFIG_VERIFY_CLIENT = StringUtils.fromString("verifyClient");
 
     //Client Endpoint (CallerActions)
     public static final BString CLIENT_ENDPOINT_SERVICE_URI = StringUtils.fromString("url");

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -375,12 +375,15 @@ public class HttpConstants {
             StringUtils.fromString("cacheValidityPeriod");
     public static final BString SECURESOCKET_CONFIG_CIPHERS = StringUtils.fromString("ciphers");
     public static final BString SECURESOCKET_CONFIG_HOST_NAME_VERIFICATION_ENABLED =
-            StringUtils.fromString("verifyHostname");
+            StringUtils.fromString("verifyHostName");
     public static final BString SECURESOCKET_CONFIG_SHARE_SESSION = StringUtils.fromString("shareSession");
     public static final BString SECURESOCKET_CONFIG_HANDSHAKE_TIMEOUT = StringUtils.fromString("handshakeTimeout");
     public static final BString SECURESOCKET_CONFIG_SESSION_TIMEOUT = StringUtils.fromString("sessionTimeout");
     public static final BString SECURESOCKET_CONFIG_MUTUAL_SSL = StringUtils.fromString("mutualSsl");
     public static final BString SECURESOCKET_CONFIG_VERIFY_CLIENT = StringUtils.fromString("verifyClient");
+
+    public static final BString SECURESOCKET_CONFIG_CERT_VALIDATION_TYPE_OCSP_STAPLING =
+            StringUtils.fromString("OCSP_STAPLING");
 
     //Client Endpoint (CallerActions)
     public static final BString CLIENT_ENDPOINT_SERVICE_URI = StringUtils.fromString("url");

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -355,7 +355,7 @@ public class HttpConstants {
     public static final BString PIPELINING_REQUEST_LIMIT = StringUtils.fromString("maxPipelinedRequests");
 
     public static final BString ENDPOINT_CONFIG_SECURESOCKET = StringUtils.fromString("secureSocket");
-    public static final BString SECURESOCKET_CONFIG_DISABLE_SSL = StringUtils.fromString("disable");
+    public static final BString SECURESOCKET_CONFIG_DISABLE_SSL = StringUtils.fromString("enable");
     public static final BString SECURESOCKET_CONFIG_CERT = StringUtils.fromString("cert");
     public static final BString SECURESOCKET_CONFIG_TRUSTSTORE_FILE_PATH = StringUtils.fromString("path");
     public static final BString SECURESOCKET_CONFIG_TRUSTSTORE_PASSWORD = StringUtils.fromString("password");

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -1678,11 +1678,12 @@ public class HttpUtil {
         String type = certValidation.getStringValue(SECURESOCKET_CONFIG_CERT_VALIDATION_TYPE).getValue();
         if (type.equals(SECURESOCKET_CONFIG_CERT_VALIDATION_TYPE_OCSP_STAPLING.getValue())) {
             sslConfiguration.setOcspStaplingEnabled(true);
+        } else {
+            sslConfiguration.setValidateCertEnabled(true);
         }
         long cacheSize = certValidation.getIntValue(SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_SIZE).intValue();
         long cacheValidityPeriod = ((BDecimal) certValidation.get(
                 SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_VALIDITY_PERIOD)).intValue();
-        sslConfiguration.setValidateCertEnabled(true);
         if (cacheValidityPeriod != 0) {
             sslConfiguration.setCacheValidityPeriod(Math.toIntExact(cacheValidityPeriod));
         }

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -116,8 +116,6 @@ import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_
 import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_HTTP_URL;
 import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_PEER_ADDRESS;
 import static io.netty.handler.codec.http.HttpHeaderNames.CACHE_CONTROL;
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.ballerinalang.mime.util.EntityBodyHandler.checkEntityBodyAvailability;
 import static org.ballerinalang.mime.util.MimeConstants.BOUNDARY;
 import static org.ballerinalang.mime.util.MimeConstants.ENTITY_BYTE_CHANNEL;
@@ -167,6 +165,7 @@ import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_CERT_
 import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_SIZE;
 import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_VALIDITY_PERIOD;
 import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_CERT_VALIDATION_TYPE;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_CERT_VALIDATION_TYPE_OCSP_STAPLING;
 import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_CIPHERS;
 import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_DISABLE_SSL;
 import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_HANDSHAKE_TIMEOUT;
@@ -1323,143 +1322,47 @@ public class HttpUtil {
         }
     }
 
-    private static BMap<?, ?> getBMapValueIfPresent(BMap<BString, Object> map, BString key) {
-        return map.containsKey(key) ? map.getMapValue(key) : null;
-    }
-
-    private static BString getBStringValueIfPresent(BMap<BString, Object> map, BString key) {
-        return map.containsKey(key) ? map.getStringValue(key) : null;
-    }
-
-    private static BArray getBArrayValueIfPresent(BMap<BString, Object> map, BString key) {
-        return map.containsKey(key) ? map.getArrayValue(key) : null;
-    }
-
-    private static boolean checkBMapContains(BMap<BString, Object> map, BString key) {
-        return map.containsKey(key);
-    }
-
     /**
      * Populates SSL configuration instance with secure socket configuration.
      *
-     * @param sslConfiguration  ssl configuration instance.
-     * @param secureSocket    secure socket configuration.
+     * @param senderConfiguration SSL configuration instance.
+     * @param secureSocket        Secure socket configuration.
      */
-    public static void populateSSLConfiguration(SslConfiguration sslConfiguration, BMap<BString, Object> secureSocket) {
-        List<Parameter> clientParams = new ArrayList<>();
-
+    public static void populateSSLConfiguration(SslConfiguration senderConfiguration,
+                                                BMap<BString, Object> secureSocket) {
+        List<Parameter> clientParamList = new ArrayList<>();
         boolean disableSslValidation = secureSocket.getBooleanValue(SECURESOCKET_CONFIG_DISABLE_SSL);
         if (disableSslValidation) {
-            sslConfiguration.disableSsl();
+            senderConfiguration.disableSsl();
             return;
         }
-
         Object cert = secureSocket.get(SECURESOCKET_CONFIG_CERT);
         if (cert == null) {
-            throw createHttpError("Need to configure 'cert' with client SSL certificate file or 'crypto:TrustStore'.",
+            throw createHttpError("Need to configure 'crypto:TrustStore' or 'cert' with client SSL certificates file.",
                                   HttpErrorType.SSL_ERROR);
         }
-        if (cert instanceof BMap) {
-            String trustStoreFile = ((BMap<BString, BString>) cert).getStringValue(
-                    SECURESOCKET_CONFIG_TRUSTSTORE_FILE_PATH).getValue();
-            if (isNotBlank(trustStoreFile)) {
-                sslConfiguration.setTrustStoreFile(trustStoreFile);
-            }
-            String trustStorePassword = ((BMap<BString, BString>) cert).getStringValue(
-                    SECURESOCKET_CONFIG_TRUSTSTORE_PASSWORD).getValue();
-            if (isNotBlank(trustStorePassword)) {
-                sslConfiguration.setTrustStorePass(trustStorePassword);
-            }
-        } else {
-            sslConfiguration.setClientTrustCertificates((String) cert);
-        }
-
-        BMap key = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_KEY);
+        evaluateCertField(cert, senderConfiguration);
+        BMap<BString, Object> key = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_KEY);
         if (key != null) {
-            if (checkBMapContains(key, SECURESOCKET_CONFIG_KEYSTORE_FILE_PATH)) {
-                String keyStoreFile = key.getStringValue(SECURESOCKET_CONFIG_KEYSTORE_FILE_PATH).getValue();
-                if (isNotBlank(keyStoreFile)) {
-                    sslConfiguration.setKeyStoreFile(keyStoreFile);
-                }
-                String keyStorePassword = key.getStringValue(SECURESOCKET_CONFIG_KEYSTORE_PASSWORD).getValue();
-                if (isNotBlank(keyStorePassword)) {
-                    sslConfiguration.setKeyStorePass(keyStorePassword);
-                }
-            } else {
-                String certFile = key.getStringValue(SECURESOCKET_CONFIG_CERTKEY_CERT_FILE).getValue();
-                String keyFile = key.getStringValue(SECURESOCKET_CONFIG_CERTKEY_KEY_FILE).getValue();
-                BString keyPassword = getBStringValueIfPresent(key, SECURESOCKET_CONFIG_CERTKEY_KEY_PASSWORD);
-                sslConfiguration.setClientCertificates(certFile);
-                sslConfiguration.setClientKeyFile(keyFile);
-                if (keyPassword != null && isNotBlank(keyPassword.getValue())) {
-                    sslConfiguration.setClientKeyPassword(keyPassword.getValue());
-                }
-            }
+            evaluateKeyField(key, senderConfiguration);
         }
-
-        BMap protocol = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_PROTOCOL);
+        BMap<BString, Object> protocol = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_PROTOCOL);
         if (protocol != null) {
-            List<String> sslEnabledProtocolsValueList = Arrays.asList(
-                    protocol.getArrayValue(SECURESOCKET_CONFIG_PROTOCOL_VERSIONS).getStringArray());
-            if (!sslEnabledProtocolsValueList.isEmpty()) {
-                String sslEnabledProtocols = sslEnabledProtocolsValueList.stream()
-                        .collect(Collectors.joining(",", "", ""));
-                Parameter clientProtocols = new Parameter(ANN_CONFIG_ATTR_SSL_ENABLED_PROTOCOLS, sslEnabledProtocols);
-                clientParams.add(clientProtocols);
-            }
-            String sslProtocol = protocol.getStringValue(SECURESOCKET_CONFIG_PROTOCOL_NAME).getValue();
-            if (isNotBlank(sslProtocol)) {
-                sslConfiguration.setSSLProtocol(sslProtocol);
-            }
+            evaluateProtocolField(protocol, senderConfiguration, clientParamList);
         }
-
-        BMap certValidation = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_CERT_VALIDATION);
+        BMap<BString, Object> certValidation = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_CERT_VALIDATION);
         if (certValidation != null) {
-            String type = certValidation.getStringValue(SECURESOCKET_CONFIG_CERT_VALIDATION_TYPE).getValue();
-            if (type.equals("OCSP_STAPLING")) {
-                sslConfiguration.setOcspStaplingEnabled(true);
-            }
-            double cacheSize = ((BDecimal) certValidation.get(
-                    SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_SIZE)).floatValue();
-            int cacheValidityPeriod = certValidation.getIntValue(
-                    SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_VALIDITY_PERIOD).intValue();
-            sslConfiguration.setValidateCertEnabled(true);
-            if (cacheValidityPeriod != 0) {
-                sslConfiguration.setCacheValidityPeriod(cacheValidityPeriod);
-            }
-            if (cacheSize != 0) {
-                sslConfiguration.setCacheSize((int) cacheSize);
-            }
+            evaluateCertValidationField(certValidation, senderConfiguration);
         }
-
-        boolean hostNameVerificationEnabled = secureSocket.getBooleanValue(
-                SECURESOCKET_CONFIG_HOST_NAME_VERIFICATION_ENABLED);
-        sslConfiguration.setHostNameVerificationEnabled(hostNameVerificationEnabled);
-
-        sslConfiguration.setSslSessionTimeOut((int) (secureSocket.getDefaultableIntValue(
-                SECURESOCKET_CONFIG_SESSION_TIMEOUT)));
-        sslConfiguration.setSslHandshakeTimeOut(secureSocket.getDefaultableIntValue(
-                SECURESOCKET_CONFIG_HANDSHAKE_TIMEOUT));
-
-        BArray cipherConfigs = getBArrayValueIfPresent(secureSocket, SECURESOCKET_CONFIG_CIPHERS);
-        if (cipherConfigs != null) {
-            List<Object> ciphersValueList = Arrays.asList(cipherConfigs.getStringArray());
-            if (ciphersValueList.size() > 0) {
-                String ciphers = ciphersValueList.stream().map(Object::toString)
-                        .collect(Collectors.joining(",", "", ""));
-                Parameter clientCiphers = new Parameter(HttpConstants.CIPHERS, ciphers);
-                clientParams.add(clientCiphers);
-            }
+        BArray ciphers = secureSocket.containsKey(SECURESOCKET_CONFIG_CIPHERS) ?
+                secureSocket.getArrayValue(SECURESOCKET_CONFIG_CIPHERS) : null;
+        if (ciphers != null) {
+            evaluateCiphersField(ciphers, clientParamList);
         }
+        evaluateCommonFields(secureSocket, senderConfiguration, clientParamList);
 
-        String enableSessionCreation = String.valueOf(secureSocket.getBooleanValue(
-                SECURESOCKET_CONFIG_SHARE_SESSION));
-        Parameter enableSessionCreationParam = new Parameter(SECURESOCKET_CONFIG_SHARE_SESSION.getValue(),
-                                                             enableSessionCreation);
-        clientParams.add(enableSessionCreationParam);
-
-        if (!clientParams.isEmpty()) {
-            sslConfiguration.setParameters(clientParams);
+        if (!clientParamList.isEmpty()) {
+            senderConfiguration.setParameters(clientParamList);
         }
     }
 
@@ -1646,112 +1549,32 @@ public class HttpUtil {
 
     private static ListenerConfiguration setSslConfig(BMap<BString, Object> secureSocket,
                                                       ListenerConfiguration listenerConfiguration) {
-        listenerConfiguration.setScheme(PROTOCOL_HTTPS);
-        BMap key = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_KEY);
-        if (checkBMapContains(key, SECURESOCKET_CONFIG_KEYSTORE_FILE_PATH)) {
-            String keyStoreFile = key.getStringValue(SECURESOCKET_CONFIG_KEYSTORE_FILE_PATH).getValue();
-            if (isBlank(keyStoreFile)) {
-                throw createHttpError("Keystore file location must be provided for secure connection.",
-                                      HttpErrorType.SSL_ERROR);
-            }
-            String keyStorePassword = key.getStringValue(SECURESOCKET_CONFIG_KEYSTORE_PASSWORD).getValue();
-            if (isBlank(keyStorePassword)) {
-                throw createHttpError("Keystore password must be provided for secure connection",
-                                      HttpErrorType.SSL_ERROR);
-            }
-            listenerConfiguration.setKeyStoreFile(keyStoreFile);
-            listenerConfiguration.setKeyStorePass(keyStorePassword);
-        } else {
-            String certFile = key.getStringValue(SECURESOCKET_CONFIG_CERTKEY_CERT_FILE).getValue();
-            String keyFile = key.getStringValue(SECURESOCKET_CONFIG_CERTKEY_KEY_FILE).getValue();
-            BString keyPassword = getBStringValueIfPresent(key, SECURESOCKET_CONFIG_CERTKEY_KEY_PASSWORD);
-            listenerConfiguration.setServerCertificates(certFile);
-            listenerConfiguration.setServerKeyFile(keyFile);
-            if (isNotBlank(keyPassword.getValue())) {
-                listenerConfiguration.setServerKeyPassword(keyPassword.getValue());
-            }
-        }
-
-        BMap mutualSsl = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_MUTUAL_SSL);
-        if (mutualSsl != null) {
-            String sslVerifyClient = secureSocket.getStringValue(SECURESOCKET_CONFIG_VERIFY_CLIENT).getValue();
-            listenerConfiguration.setVerifyClient(sslVerifyClient);
-            Object cert = secureSocket.get(SECURESOCKET_CONFIG_CERT);
-            if (cert instanceof BMap) {
-                String trustStoreFile = ((BMap<BString, BString>) cert).getStringValue(
-                        SECURESOCKET_CONFIG_TRUSTSTORE_FILE_PATH).getValue();
-                String trustStorePassword = ((BMap<BString, BString>) cert).getStringValue(
-                        SECURESOCKET_CONFIG_TRUSTSTORE_PASSWORD).getValue();
-                listenerConfiguration.setTrustStoreFile(trustStoreFile);
-                listenerConfiguration.setTrustStorePass(trustStorePassword);
-            } else {
-                listenerConfiguration.setServerTrustCertificates((String) cert);
-            }
-        }
-
         List<Parameter> serverParamList = new ArrayList<>();
-
-        BMap protocol = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_PROTOCOL);
+        listenerConfiguration.setScheme(PROTOCOL_HTTPS);
+        BMap<BString, Object> key = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_KEY);
+        assert key != null; // This validation happens at Ballerina level
+        evaluateKeyField(key, listenerConfiguration);
+        BMap<BString, Object> mutualSsl = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_MUTUAL_SSL);
+        if (mutualSsl != null) {
+            String verifyClient = mutualSsl.getStringValue(SECURESOCKET_CONFIG_VERIFY_CLIENT).getValue();
+            listenerConfiguration.setVerifyClient(verifyClient);
+            Object cert = mutualSsl.get(SECURESOCKET_CONFIG_CERT);
+            evaluateCertField(cert, listenerConfiguration);
+        }
+        BMap<BString, Object> protocol = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_PROTOCOL);
         if (protocol != null) {
-            List<String> sslEnabledProtocolsValueList = Arrays.asList(
-                    protocol.getArrayValue(SECURESOCKET_CONFIG_PROTOCOL_VERSIONS).getStringArray());
-            if (!sslEnabledProtocolsValueList.isEmpty()) {
-                String sslEnabledProtocols = sslEnabledProtocolsValueList.stream()
-                        .collect(Collectors.joining(",", "", ""));
-                Parameter serverProtocols = new Parameter(ANN_CONFIG_ATTR_SSL_ENABLED_PROTOCOLS, sslEnabledProtocols);
-                serverParamList.add(serverProtocols);
-            }
-
-            String sslProtocol = protocol.getStringValue(SECURESOCKET_CONFIG_PROTOCOL_NAME).getValue();
-            if (isNotBlank(sslProtocol)) {
-                listenerConfiguration.setSSLProtocol(sslProtocol);
-            }
+            evaluateProtocolField(protocol, listenerConfiguration, serverParamList);
         }
-
-        BMap certValidation = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_CERT_VALIDATION);
+        BMap<BString, Object> certValidation = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_CERT_VALIDATION);
         if (certValidation != null) {
-            String type = certValidation.getStringValue(SECURESOCKET_CONFIG_CERT_VALIDATION_TYPE).getValue();
-            if (type.equals("OCSP_STAPLING")) {
-                listenerConfiguration.setOcspStaplingEnabled(true);
-            }
-            double cacheSize = ((BDecimal) certValidation.get(
-                    SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_SIZE)).floatValue();
-            int cacheValidityPeriod = certValidation.getIntValue(
-                    SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_VALIDITY_PERIOD).intValue();
-            listenerConfiguration.setValidateCertEnabled(true);
-            if (cacheValidityPeriod != 0) {
-                listenerConfiguration.setCacheValidityPeriod(Math.toIntExact(cacheValidityPeriod));
-            }
-            if (cacheSize != 0) {
-                listenerConfiguration.setCacheSize(Math.toIntExact((int) cacheSize));
-            }
+            evaluateCertValidationField(certValidation, listenerConfiguration);
         }
-
-        BArray cipherConfigs = getBArrayValueIfPresent(secureSocket, SECURESOCKET_CONFIG_CIPHERS);
-        if (cipherConfigs != null) {
-            List<Object> ciphersValueList = Arrays.asList(cipherConfigs.getStringArray());
-            if (ciphersValueList.size() > 0) {
-                String ciphers = ciphersValueList.stream().map(Object::toString)
-                        .collect(Collectors.joining(",", "", ""));
-                Parameter serverParameters = new Parameter(HttpConstants.CIPHERS, ciphers);
-                serverParamList.add(serverParameters);
-            }
+        BArray ciphers = secureSocket.containsKey(SECURESOCKET_CONFIG_CIPHERS) ?
+                secureSocket.getArrayValue(SECURESOCKET_CONFIG_CIPHERS) : null;
+        if (ciphers != null) {
+            evaluateCiphersField(ciphers, serverParamList);
         }
-
-        boolean hostNameVerificationEnabled = secureSocket.getBooleanValue(
-                SECURESOCKET_CONFIG_HOST_NAME_VERIFICATION_ENABLED);
-        listenerConfiguration.setHostNameVerificationEnabled(hostNameVerificationEnabled);
-
-        listenerConfiguration.setSslSessionTimeOut((int) (secureSocket.getDefaultableIntValue(
-                SECURESOCKET_CONFIG_SESSION_TIMEOUT)));
-        listenerConfiguration.setSslHandshakeTimeOut(secureSocket.getDefaultableIntValue(
-                SECURESOCKET_CONFIG_HANDSHAKE_TIMEOUT));
-
-
-        String enableSessionCreation = String.valueOf(secureSocket.getBooleanValue(SECURESOCKET_CONFIG_SHARE_SESSION));
-        Parameter enableSessionCreationParam = new Parameter(SECURESOCKET_CONFIG_SHARE_SESSION.getValue(),
-                                                             enableSessionCreation);
-        serverParamList.add(enableSessionCreationParam);
+        evaluateCommonFields(secureSocket, listenerConfiguration, serverParamList);
 
         listenerConfiguration.setTLSStoreType(PKCS_STORE_TYPE);
         if (!serverParamList.isEmpty()) {
@@ -1760,6 +1583,147 @@ public class HttpUtil {
         listenerConfiguration.setId(HttpUtil.getListenerInterface(listenerConfiguration.getHost(),
                                                                   listenerConfiguration.getPort()));
         return listenerConfiguration;
+    }
+
+    private static void evaluateKeyField(BMap<BString, Object> key, SslConfiguration sslConfiguration) {
+        if (key.containsKey(SECURESOCKET_CONFIG_KEYSTORE_FILE_PATH)) {
+            String keyStoreFile = key.getStringValue(SECURESOCKET_CONFIG_KEYSTORE_FILE_PATH).getValue();
+            if (keyStoreFile.isBlank()) {
+                throw createHttpError("KeyStore file location must be provided for secure connection.",
+                                      HttpErrorType.SSL_ERROR);
+            }
+            String keyStorePassword = key.getStringValue(SECURESOCKET_CONFIG_KEYSTORE_PASSWORD).getValue();
+            if (keyStorePassword.isBlank()) {
+                throw createHttpError("KeyStore password must be provided for secure connection.",
+                                      HttpErrorType.SSL_ERROR);
+            }
+            sslConfiguration.setKeyStoreFile(keyStoreFile);
+            sslConfiguration.setKeyStorePass(keyStorePassword);
+        } else {
+            String certFile = key.getStringValue(SECURESOCKET_CONFIG_CERTKEY_CERT_FILE).getValue();
+            String keyFile = key.getStringValue(SECURESOCKET_CONFIG_CERTKEY_KEY_FILE).getValue();
+            BString keyPassword = key.containsKey(SECURESOCKET_CONFIG_CERTKEY_KEY_PASSWORD) ?
+                    key.getStringValue(SECURESOCKET_CONFIG_CERTKEY_KEY_PASSWORD) : null;
+             if (certFile.isBlank()) {
+                throw createHttpError("Certificate file location must be provided for secure connection.",
+                                      HttpErrorType.SSL_ERROR);
+            }
+            if (keyFile.isBlank()) {
+                throw createHttpError("Private key file location must be provided for secure connection.",
+                                      HttpErrorType.SSL_ERROR);
+            }
+            if (sslConfiguration instanceof ListenerConfiguration) {
+                sslConfiguration.setServerCertificates(certFile);
+                sslConfiguration.setServerKeyFile(keyFile);
+                if (keyPassword != null && !keyPassword.getValue().isBlank()) {
+                    sslConfiguration.setServerKeyPassword(keyPassword.getValue());
+                }
+            } else {
+                sslConfiguration.setClientCertificates(certFile);
+                sslConfiguration.setClientKeyFile(keyFile);
+                if (keyPassword != null && !keyPassword.getValue().isBlank()) {
+                    sslConfiguration.setClientKeyPassword(keyPassword.getValue());
+                }
+            }
+        }
+    }
+
+    private static void evaluateCertField(Object cert, SslConfiguration sslConfiguration) {
+        if (cert instanceof BMap) {
+            BMap<BString, BString> trustStore = (BMap<BString, BString>) cert;
+            String trustStoreFile = trustStore.getStringValue(SECURESOCKET_CONFIG_TRUSTSTORE_FILE_PATH).getValue();
+            String trustStorePassword = trustStore.getStringValue(SECURESOCKET_CONFIG_TRUSTSTORE_PASSWORD).getValue();
+            if (trustStoreFile.isBlank()) {
+                throw createHttpError("TrustStore file location must be provided for secure connection.",
+                                      HttpErrorType.SSL_ERROR);
+            }
+            if (trustStorePassword.isBlank()) {
+                throw createHttpError("TrustStore password must be provided for secure connection.",
+                                      HttpErrorType.SSL_ERROR);
+            }
+            sslConfiguration.setTrustStoreFile(trustStoreFile);
+            sslConfiguration.setTrustStorePass(trustStorePassword);
+        } else {
+            String certFile = ((BString) cert).getValue();
+            if (certFile.isBlank()) {
+                throw createHttpError("Certificate file location must be provided for secure connection.",
+                                      HttpErrorType.SSL_ERROR);
+            }
+            if (sslConfiguration instanceof ListenerConfiguration) {
+                sslConfiguration.setServerTrustCertificates(certFile);
+            } else {
+                sslConfiguration.setClientTrustCertificates(certFile);
+            }
+        }
+    }
+
+    private static void evaluateProtocolField(BMap<BString, Object> protocol,
+                                              SslConfiguration sslConfiguration,
+                                              List<Parameter> paramList) {
+        List<String> sslEnabledProtocolsValueList = Arrays.asList(
+                protocol.getArrayValue(SECURESOCKET_CONFIG_PROTOCOL_VERSIONS).getStringArray());
+        if (!sslEnabledProtocolsValueList.isEmpty()) {
+            String sslEnabledProtocols = sslEnabledProtocolsValueList.stream().collect(Collectors.joining(",", "", ""));
+            Parameter serverProtocols = new Parameter(ANN_CONFIG_ATTR_SSL_ENABLED_PROTOCOLS, sslEnabledProtocols);
+            paramList.add(serverProtocols);
+        }
+        String sslProtocol = protocol.getStringValue(SECURESOCKET_CONFIG_PROTOCOL_NAME).getValue();
+        if (!sslProtocol.isBlank()) {
+            sslConfiguration.setSSLProtocol(sslProtocol);
+        }
+    }
+
+    private static void evaluateCertValidationField(BMap<BString, Object> certValidation,
+                                                    SslConfiguration sslConfiguration) {
+        String type = certValidation.getStringValue(SECURESOCKET_CONFIG_CERT_VALIDATION_TYPE).getValue();
+        if (type.equals(SECURESOCKET_CONFIG_CERT_VALIDATION_TYPE_OCSP_STAPLING.getValue())) {
+            sslConfiguration.setOcspStaplingEnabled(true);
+        }
+        long cacheSize = certValidation.getIntValue(SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_SIZE).intValue();
+        long cacheValidityPeriod = ((BDecimal) certValidation.get(
+                SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_VALIDITY_PERIOD)).intValue();
+        sslConfiguration.setValidateCertEnabled(true);
+        if (cacheValidityPeriod != 0) {
+            sslConfiguration.setCacheValidityPeriod(Math.toIntExact(cacheValidityPeriod));
+        }
+        if (cacheSize != 0) {
+            sslConfiguration.setCacheSize(Math.toIntExact(cacheSize));
+        }
+    }
+
+    private static void evaluateCiphersField(BArray ciphers, List<Parameter> paramList) {
+        Object[] ciphersArray = ciphers.getStringArray();
+        List<Object> ciphersList = Arrays.asList(ciphersArray);
+        if (ciphersList.size() > 0) {
+            String ciphersString = ciphersList.stream().map(Object::toString).collect(Collectors.joining(",", "", ""));
+            Parameter serverParameters = new Parameter(HttpConstants.CIPHERS, ciphersString);
+            paramList.add(serverParameters);
+        }
+    }
+
+    private static void evaluateCommonFields(BMap<BString, Object> secureSocket, SslConfiguration sslConfiguration,
+                                             List<Parameter> paramList) {
+        if (!(sslConfiguration instanceof ListenerConfiguration)) {
+            boolean hostNameVerificationEnabled = secureSocket.getBooleanValue(
+                    SECURESOCKET_CONFIG_HOST_NAME_VERIFICATION_ENABLED);
+            sslConfiguration.setHostNameVerificationEnabled(hostNameVerificationEnabled);
+        }
+        sslConfiguration.setSslSessionTimeOut((int) getLongValueOrDefault(secureSocket,
+                                                                          SECURESOCKET_CONFIG_SESSION_TIMEOUT));
+        sslConfiguration.setSslHandshakeTimeOut(getLongValueOrDefault(secureSocket,
+                                                                      SECURESOCKET_CONFIG_HANDSHAKE_TIMEOUT));
+        String enableSessionCreation = String.valueOf(secureSocket.getBooleanValue(SECURESOCKET_CONFIG_SHARE_SESSION));
+        Parameter enableSessionCreationParam = new Parameter(SECURESOCKET_CONFIG_SHARE_SESSION.getValue(),
+                                                             enableSessionCreation);
+        paramList.add(enableSessionCreationParam);
+    }
+
+    private static BMap<BString, Object> getBMapValueIfPresent(BMap<BString, Object> map, BString key) {
+        return map.containsKey(key) ? (BMap<BString, Object>) map.getMapValue(key) : null;
+    }
+
+    private static long getLongValueOrDefault(BMap<BString, Object> map, BString key) {
+        return map.containsKey(key) ? ((BDecimal) map.get(key)).intValue() : 0L;
     }
 
     public static String getServiceName(BObject balService) {

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -117,7 +117,6 @@ import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_
 import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_PEER_ADDRESS;
 import static io.netty.handler.codec.http.HttpHeaderNames.CACHE_CONTROL;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.ballerinalang.mime.util.EntityBodyHandler.checkEntityBodyAvailability;
 import static org.ballerinalang.mime.util.MimeConstants.BOUNDARY;
@@ -138,20 +137,6 @@ import static org.ballerinalang.net.http.HttpConstants.AUTO;
 import static org.ballerinalang.net.http.HttpConstants.CONNECTION_MANAGER;
 import static org.ballerinalang.net.http.HttpConstants.CONNECTION_POOLING_MAX_ACTIVE_STREAMS_PER_CONNECTION;
 import static org.ballerinalang.net.http.HttpConstants.DOUBLE_SLASH;
-import static org.ballerinalang.net.http.HttpConstants.ENABLED_PROTOCOLS;
-import static org.ballerinalang.net.http.HttpConstants.ENDPOINT_CONFIG_CERTIFICATE;
-import static org.ballerinalang.net.http.HttpConstants.ENDPOINT_CONFIG_DISABLE_SSL;
-import static org.ballerinalang.net.http.HttpConstants.ENDPOINT_CONFIG_HANDSHAKE_TIMEOUT;
-import static org.ballerinalang.net.http.HttpConstants.ENDPOINT_CONFIG_KEY;
-import static org.ballerinalang.net.http.HttpConstants.ENDPOINT_CONFIG_KEY_PASSWORD;
-import static org.ballerinalang.net.http.HttpConstants.ENDPOINT_CONFIG_KEY_STORE;
-import static org.ballerinalang.net.http.HttpConstants.ENDPOINT_CONFIG_OCSP_STAPLING;
-import static org.ballerinalang.net.http.HttpConstants.ENDPOINT_CONFIG_PROTOCOLS;
-import static org.ballerinalang.net.http.HttpConstants.ENDPOINT_CONFIG_SESSION_TIMEOUT;
-import static org.ballerinalang.net.http.HttpConstants.ENDPOINT_CONFIG_TRUST_CERTIFICATES;
-import static org.ballerinalang.net.http.HttpConstants.ENDPOINT_CONFIG_TRUST_STORE;
-import static org.ballerinalang.net.http.HttpConstants.ENDPOINT_CONFIG_VALIDATE_CERT;
-import static org.ballerinalang.net.http.HttpConstants.FILE_PATH;
 import static org.ballerinalang.net.http.HttpConstants.HTTP_ERROR_MESSAGE;
 import static org.ballerinalang.net.http.HttpConstants.HTTP_ERROR_STATUS_CODE;
 import static org.ballerinalang.net.http.HttpConstants.HTTP_HEADERS;
@@ -162,7 +147,6 @@ import static org.ballerinalang.net.http.HttpConstants.MUTUAL_SSL_HANDSHAKE_RECO
 import static org.ballerinalang.net.http.HttpConstants.NEVER;
 import static org.ballerinalang.net.http.HttpConstants.NO_CONTENT_LENGTH_FOUND;
 import static org.ballerinalang.net.http.HttpConstants.ONE_BYTE;
-import static org.ballerinalang.net.http.HttpConstants.PASSWORD;
 import static org.ballerinalang.net.http.HttpConstants.PKCS_STORE_TYPE;
 import static org.ballerinalang.net.http.HttpConstants.PROTOCOL_HTTPS;
 import static org.ballerinalang.net.http.HttpConstants.REQUEST;
@@ -175,10 +159,31 @@ import static org.ballerinalang.net.http.HttpConstants.RESPONSE_CACHE_CONTROL;
 import static org.ballerinalang.net.http.HttpConstants.RESPONSE_CACHE_CONTROL_FIELD;
 import static org.ballerinalang.net.http.HttpConstants.RESPONSE_REASON_PHRASE_FIELD;
 import static org.ballerinalang.net.http.HttpConstants.RESPONSE_STATUS_CODE_FIELD;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_CERT;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_CERTKEY_CERT_FILE;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_CERTKEY_KEY_FILE;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_CERTKEY_KEY_PASSWORD;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_CERT_VALIDATION;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_SIZE;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_VALIDITY_PERIOD;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_CERT_VALIDATION_TYPE;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_CIPHERS;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_DISABLE_SSL;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_HANDSHAKE_TIMEOUT;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_HOST_NAME_VERIFICATION_ENABLED;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_KEY;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_KEYSTORE_FILE_PATH;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_KEYSTORE_PASSWORD;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_MUTUAL_SSL;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_PROTOCOL;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_PROTOCOL_NAME;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_PROTOCOL_VERSIONS;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_SESSION_TIMEOUT;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_SHARE_SESSION;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_TRUSTSTORE_FILE_PATH;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_TRUSTSTORE_PASSWORD;
+import static org.ballerinalang.net.http.HttpConstants.SECURESOCKET_CONFIG_VERIFY_CLIENT;
 import static org.ballerinalang.net.http.HttpConstants.SERVER_NAME;
-import static org.ballerinalang.net.http.HttpConstants.SSL_CONFIG_ENABLE_SESSION_CREATION;
-import static org.ballerinalang.net.http.HttpConstants.SSL_CONFIG_SSL_VERIFY_CLIENT;
-import static org.ballerinalang.net.http.HttpConstants.SSL_PROTOCOL_VERSION;
 import static org.ballerinalang.net.http.HttpConstants.TRANSPORT_MESSAGE;
 import static org.ballerinalang.net.http.nativeimpl.ModuleUtils.getHttpPackage;
 import static org.ballerinalang.net.http.nativeimpl.pipelining.PipeliningHandler.sendPipelinedResponse;
@@ -1223,7 +1228,8 @@ public class HttpUtil {
     public static void populateSenderConfigurations(SenderConfiguration senderConfiguration,
             BMap<BString, Object> clientEndpointConfig, String scheme) {
         ProxyServerConfiguration proxyServerConfiguration;
-        BMap secureSocket = clientEndpointConfig.getMapValue(HttpConstants.ENDPOINT_CONFIG_SECURE_SOCKET);
+        BMap<BString, Object> secureSocket = (BMap<BString, Object>) clientEndpointConfig
+                .getMapValue(HttpConstants.ENDPOINT_CONFIG_SECURESOCKET);
         String httpVersion = clientEndpointConfig.getStringValue(HttpConstants.CLIENT_EP_HTTP_VERSION).getValue();
         if (secureSocket != null) {
             HttpUtil.populateSSLConfiguration(senderConfiguration, secureSocket);
@@ -1317,112 +1323,127 @@ public class HttpUtil {
         }
     }
 
+    private static BMap<?, ?> getBMapValueIfPresent(BMap<BString, Object> map, BString key) {
+        return map.containsKey(key) ? map.getMapValue(key) : null;
+    }
+
+    private static BString getBStringValueIfPresent(BMap<BString, Object> map, BString key) {
+        return map.containsKey(key) ? map.getStringValue(key) : null;
+    }
+
+    private static BArray getBArrayValueIfPresent(BMap<BString, Object> map, BString key) {
+        return map.containsKey(key) ? map.getArrayValue(key) : null;
+    }
+
+    private static boolean checkBMapContains(BMap<BString, Object> map, BString key) {
+        return map.containsKey(key);
+    }
+
     /**
      * Populates SSL configuration instance with secure socket configuration.
      *
      * @param sslConfiguration  ssl configuration instance.
      * @param secureSocket    secure socket configuration.
      */
-    public static void populateSSLConfiguration(SslConfiguration sslConfiguration, BMap secureSocket) {
-        BMap trustStore = secureSocket.getMapValue(ENDPOINT_CONFIG_TRUST_STORE);
-        BMap keyStore = secureSocket.getMapValue(ENDPOINT_CONFIG_KEY_STORE);
-        BMap protocols = secureSocket.getMapValue(ENDPOINT_CONFIG_PROTOCOLS);
-        BMap validateCert = secureSocket.getMapValue(ENDPOINT_CONFIG_VALIDATE_CERT);
-        String keyFile = secureSocket.getStringValue(ENDPOINT_CONFIG_KEY).getValue();
-        String certFile = secureSocket.getStringValue(ENDPOINT_CONFIG_CERTIFICATE).getValue();
-        String trustCerts = secureSocket.getStringValue(ENDPOINT_CONFIG_TRUST_CERTIFICATES).getValue();
-        String keyPassword = secureSocket.getStringValue(ENDPOINT_CONFIG_KEY_PASSWORD).getValue();
-        boolean disableSslValidation = secureSocket.getBooleanValue(ENDPOINT_CONFIG_DISABLE_SSL);
+    public static void populateSSLConfiguration(SslConfiguration sslConfiguration, BMap<BString, Object> secureSocket) {
         List<Parameter> clientParams = new ArrayList<>();
+
+        boolean disableSslValidation = secureSocket.getBooleanValue(SECURESOCKET_CONFIG_DISABLE_SSL);
         if (disableSslValidation) {
             sslConfiguration.disableSsl();
             return;
-        } else if (isEmpty(trustCerts) && trustStore == null) {
-            sslConfiguration.useJavaDefaults();
-            return;
         }
-        if (trustStore != null && isNotBlank(trustCerts)) {
-            throw createHttpError("Cannot configure both trustStore and trustCerts at the same time.",
-                    HttpErrorType.SSL_ERROR);
+
+        Object cert = secureSocket.get(SECURESOCKET_CONFIG_CERT);
+        if (cert == null) {
+            throw createHttpError("Need to configure 'cert' with client SSL certificate file or 'crypto:TrustStore'.",
+                                  HttpErrorType.SSL_ERROR);
         }
-        if (trustStore != null) {
-            String trustStoreFile = trustStore.getStringValue(FILE_PATH).getValue();
+        if (cert instanceof BMap) {
+            String trustStoreFile = ((BMap<BString, BString>) cert).getStringValue(
+                    SECURESOCKET_CONFIG_TRUSTSTORE_FILE_PATH).getValue();
             if (isNotBlank(trustStoreFile)) {
                 sslConfiguration.setTrustStoreFile(trustStoreFile);
             }
-            String trustStorePassword = trustStore.getStringValue(PASSWORD).getValue();
+            String trustStorePassword = ((BMap<BString, BString>) cert).getStringValue(
+                    SECURESOCKET_CONFIG_TRUSTSTORE_PASSWORD).getValue();
             if (isNotBlank(trustStorePassword)) {
                 sslConfiguration.setTrustStorePass(trustStorePassword);
             }
-        } else if (isNotBlank(trustCerts)) {
-            sslConfiguration.setClientTrustCertificates(trustCerts);
+        } else {
+            sslConfiguration.setClientTrustCertificates((String) cert);
         }
-        if (keyStore != null && isNotBlank(keyFile)) {
-            throw createHttpError("Cannot configure both keyStore and keyFile.", HttpErrorType.SSL_ERROR);
-        } else if (isNotBlank(keyFile) && isBlank(certFile)) {
-            throw createHttpError("Need to configure certFile containing client ssl certificates.",
-                    HttpErrorType.SSL_ERROR);
+
+        BMap key = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_KEY);
+        if (key != null) {
+            if (checkBMapContains(key, SECURESOCKET_CONFIG_KEYSTORE_FILE_PATH)) {
+                String keyStoreFile = key.getStringValue(SECURESOCKET_CONFIG_KEYSTORE_FILE_PATH).getValue();
+                if (isNotBlank(keyStoreFile)) {
+                    sslConfiguration.setKeyStoreFile(keyStoreFile);
+                }
+                String keyStorePassword = key.getStringValue(SECURESOCKET_CONFIG_KEYSTORE_PASSWORD).getValue();
+                if (isNotBlank(keyStorePassword)) {
+                    sslConfiguration.setKeyStorePass(keyStorePassword);
+                }
+            } else {
+                String certFile = key.getStringValue(SECURESOCKET_CONFIG_CERTKEY_CERT_FILE).getValue();
+                String keyFile = key.getStringValue(SECURESOCKET_CONFIG_CERTKEY_KEY_FILE).getValue();
+                BString keyPassword = getBStringValueIfPresent(key, SECURESOCKET_CONFIG_CERTKEY_KEY_PASSWORD);
+                sslConfiguration.setClientCertificates(certFile);
+                sslConfiguration.setClientKeyFile(keyFile);
+                if (keyPassword != null && isNotBlank(keyPassword.getValue())) {
+                    sslConfiguration.setClientKeyPassword(keyPassword.getValue());
+                }
+            }
         }
-        if (keyStore != null) {
-            String keyStoreFile = keyStore.getStringValue(FILE_PATH).getValue();
-            if (isNotBlank(keyStoreFile)) {
-                sslConfiguration.setKeyStoreFile(keyStoreFile);
-            }
-            String keyStorePassword = keyStore.getStringValue(PASSWORD).getValue();
-            if (isNotBlank(keyStorePassword)) {
-                sslConfiguration.setKeyStorePass(keyStorePassword);
-            }
-        } else if (isNotBlank(keyFile)) {
-            sslConfiguration.setClientKeyFile(keyFile);
-            sslConfiguration.setClientCertificates(certFile);
-            if (isNotBlank(keyPassword)) {
-                sslConfiguration.setClientKeyPassword(keyPassword);
-            }
-        }
-        if (protocols != null) {
+
+        BMap protocol = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_PROTOCOL);
+        if (protocol != null) {
             List<String> sslEnabledProtocolsValueList = Arrays.asList(
-                    protocols.getArrayValue(ENABLED_PROTOCOLS).getStringArray());
+                    protocol.getArrayValue(SECURESOCKET_CONFIG_PROTOCOL_VERSIONS).getStringArray());
             if (!sslEnabledProtocolsValueList.isEmpty()) {
                 String sslEnabledProtocols = sslEnabledProtocolsValueList.stream()
                         .collect(Collectors.joining(",", "", ""));
                 Parameter clientProtocols = new Parameter(ANN_CONFIG_ATTR_SSL_ENABLED_PROTOCOLS, sslEnabledProtocols);
                 clientParams.add(clientProtocols);
             }
-
-            String sslProtocol = protocols.getStringValue(SSL_PROTOCOL_VERSION).getValue();
+            String sslProtocol = protocol.getStringValue(SECURESOCKET_CONFIG_PROTOCOL_NAME).getValue();
             if (isNotBlank(sslProtocol)) {
                 sslConfiguration.setSSLProtocol(sslProtocol);
             }
         }
 
-        if (validateCert != null) {
-            boolean validateCertEnabled = validateCert.getBooleanValue(HttpConstants.ENABLE);
-            int cacheSize = validateCert.getIntValue(HttpConstants.SSL_CONFIG_CACHE_SIZE).intValue();
-            int cacheValidityPeriod = validateCert.getIntValue(HttpConstants.SSL_CONFIG_CACHE_VALIDITY_PERIOD)
-                    .intValue();
-            sslConfiguration.setValidateCertEnabled(validateCertEnabled);
+        BMap certValidation = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_CERT_VALIDATION);
+        if (certValidation != null) {
+            String type = certValidation.getStringValue(SECURESOCKET_CONFIG_CERT_VALIDATION_TYPE).getValue();
+            if (type.equals("OCSP_STAPLING")) {
+                sslConfiguration.setOcspStaplingEnabled(true);
+            }
+            double cacheSize = ((BDecimal) certValidation.get(
+                    SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_SIZE)).floatValue();
+            int cacheValidityPeriod = certValidation.getIntValue(
+                    SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_VALIDITY_PERIOD).intValue();
+            sslConfiguration.setValidateCertEnabled(true);
             if (cacheValidityPeriod != 0) {
                 sslConfiguration.setCacheValidityPeriod(cacheValidityPeriod);
             }
             if (cacheSize != 0) {
-                sslConfiguration.setCacheSize(cacheSize);
+                sslConfiguration.setCacheSize((int) cacheSize);
             }
         }
-        boolean hostNameVerificationEnabled = secureSocket
-                .getBooleanValue(HttpConstants.SSL_CONFIG_HOST_NAME_VERIFICATION_ENABLED);
-        boolean ocspStaplingEnabled = secureSocket.getBooleanValue(HttpConstants.ENDPOINT_CONFIG_OCSP_STAPLING);
-        sslConfiguration.setOcspStaplingEnabled(ocspStaplingEnabled);
+
+        boolean hostNameVerificationEnabled = secureSocket.getBooleanValue(
+                SECURESOCKET_CONFIG_HOST_NAME_VERIFICATION_ENABLED);
         sslConfiguration.setHostNameVerificationEnabled(hostNameVerificationEnabled);
 
-        sslConfiguration.setSslSessionTimeOut(
-                (int) ((secureSocket).getDefaultableIntValue(ENDPOINT_CONFIG_SESSION_TIMEOUT)));
+        sslConfiguration.setSslSessionTimeOut((int) (secureSocket.getDefaultableIntValue(
+                SECURESOCKET_CONFIG_SESSION_TIMEOUT)));
+        sslConfiguration.setSslHandshakeTimeOut(secureSocket.getDefaultableIntValue(
+                SECURESOCKET_CONFIG_HANDSHAKE_TIMEOUT));
 
-        sslConfiguration.setSslHandshakeTimeOut(
-                (secureSocket).getDefaultableIntValue(ENDPOINT_CONFIG_HANDSHAKE_TIMEOUT));
-
-        Object[] cipherConfigs = secureSocket.getArrayValue(HttpConstants.SSL_CONFIG_CIPHERS).getStringArray();
+        BArray cipherConfigs = getBArrayValueIfPresent(secureSocket, SECURESOCKET_CONFIG_CIPHERS);
         if (cipherConfigs != null) {
-            List<Object> ciphersValueList = Arrays.asList(cipherConfigs);
+            List<Object> ciphersValueList = Arrays.asList(cipherConfigs.getStringArray());
             if (ciphersValueList.size() > 0) {
                 String ciphers = ciphersValueList.stream().map(Object::toString)
                         .collect(Collectors.joining(",", "", ""));
@@ -1430,11 +1451,13 @@ public class HttpUtil {
                 clientParams.add(clientCiphers);
             }
         }
-        String enableSessionCreation = String.valueOf(
-                secureSocket.getBooleanValue(HttpConstants.SSL_CONFIG_ENABLE_SESSION_CREATION));
-        Parameter clientEnableSessionCreation = new Parameter(
-                HttpConstants.SSL_CONFIG_ENABLE_SESSION_CREATION.getValue(), enableSessionCreation);
-        clientParams.add(clientEnableSessionCreation);
+
+        String enableSessionCreation = String.valueOf(secureSocket.getBooleanValue(
+                SECURESOCKET_CONFIG_SHARE_SESSION));
+        Parameter enableSessionCreationParam = new Parameter(SECURESOCKET_CONFIG_SHARE_SESSION.getValue(),
+                                                             enableSessionCreation);
+        clientParams.add(enableSessionCreationParam);
+
         if (!clientParams.isEmpty()) {
             sslConfiguration.setParameters(clientParams);
         }
@@ -1520,7 +1543,7 @@ public class HttpUtil {
      */
     public static ListenerConfiguration getListenerConfig(long port, BMap endpointConfig) {
         String host = endpointConfig.getStringValue(HttpConstants.ENDPOINT_CONFIG_HOST).getValue();
-        BMap sslConfig = endpointConfig.getMapValue(HttpConstants.ENDPOINT_CONFIG_SECURE_SOCKET);
+        BMap<BString, Object> sslConfig = endpointConfig.getMapValue(HttpConstants.ENDPOINT_CONFIG_SECURESOCKET);
         String httpVersion = endpointConfig.getStringValue(HttpConstants.ENDPOINT_CONFIG_VERSION).getValue();
         long idleTimeout = endpointConfig.getIntValue(HttpConstants.ENDPOINT_CONFIG_TIMEOUT);
 
@@ -1621,138 +1644,121 @@ public class HttpUtil {
         return userAgent;
     }
 
-    private static ListenerConfiguration setSslConfig(BMap sslConfig, ListenerConfiguration listenerConfiguration) {
+    private static ListenerConfiguration setSslConfig(BMap<BString, Object> secureSocket,
+                                                      ListenerConfiguration listenerConfiguration) {
         listenerConfiguration.setScheme(PROTOCOL_HTTPS);
-        BMap trustStore = sslConfig.getMapValue(ENDPOINT_CONFIG_TRUST_STORE);
-        BMap keyStore = sslConfig.getMapValue(ENDPOINT_CONFIG_KEY_STORE);
-        BMap protocols = sslConfig.getMapValue(ENDPOINT_CONFIG_PROTOCOLS);
-        BMap validateCert = sslConfig.getMapValue(ENDPOINT_CONFIG_VALIDATE_CERT);
-        BMap ocspStapling = sslConfig.getMapValue(ENDPOINT_CONFIG_OCSP_STAPLING);
-        String keyFile = sslConfig.getStringValue(ENDPOINT_CONFIG_KEY).getValue();
-        String certFile = sslConfig.getStringValue(ENDPOINT_CONFIG_CERTIFICATE).getValue();
-        String trustCerts = sslConfig.getStringValue(ENDPOINT_CONFIG_TRUST_CERTIFICATES).getValue();
-        String keyPassword = sslConfig.getStringValue(ENDPOINT_CONFIG_KEY_PASSWORD).getValue();
-
-        if (keyStore != null && isNotBlank(keyFile)) {
-            throw createHttpError("Cannot configure both keyStore and keyFile at the same time.",
-                                  HttpErrorType.SSL_ERROR);
-        } else if (keyStore == null && (isBlank(keyFile) || isBlank(certFile))) {
-            throw createHttpError("Either keystore or certificateKey and server certificates must be provided "
-                                          + "for secure connection", HttpErrorType.SSL_ERROR);
-        }
-        if (keyStore != null) {
-            String keyStoreFile = keyStore.getStringValue(FILE_PATH).getValue();
+        BMap key = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_KEY);
+        if (checkBMapContains(key, SECURESOCKET_CONFIG_KEYSTORE_FILE_PATH)) {
+            String keyStoreFile = key.getStringValue(SECURESOCKET_CONFIG_KEYSTORE_FILE_PATH).getValue();
             if (isBlank(keyStoreFile)) {
                 throw createHttpError("Keystore file location must be provided for secure connection.",
-                        HttpErrorType.SSL_ERROR);
+                                      HttpErrorType.SSL_ERROR);
             }
-            String keyStorePassword = keyStore.getStringValue(PASSWORD).getValue();
+            String keyStorePassword = key.getStringValue(SECURESOCKET_CONFIG_KEYSTORE_PASSWORD).getValue();
             if (isBlank(keyStorePassword)) {
                 throw createHttpError("Keystore password must be provided for secure connection",
-                        HttpErrorType.SSL_ERROR);
+                                      HttpErrorType.SSL_ERROR);
             }
             listenerConfiguration.setKeyStoreFile(keyStoreFile);
             listenerConfiguration.setKeyStorePass(keyStorePassword);
         } else {
-            listenerConfiguration.setServerKeyFile(keyFile);
+            String certFile = key.getStringValue(SECURESOCKET_CONFIG_CERTKEY_CERT_FILE).getValue();
+            String keyFile = key.getStringValue(SECURESOCKET_CONFIG_CERTKEY_KEY_FILE).getValue();
+            BString keyPassword = getBStringValueIfPresent(key, SECURESOCKET_CONFIG_CERTKEY_KEY_PASSWORD);
             listenerConfiguration.setServerCertificates(certFile);
-            if (isNotBlank(keyPassword)) {
-                listenerConfiguration.setServerKeyPassword(keyPassword);
+            listenerConfiguration.setServerKeyFile(keyFile);
+            if (isNotBlank(keyPassword.getValue())) {
+                listenerConfiguration.setServerKeyPassword(keyPassword.getValue());
             }
         }
-        String sslVerifyClient = sslConfig.getStringValue(SSL_CONFIG_SSL_VERIFY_CLIENT).getValue();
-        listenerConfiguration.setVerifyClient(sslVerifyClient);
-        listenerConfiguration
-                .setSslSessionTimeOut((int) (sslConfig).getDefaultableIntValue(ENDPOINT_CONFIG_SESSION_TIMEOUT));
-        listenerConfiguration
-                .setSslHandshakeTimeOut((sslConfig).getDefaultableIntValue(ENDPOINT_CONFIG_HANDSHAKE_TIMEOUT));
-        if (trustStore == null && isNotBlank(sslVerifyClient) && isBlank(trustCerts)) {
-            throw createHttpError("Truststore location or trustCertificates must be provided to enable Mutual SSL",
-                    HttpErrorType.SSL_ERROR);
-        }
-        if (trustStore != null) {
-            String trustStoreFile = trustStore.getStringValue(FILE_PATH).getValue();
-            String trustStorePassword = trustStore.getStringValue(PASSWORD).getValue();
-            if (isBlank(trustStoreFile) && isNotBlank(sslVerifyClient)) {
-                throw createHttpError("Truststore location must be provided to enable Mutual SSL",
-                                      HttpErrorType.SSL_ERROR);
+
+        BMap mutualSsl = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_MUTUAL_SSL);
+        if (mutualSsl != null) {
+            String sslVerifyClient = secureSocket.getStringValue(SECURESOCKET_CONFIG_VERIFY_CLIENT).getValue();
+            listenerConfiguration.setVerifyClient(sslVerifyClient);
+            Object cert = secureSocket.get(SECURESOCKET_CONFIG_CERT);
+            if (cert instanceof BMap) {
+                String trustStoreFile = ((BMap<BString, BString>) cert).getStringValue(
+                        SECURESOCKET_CONFIG_TRUSTSTORE_FILE_PATH).getValue();
+                String trustStorePassword = ((BMap<BString, BString>) cert).getStringValue(
+                        SECURESOCKET_CONFIG_TRUSTSTORE_PASSWORD).getValue();
+                listenerConfiguration.setTrustStoreFile(trustStoreFile);
+                listenerConfiguration.setTrustStorePass(trustStorePassword);
+            } else {
+                listenerConfiguration.setServerTrustCertificates((String) cert);
             }
-            if (isBlank(trustStorePassword) && isNotBlank(sslVerifyClient)) {
-                throw createHttpError("Truststore password value must be provided to enable Mutual SSL",
-                                      HttpErrorType.SSL_ERROR);
-            }
-            listenerConfiguration.setTrustStoreFile(trustStoreFile);
-            listenerConfiguration.setTrustStorePass(trustStorePassword);
-        } else if (isNotBlank(trustCerts)) {
-            listenerConfiguration.setServerTrustCertificates(trustCerts);
         }
+
         List<Parameter> serverParamList = new ArrayList<>();
-        Parameter serverParameters;
-        if (protocols != null) {
+
+        BMap protocol = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_PROTOCOL);
+        if (protocol != null) {
             List<String> sslEnabledProtocolsValueList = Arrays.asList(
-                    protocols.getArrayValue(ENABLED_PROTOCOLS).getStringArray());
+                    protocol.getArrayValue(SECURESOCKET_CONFIG_PROTOCOL_VERSIONS).getStringArray());
             if (!sslEnabledProtocolsValueList.isEmpty()) {
                 String sslEnabledProtocols = sslEnabledProtocolsValueList.stream()
                         .collect(Collectors.joining(",", "", ""));
-                serverParameters = new Parameter(ANN_CONFIG_ATTR_SSL_ENABLED_PROTOCOLS, sslEnabledProtocols);
-                serverParamList.add(serverParameters);
+                Parameter serverProtocols = new Parameter(ANN_CONFIG_ATTR_SSL_ENABLED_PROTOCOLS, sslEnabledProtocols);
+                serverParamList.add(serverProtocols);
             }
 
-            String sslProtocol = protocols.getStringValue(SSL_PROTOCOL_VERSION).getValue();
+            String sslProtocol = protocol.getStringValue(SECURESOCKET_CONFIG_PROTOCOL_NAME).getValue();
             if (isNotBlank(sslProtocol)) {
                 listenerConfiguration.setSSLProtocol(sslProtocol);
             }
         }
 
-        List<String> ciphersValueList = Arrays.asList(
-                sslConfig.getArrayValue(HttpConstants.SSL_CONFIG_CIPHERS).getStringArray());
-        if (!ciphersValueList.isEmpty()) {
-            String ciphers = ciphersValueList.stream().collect(Collectors.joining(",", "", ""));
-            serverParameters = new Parameter(HttpConstants.CIPHERS, ciphers);
-            serverParamList.add(serverParameters);
-        }
-        if (validateCert != null) {
-            boolean validateCertificateEnabled = validateCert.getBooleanValue(HttpConstants.ENABLE);
-            long cacheSize = validateCert.getIntValue(HttpConstants.SSL_CONFIG_CACHE_SIZE);
-            long cacheValidationPeriod = validateCert.getIntValue(HttpConstants.SSL_CONFIG_CACHE_VALIDITY_PERIOD);
-            listenerConfiguration.setValidateCertEnabled(validateCertificateEnabled);
-            if (validateCertificateEnabled) {
-                if (cacheSize != 0) {
-                    listenerConfiguration.setCacheSize(Math.toIntExact(cacheSize));
-                }
-                if (cacheValidationPeriod != 0) {
-                    listenerConfiguration.setCacheValidityPeriod(Math.toIntExact(cacheValidationPeriod));
-                }
+        BMap certValidation = getBMapValueIfPresent(secureSocket, SECURESOCKET_CONFIG_CERT_VALIDATION);
+        if (certValidation != null) {
+            String type = certValidation.getStringValue(SECURESOCKET_CONFIG_CERT_VALIDATION_TYPE).getValue();
+            if (type.equals("OCSP_STAPLING")) {
+                listenerConfiguration.setOcspStaplingEnabled(true);
+            }
+            double cacheSize = ((BDecimal) certValidation.get(
+                    SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_SIZE)).floatValue();
+            int cacheValidityPeriod = certValidation.getIntValue(
+                    SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_VALIDITY_PERIOD).intValue();
+            listenerConfiguration.setValidateCertEnabled(true);
+            if (cacheValidityPeriod != 0) {
+                listenerConfiguration.setCacheValidityPeriod(Math.toIntExact(cacheValidityPeriod));
+            }
+            if (cacheSize != 0) {
+                listenerConfiguration.setCacheSize(Math.toIntExact((int) cacheSize));
             }
         }
-        if (ocspStapling != null) {
-            boolean ocspStaplingEnabled = ocspStapling.getBooleanValue(HttpConstants.ENABLE);
-            listenerConfiguration.setOcspStaplingEnabled(ocspStaplingEnabled);
-            long cacheSize = ocspStapling.getIntValue(HttpConstants.SSL_CONFIG_CACHE_SIZE);
-            long cacheValidationPeriod = ocspStapling.getIntValue(HttpConstants.SSL_CONFIG_CACHE_VALIDITY_PERIOD);
-            listenerConfiguration.setValidateCertEnabled(ocspStaplingEnabled);
-            if (ocspStaplingEnabled) {
-                if (cacheSize != 0) {
-                    listenerConfiguration.setCacheSize(Math.toIntExact(cacheSize));
-                }
-                if (cacheValidationPeriod != 0) {
-                    listenerConfiguration.setCacheValidityPeriod(Math.toIntExact(cacheValidationPeriod));
-                }
+
+        BArray cipherConfigs = getBArrayValueIfPresent(secureSocket, SECURESOCKET_CONFIG_CIPHERS);
+        if (cipherConfigs != null) {
+            List<Object> ciphersValueList = Arrays.asList(cipherConfigs.getStringArray());
+            if (ciphersValueList.size() > 0) {
+                String ciphers = ciphersValueList.stream().map(Object::toString)
+                        .collect(Collectors.joining(",", "", ""));
+                Parameter serverParameters = new Parameter(HttpConstants.CIPHERS, ciphers);
+                serverParamList.add(serverParameters);
             }
         }
-        listenerConfiguration.setTLSStoreType(PKCS_STORE_TYPE);
-        String serverEnableSessionCreation = String
-                .valueOf(sslConfig.getBooleanValue(SSL_CONFIG_ENABLE_SESSION_CREATION));
-        Parameter enableSessionCreationParam = new Parameter(SSL_CONFIG_ENABLE_SESSION_CREATION.getValue(),
-                                                             serverEnableSessionCreation);
+
+        boolean hostNameVerificationEnabled = secureSocket.getBooleanValue(
+                SECURESOCKET_CONFIG_HOST_NAME_VERIFICATION_ENABLED);
+        listenerConfiguration.setHostNameVerificationEnabled(hostNameVerificationEnabled);
+
+        listenerConfiguration.setSslSessionTimeOut((int) (secureSocket.getDefaultableIntValue(
+                SECURESOCKET_CONFIG_SESSION_TIMEOUT)));
+        listenerConfiguration.setSslHandshakeTimeOut(secureSocket.getDefaultableIntValue(
+                SECURESOCKET_CONFIG_HANDSHAKE_TIMEOUT));
+
+
+        String enableSessionCreation = String.valueOf(secureSocket.getBooleanValue(SECURESOCKET_CONFIG_SHARE_SESSION));
+        Parameter enableSessionCreationParam = new Parameter(SECURESOCKET_CONFIG_SHARE_SESSION.getValue(),
+                                                             enableSessionCreation);
         serverParamList.add(enableSessionCreationParam);
+
+        listenerConfiguration.setTLSStoreType(PKCS_STORE_TYPE);
         if (!serverParamList.isEmpty()) {
             listenerConfiguration.setParameters(serverParamList);
         }
-
-        listenerConfiguration
-                .setId(HttpUtil.getListenerInterface(listenerConfiguration.getHost(), listenerConfiguration.getPort()));
-
+        listenerConfiguration.setId(HttpUtil.getListenerInterface(listenerConfiguration.getHost(),
+                                                                  listenerConfiguration.getPort()));
         return listenerConfiguration;
     }
 

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -1331,8 +1331,8 @@ public class HttpUtil {
     public static void populateSSLConfiguration(SslConfiguration senderConfiguration,
                                                 BMap<BString, Object> secureSocket) {
         List<Parameter> clientParamList = new ArrayList<>();
-        boolean disableSslValidation = secureSocket.getBooleanValue(SECURESOCKET_CONFIG_DISABLE_SSL);
-        if (disableSslValidation) {
+        boolean enable = secureSocket.getBooleanValue(SECURESOCKET_CONFIG_DISABLE_SSL);
+        if (!enable) {
             senderConfiguration.disableSsl();
             return;
         }

--- a/http-native/src/main/java/org/ballerinalang/net/http/websocket/WebSocketUtil.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/websocket/WebSocketUtil.java
@@ -492,7 +492,7 @@ public class WebSocketUtil {
 
         BMap<BString, Object> secureSocket =
                 (BMap<BString, Object>) clientEndpointConfig.getMapValue(
-                        HttpConstants.ENDPOINT_CONFIG_SECURE_SOCKET);
+                        HttpConstants.ENDPOINT_CONFIG_SECURESOCKET);
         if (secureSocket != null) {
             HttpUtil.populateSSLConfiguration(clientConnectorConfig, secureSocket);
         } else if (scheme.equals(WebSocketConstants.WSS_SCHEME)) {


### PR DESCRIPTION
## Purpose
This PR redesign the HTTP listener/client `SecureSocket` API for SwanLake release. The updated API would be as follows:

**Listener**
```ballerina
public type ListenerSecureSocket record {|
   crypto:KeyStore|CertKey key;
   record {|
       VerifyClient verifyClient = REQUIRE;
       crypto:TrustStore|string cert;
   |} mutualSsl?;
   record {|
       Protocol name;
       string[] versions = [];
   |} protocol?;
   record {|
       CertValidationType type = OCSP_STAPLING;
       int cacheSize;
       decimal cacheValidityPeriod;
   |} certValidation?;
   string[] ciphers = [];
   boolean shareSession = true;
   decimal handshakeTimeout?;
   decimal sessionTimeout?;
|};
 
public type CertKey record {|
   string certFile;
   string keyFile;
   string keyPassword?;
|};
 
public enum VerifyClient {
   REQUIRE,
   OPTIONAL
}
 
public enum Protocol {
   SSL,
   TLS,
   DTLS
}
 
public enum CertValidationType {
   OCSP_CRL,
   OCSP_STAPLING
}
```

**Client**
```ballerina
public type ClientSecureSocket record {|
   boolean enable = true;
   crypto:TrustStore|string cert?;
   crypto:KeyStore|CertKey key?;
   record {|
       Protocol name;
       string[] versions = [];
   |} protocol?;
   record {|
       CertValidationType type = OCSP_STAPLING;
       int cacheSize;
       decimal cacheValidityPeriod;
   |} certValidation?;
   string[] ciphers?;
   boolean verifyHostName = true;
   boolean shareSession = true;
   decimal handshakeTimeout?;
   decimal sessionTimeout?;
|};
 
public type CertKey record {|
   string certFile;
   string keyFile;
   string keyPassword?;
|};
 
public enum Protocol {
   SSL,
   TLS,
   DTLS
}
 
public enum CertValidationType {
   OCSP_CRL,
   OCSP_STAPLING
}
```

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/917

Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/584