### PR TITLE
Update for JDK11 client config API change

### DIFF
--- a/http-ballerina-tests/tests/auth_client_auth_handler_test.bal
+++ b/http-ballerina-tests/tests/auth_client_auth_handler_test.bal
@@ -89,7 +89,7 @@ isolated function testClientOAuth2Handler() {
         scopes: ["token-scope1", "token-scope2"],
         clientConfig: {
             secureSocket: {
-               trustStore: {
+               cert: {
                    path: TRUSTSTORE_PATH,
                    password: "ballerina"
                }
@@ -106,7 +106,7 @@ isolated function testClientOAuth2Handler() {
         scopes: ["token-scope1", "token-scope2"],
         clientConfig: {
             secureSocket: {
-               trustStore: {
+               cert: {
                    path: TRUSTSTORE_PATH,
                    password: "ballerina"
                }
@@ -122,7 +122,7 @@ isolated function testClientOAuth2Handler() {
         scopes: ["token-scope1", "token-scope2"],
         clientConfig: {
             secureSocket: {
-               trustStore: {
+               cert: {
                    path: TRUSTSTORE_PATH,
                    password: "ballerina"
                }

--- a/http-ballerina-tests/tests/auth_listener_auth_handler_test.bal
+++ b/http-ballerina-tests/tests/auth_listener_auth_handler_test.bal
@@ -270,7 +270,7 @@ function testListenerOAuth2HandlerAuthSuccess() {
         scopeKey: "scp",
         clientConfig: {
             secureSocket: {
-               trustStore: {
+               cert: {
                    path: TRUSTSTORE_PATH,
                    password: "ballerina"
                }
@@ -297,7 +297,7 @@ function testListenerOAuth2HandlerAuthzFailure() {
         scopeKey: "scp",
         clientConfig: {
             secureSocket: {
-               trustStore: {
+               cert: {
                    path: TRUSTSTORE_PATH,
                    password: "ballerina"
                }
@@ -322,7 +322,7 @@ function testListenerOAuth2HandlerAuthnFailure() {
         scopeKey: "scp",
         clientConfig: {
             secureSocket: {
-               trustStore: {
+               cert: {
                    path: TRUSTSTORE_PATH,
                    password: "ballerina"
                }

--- a/http-ballerina-tests/tests/auth_listener_declarative_design_test.bal
+++ b/http-ballerina-tests/tests/auth_listener_declarative_design_test.bal
@@ -62,7 +62,7 @@ function testNoAuthServiceResourceSuccess() {
 }
 
 @test:Config {}
-function testNNoAuthServiceResourceWithRequestSuccess() {
+function testNoAuthServiceResourceWithRequestSuccess() {
     assertSuccess(sendBearerTokenRequest("/baz/bar", JWT2));
 }
 

--- a/http-ballerina-tests/tests/auth_listener_declarative_design_test.bal
+++ b/http-ballerina-tests/tests/auth_listener_declarative_design_test.bal
@@ -157,7 +157,7 @@ function testJwtAuthServiceAuthnFailure() {
                 scopeKey: "scp",
                 clientConfig: {
                     secureSocket: {
-                       trustStore: {
+                       cert: {
                            path: TRUSTSTORE_PATH,
                            password: "ballerina"
                        }
@@ -239,7 +239,7 @@ service /foo on authListener {
                     scopeKey: "scp",
                     clientConfig: {
                         secureSocket: {
-                           trustStore: {
+                           cert: {
                                path: TRUSTSTORE_PATH,
                                password: "ballerina"
                            }
@@ -312,7 +312,7 @@ function testOAuth2ResourceAuthnFailure() {
                 scopeKey: "scp",
                 clientConfig: {
                     secureSocket: {
-                       trustStore: {
+                       cert: {
                            path: TRUSTSTORE_PATH,
                            password: "ballerina"
                        }
@@ -378,7 +378,7 @@ function testServiceResourceAuthnFailure() {
                 scopeKey: "scp",
                 clientConfig: {
                     secureSocket: {
-                       trustStore: {
+                       cert: {
                            path: TRUSTSTORE_PATH,
                            password: "ballerina"
                        }
@@ -445,7 +445,7 @@ service /bar on authListener {
                     scopeKey: "scp",
                     clientConfig: {
                         secureSocket: {
-                           trustStore: {
+                           cert: {
                                path: TRUSTSTORE_PATH,
                                password: "ballerina"
                            }

--- a/http-ballerina-tests/tests/auth_listener_imperative_design_test.bal
+++ b/http-ballerina-tests/tests/auth_listener_imperative_design_test.bal
@@ -60,8 +60,8 @@ service /imperative on authListener {
         return "Hello World!";
     }
 
-    resource function get baz(@http:Header { name: "Authorization" } string headers) returns string|http:Unauthorized|http:Forbidden {
-        jwt:Payload|http:Unauthorized authn = handler.authenticate(headers);
+    resource function get baz(@http:Header { name: "Authorization" } string header) returns string|http:Unauthorized|http:Forbidden {
+        jwt:Payload|http:Unauthorized authn = handler.authenticate(header);
         if (authn is http:Unauthorized) {
             return authn;
         }

--- a/http-ballerina-tests/tests/ssl_mutual_ssl_test.bal
+++ b/http-ballerina-tests/tests/ssl_mutual_ssl_test.bal
@@ -87,7 +87,7 @@ service /echoDummyService15 on echoDummy15 {
 }
 
 http:ClientConfiguration mutualSslClientConf = {
-    secureSocket:{
+    secureSocket: {
         key: {
             path: "tests/certsandkeys/ballerinaKeystore.p12",
             password: "ballerina"


### PR DESCRIPTION
## Purpose
This PR updates the tests cases for the JDK11 client config API change done by https://github.com/ballerina-platform/module-ballerina-jwt/pull/137 and https://github.com/ballerina-platform/module-ballerina-oauth2/pull/98

Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/584