### PR TITLE
Add enrich header APIs for auth client handlers

### DIFF
--- a/http-ballerina-tests/tests/auth_client_auth_handler_test.bal
+++ b/http-ballerina-tests/tests/auth_client_auth_handler_test.bal
@@ -27,12 +27,29 @@ isolated function testClientBasicAuthHandler() {
     };
     http:ClientBasicAuthHandler handler = new(config);
     http:Request request = createDummyRequest();
-    http:Request|http:ClientAuthError result = handler.enrich(request);
-    if (result is http:Request) {
-        string header = checkpanic result.getHeader(http:AUTH_HEADER);
+    http:Request|http:ClientAuthError result1 = handler.enrich(request);
+    if (result1 is http:Request) {
+        string header = checkpanic result1.getHeader(http:AUTH_HEADER);
         test:assertEquals(header, "Basic YWRtaW46MTIz");
     } else {
-        test:assertFail(msg = "Test Failed! " + result.message());
+        test:assertFail(msg = "Test Failed! " + result1.message());
+    }
+
+    map<string|string[]> headers = {};
+    map<string|string[]>|http:ClientAuthError result2 = handler.enrichHeaders(headers);
+    if (result2 is map<string|string[]>) {
+        string header = <string>result2.get(http:AUTH_HEADER);
+        test:assertEquals(header, "Basic YWRtaW46MTIz");
+    } else {
+        test:assertFail(msg = "Test Failed! " + result2.message());
+    }
+
+    map<string|string[]>|http:ClientAuthError result3 = handler.getHeaders();
+    if (result3 is map<string|string[]>) {
+        string header = <string>result3.get(http:AUTH_HEADER);
+        test:assertEquals(header, "Basic YWRtaW46MTIz");
+    } else {
+        test:assertFail(msg = "Test Failed! " + result3.message());
     }
 }
 
@@ -43,12 +60,29 @@ isolated function testClientBearerTokenAuthHandler() {
     };
     http:ClientBearerTokenAuthHandler handler = new(config);
     http:Request request = createDummyRequest();
-    http:Request|http:ClientAuthError result = handler.enrich(request);
-    if (result is http:Request) {
-        string header = checkpanic result.getHeader(http:AUTH_HEADER);
+    http:Request|http:ClientAuthError result1 = handler.enrich(request);
+    if (result1 is http:Request) {
+        string header = checkpanic result1.getHeader(http:AUTH_HEADER);
         test:assertEquals(header, "Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ");
     } else {
-        test:assertFail(msg = "Test Failed! " + result.message());
+        test:assertFail(msg = "Test Failed! " + result1.message());
+    }
+
+    map<string|string[]> headers = {};
+    map<string|string[]>|http:ClientAuthError result2 = handler.enrichHeaders(headers);
+    if (result2 is map<string|string[]>) {
+        string header = <string>result2.get(http:AUTH_HEADER);
+        test:assertEquals(header, "Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ");
+    } else {
+        test:assertFail(msg = "Test Failed! " + result2.message());
+    }
+
+    map<string|string[]>|http:ClientAuthError result3 = handler.getHeaders();
+    if (result3 is map<string|string[]>) {
+        string header = <string>result3.get(http:AUTH_HEADER);
+        test:assertEquals(header, "Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ");
+    } else {
+        test:assertFail(msg = "Test Failed! " + result3.message());
     }
 }
 
@@ -71,12 +105,29 @@ isolated function testClientSelfSignedJwtAuthHandler() {
     };
     http:ClientSelfSignedJwtAuthHandler handler = new(config);
     http:Request request = createDummyRequest();
-    http:Request|http:ClientAuthError result = handler.enrich(request);
-    if (result is http:Request) {
-        string header = checkpanic result.getHeader(http:AUTH_HEADER);
+    http:Request|http:ClientAuthError result1 = handler.enrich(request);
+    if (result1 is http:Request) {
+        string header = checkpanic result1.getHeader(http:AUTH_HEADER);
         test:assertTrue(header.startsWith("Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ"));
     } else {
-        test:assertFail(msg = "Test Failed! " + result.message());
+        test:assertFail(msg = "Test Failed! " + result1.message());
+    }
+
+    map<string|string[]> headers = {};
+    map<string|string[]>|http:ClientAuthError result2 = handler.enrichHeaders(headers);
+    if (result2 is map<string|string[]>) {
+        string header = <string>result2.get(http:AUTH_HEADER);
+        test:assertTrue(header.startsWith("Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ"));
+    } else {
+        test:assertFail(msg = "Test Failed! " + result2.message());
+    }
+
+    map<string|string[]>|http:ClientAuthError result3 = handler.getHeaders();
+    if (result3 is map<string|string[]>) {
+        string header = <string>result3.get(http:AUTH_HEADER);
+        test:assertTrue(header.startsWith("Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ"));
+    } else {
+        test:assertFail(msg = "Test Failed! " + result3.message());
     }
 }
 
@@ -132,29 +183,80 @@ isolated function testClientOAuth2Handler() {
 
     http:Request request = createDummyRequest();
     http:ClientOAuth2Handler handler = new(config1);
-    http:Request|http:ClientAuthError result = handler->enrich(request);
-    if (result is http:Request) {
-        string header = checkpanic result.getHeader(http:AUTH_HEADER);
+    http:Request|http:ClientAuthError result1 = handler->enrich(request);
+    if (result1 is http:Request) {
+        string header = checkpanic result1.getHeader(http:AUTH_HEADER);
         test:assertEquals(header, "Bearer 2YotnFZFEjr1zCsicMWpAA");
     } else {
-        test:assertFail(msg = "Test Failed! " + result.message());
+        test:assertFail(msg = "Test Failed! " + result1.message());
+    }
+
+    map<string|string[]> headers = {};
+    map<string|string[]>|http:ClientAuthError result2 = handler.enrichHeaders(headers);
+    if (result2 is map<string|string[]>) {
+        string header = <string>result2.get(http:AUTH_HEADER);
+        test:assertEquals(header, "Bearer 2YotnFZFEjr1zCsicMWpAA");
+    } else {
+        test:assertFail(msg = "Test Failed! " + result2.message());
+    }
+
+    map<string|string[]>|http:ClientAuthError result3 = handler.getHeaders();
+    if (result3 is map<string|string[]>) {
+        string header = <string>result3.get(http:AUTH_HEADER);
+        test:assertEquals(header, "Bearer 2YotnFZFEjr1zCsicMWpAA");
+    } else {
+        test:assertFail(msg = "Test Failed! " + result3.message());
     }
 
     handler = new(config2);
-    result = handler->enrich(request);
-    if (result is http:Request) {
-        string header = checkpanic result.getHeader(http:AUTH_HEADER);
+    result1 = handler->enrich(request);
+    if (result1 is http:Request) {
+        string header = checkpanic result1.getHeader(http:AUTH_HEADER);
         test:assertEquals(header, "Bearer 2YotnFZFEjr1zCsicMWpAA");
     } else {
-        test:assertFail(msg = "Test Failed! " + result.message());
+        test:assertFail(msg = "Test Failed! " + result1.message());
+    }
+
+    headers = {};
+    result2 = handler.enrichHeaders(headers);
+    if (result2 is map<string|string[]>) {
+        string header = <string>result2.get(http:AUTH_HEADER);
+        test:assertEquals(header, "Bearer 2YotnFZFEjr1zCsicMWpAA");
+    } else {
+        test:assertFail(msg = "Test Failed! " + result2.message());
+    }
+
+    result3 = handler.getHeaders();
+    if (result3 is map<string|string[]>) {
+        string header = <string>result3.get(http:AUTH_HEADER);
+        test:assertEquals(header, "Bearer 2YotnFZFEjr1zCsicMWpAA");
+    } else {
+        test:assertFail(msg = "Test Failed! " + result3.message());
     }
 
     handler = new(config3);
-    result = handler->enrich(request);
-    if (result is http:Request) {
-        string header = checkpanic result.getHeader(http:AUTH_HEADER);
+    result1 = handler->enrich(request);
+    if (result1 is http:Request) {
+        string header = checkpanic result1.getHeader(http:AUTH_HEADER);
         test:assertEquals(header, "Bearer 2YotnFZFEjr1zCsicMWpAA");
     } else {
-        test:assertFail(msg = "Test Failed! " + result.message());
+        test:assertFail(msg = "Test Failed! " + result1.message());
+    }
+
+    headers = {};
+    result2 = handler.enrichHeaders(headers);
+    if (result2 is map<string|string[]>) {
+        string header = <string>result2.get(http:AUTH_HEADER);
+        test:assertEquals(header, "Bearer 2YotnFZFEjr1zCsicMWpAA");
+    } else {
+        test:assertFail(msg = "Test Failed! " + result2.message());
+    }
+
+    result3 = handler.getHeaders();
+    if (result3 is map<string|string[]>) {
+        string header = <string>result3.get(http:AUTH_HEADER);
+        test:assertEquals(header, "Bearer 2YotnFZFEjr1zCsicMWpAA");
+    } else {
+        test:assertFail(msg = "Test Failed! " + result3.message());
     }
 }

--- a/http-ballerina-tests/tests/auth_client_auth_handler_test.bal
+++ b/http-ballerina-tests/tests/auth_client_auth_handler_test.bal
@@ -44,7 +44,7 @@ isolated function testClientBasicAuthHandler() {
         test:assertFail(msg = "Test Failed! " + result2.message());
     }
 
-    map<string|string[]>|http:ClientAuthError result3 = handler.getHeaders();
+    map<string|string[]>|http:ClientAuthError result3 = handler.getSecurityHeaders();
     if (result3 is map<string|string[]>) {
         string header = <string>result3.get(http:AUTH_HEADER);
         test:assertEquals(header, "Basic YWRtaW46MTIz");
@@ -77,7 +77,7 @@ isolated function testClientBearerTokenAuthHandler() {
         test:assertFail(msg = "Test Failed! " + result2.message());
     }
 
-    map<string|string[]>|http:ClientAuthError result3 = handler.getHeaders();
+    map<string|string[]>|http:ClientAuthError result3 = handler.getSecurityHeaders();
     if (result3 is map<string|string[]>) {
         string header = <string>result3.get(http:AUTH_HEADER);
         test:assertEquals(header, "Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ");
@@ -122,7 +122,7 @@ isolated function testClientSelfSignedJwtAuthHandler() {
         test:assertFail(msg = "Test Failed! " + result2.message());
     }
 
-    map<string|string[]>|http:ClientAuthError result3 = handler.getHeaders();
+    map<string|string[]>|http:ClientAuthError result3 = handler.getSecurityHeaders();
     if (result3 is map<string|string[]>) {
         string header = <string>result3.get(http:AUTH_HEADER);
         test:assertTrue(header.startsWith("Bearer eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QifQ"));
@@ -200,7 +200,7 @@ isolated function testClientOAuth2Handler() {
         test:assertFail(msg = "Test Failed! " + result2.message());
     }
 
-    map<string|string[]>|http:ClientAuthError result3 = handler.getHeaders();
+    map<string|string[]>|http:ClientAuthError result3 = handler.getSecurityHeaders();
     if (result3 is map<string|string[]>) {
         string header = <string>result3.get(http:AUTH_HEADER);
         test:assertEquals(header, "Bearer 2YotnFZFEjr1zCsicMWpAA");
@@ -226,7 +226,7 @@ isolated function testClientOAuth2Handler() {
         test:assertFail(msg = "Test Failed! " + result2.message());
     }
 
-    result3 = handler.getHeaders();
+    result3 = handler.getSecurityHeaders();
     if (result3 is map<string|string[]>) {
         string header = <string>result3.get(http:AUTH_HEADER);
         test:assertEquals(header, "Bearer 2YotnFZFEjr1zCsicMWpAA");
@@ -252,7 +252,7 @@ isolated function testClientOAuth2Handler() {
         test:assertFail(msg = "Test Failed! " + result2.message());
     }
 
-    result3 = handler.getHeaders();
+    result3 = handler.getSecurityHeaders();
     if (result3 is map<string|string[]>) {
         string header = <string>result3.get(http:AUTH_HEADER);
         test:assertEquals(header, "Bearer 2YotnFZFEjr1zCsicMWpAA");

--- a/http-ballerina-tests/tests/auth_client_imperative_design_test.bal
+++ b/http-ballerina-tests/tests/auth_client_imperative_design_test.bal
@@ -1,0 +1,103 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// NOTE: All the tokens/credentials used in this test are dummy tokens/credentials and used only for testing purposes.
+
+import ballerina/http;
+import ballerina/jwt;
+import ballerina/test;
+
+service /imperativeclient on authListener {
+    resource function get foo(http:Request req) returns string|http:Unauthorized|http:Forbidden {
+        jwt:Payload|http:Unauthorized authn = handler.authenticate(req);
+        if (authn is http:Unauthorized) {
+            return authn;
+        }
+        http:Forbidden? authz = handler.authorize(<jwt:Payload> authn, ["write", "update"]);
+        if (authz is http:Forbidden) {
+            return authz;
+        }
+        return "Hello World!";
+    }
+
+    resource function post foo(http:Request req) returns string|http:Unauthorized|http:Forbidden {
+        jwt:Payload|http:Unauthorized authn = handler.authenticate(req);
+        if (authn is http:Unauthorized) {
+            return authn;
+        }
+        http:Forbidden? authz = handler.authorize(<jwt:Payload> authn, ["write", "update"]);
+        if (authz is http:Forbidden) {
+            return authz;
+        }
+        return "Hello World!";
+    }
+}
+
+http:Client imperativeClientEP = checkpanic new("https://localhost:" + securedListenerPort.toString(), {
+    secureSocket: {
+        cert: {
+            path: TRUSTSTORE_PATH,
+            password: "ballerina"
+        }
+    }
+});
+
+@test:Config {}
+function testImperativeEnrichRequest() {
+    http:BearerTokenConfig config = {
+        token: JWT1
+    };
+    http:ClientBearerTokenAuthHandler handler = new(config);
+    http:Request request = createDummyRequest();
+    http:Request|http:ClientAuthError result = handler.enrich(request);
+    if (result is http:Request) {
+        http:Response|http:ClientError response = imperativeClientEP->post("/imperativeclient/foo", result);
+        assertSuccess(response);
+    } else {
+        test:assertFail(msg = "Test Failed! " + result.message());
+    }
+}
+
+@test:Config {}
+function testImperativeEnrichHeaders() {
+    http:BearerTokenConfig config = {
+        token: JWT1
+    };
+    http:ClientBearerTokenAuthHandler handler = new(config);
+    map<string|string[]> headers = {};
+    map<string|string[]>|http:ClientAuthError result = handler.enrichHeaders(headers);
+    if (result is map<string|string[]>) {
+        http:Response|http:ClientError response = imperativeClientEP->get("/imperativeclient/foo", result);
+        assertSuccess(response);
+    } else {
+        test:assertFail(msg = "Test Failed! " + result.message());
+    }
+}
+
+@test:Config {}
+function testImperativeGetHeaders() {
+    http:BearerTokenConfig config = {
+        token: JWT1
+    };
+    http:ClientBearerTokenAuthHandler handler = new(config);
+    map<string|string[]>|http:ClientAuthError result = handler.getHeaders();
+    if (result is map<string|string[]>) {
+        http:Response|http:ClientError response = imperativeClientEP->get("/imperativeclient/foo", result);
+        assertSuccess(response);
+    } else {
+        test:assertFail(msg = "Test Failed! " + result.message());
+    }
+}

--- a/http-ballerina-tests/tests/auth_client_imperative_design_test.bal
+++ b/http-ballerina-tests/tests/auth_client_imperative_design_test.bal
@@ -88,12 +88,12 @@ function testImperativeEnrichHeaders() {
 }
 
 @test:Config {}
-function testImperativeGetHeaders() {
+function testImperativeGetSecurityHeaders() {
     http:BearerTokenConfig config = {
         token: JWT1
     };
     http:ClientBearerTokenAuthHandler handler = new(config);
-    map<string|string[]>|http:ClientAuthError result = handler.getHeaders();
+    map<string|string[]>|http:ClientAuthError result = handler.getSecurityHeaders();
     if (result is map<string|string[]>) {
         http:Response|http:ClientError response = imperativeClientEP->get("/imperativeclient/foo", result);
         assertSuccess(response);

--- a/http-ballerina/auth_client_basic_auth_handler.bal
+++ b/http-ballerina/auth_client_basic_auth_handler.bal
@@ -64,7 +64,7 @@ public class ClientBasicAuthHandler {
     # Returns the headers map with the relevant authentication requirements.
     #
     # + return - The updated headers map or else an `http:ClientAuthError` in case of an error
-    public isolated function getHeaders() returns map<string|string[]>|ClientAuthError {
+    public isolated function getSecurityHeaders() returns map<string|string[]>|ClientAuthError {
         string|auth:Error result = self.provider.generateToken();
         if (result is string) {
             map<string|string[]> headers = {};

--- a/http-ballerina/auth_client_basic_auth_handler.bal
+++ b/http-ballerina/auth_client_basic_auth_handler.bal
@@ -67,9 +67,8 @@ public class ClientBasicAuthHandler {
     public isolated function getHeaders() returns map<string|string[]>|ClientAuthError {
         string|auth:Error result = self.provider.generateToken();
         if (result is string) {
-            map<string|string[]> headers = {
-                AUTH_HEADER: AUTH_SCHEME_BASIC + " " + result
-            };
+            map<string|string[]> headers = {};
+            headers[AUTH_HEADER] = AUTH_SCHEME_BASIC + " " + result;
             return headers;
         } else {
             return prepareClientAuthError("Failed to enrich headers with Basic Auth token.", result);

--- a/http-ballerina/auth_client_basic_auth_handler.bal
+++ b/http-ballerina/auth_client_basic_auth_handler.bal
@@ -46,4 +46,33 @@ public class ClientBasicAuthHandler {
             return prepareClientAuthError("Failed to enrich request with Basic Auth token.", result);
         }
     }
+
+    # Enrich the headers map with the relevant authentication requirements.
+    #
+    # + headers - The headers map
+    # + return - The updated headers map or else an `http:ClientAuthError` in case of an error
+    public isolated function enrichHeaders(map<string|string[]> headers) returns map<string|string[]>|ClientAuthError {
+        string|auth:Error result = self.provider.generateToken();
+        if (result is string) {
+            headers[AUTH_HEADER] = AUTH_SCHEME_BASIC + " " + result;
+            return headers;
+        } else {
+            return prepareClientAuthError("Failed to enrich headers with Basic Auth token.", result);
+        }
+    }
+
+    # Returns the headers map with the relevant authentication requirements.
+    #
+    # + return - The updated headers map or else an `http:ClientAuthError` in case of an error
+    public isolated function getHeaders() returns map<string|string[]>|ClientAuthError {
+        string|auth:Error result = self.provider.generateToken();
+        if (result is string) {
+            map<string|string[]> headers = {
+                AUTH_HEADER: AUTH_SCHEME_BASIC + " " + result
+            };
+            return headers;
+        } else {
+            return prepareClientAuthError("Failed to enrich headers with Basic Auth token.", result);
+        }
+    }
 }

--- a/http-ballerina/auth_client_bearer_token_auth_handler.bal
+++ b/http-ballerina/auth_client_bearer_token_auth_handler.bal
@@ -55,9 +55,8 @@ public class ClientBearerTokenAuthHandler {
     #
     # + return - The updated headers map or else an `http:ClientAuthError` in case of an error
     public isolated function getHeaders() returns map<string|string[]>|ClientAuthError {
-        map<string|string[]> headers = {
-            AUTH_HEADER: AUTH_SCHEME_BEARER + " " + self.config.token
-        };
+        map<string|string[]> headers = {};
+        headers[AUTH_HEADER] = AUTH_SCHEME_BEARER + " " + self.config.token;
         return headers;
     }
 }

--- a/http-ballerina/auth_client_bearer_token_auth_handler.bal
+++ b/http-ballerina/auth_client_bearer_token_auth_handler.bal
@@ -54,7 +54,7 @@ public class ClientBearerTokenAuthHandler {
     # Returns the headers map with the relevant authentication requirements.
     #
     # + return - The updated headers map or else an `http:ClientAuthError` in case of an error
-    public isolated function getHeaders() returns map<string|string[]>|ClientAuthError {
+    public isolated function getSecurityHeaders() returns map<string|string[]>|ClientAuthError {
         map<string|string[]> headers = {};
         headers[AUTH_HEADER] = AUTH_SCHEME_BEARER + " " + self.config.token;
         return headers;

--- a/http-ballerina/auth_client_bearer_token_auth_handler.bal
+++ b/http-ballerina/auth_client_bearer_token_auth_handler.bal
@@ -41,4 +41,23 @@ public class ClientBearerTokenAuthHandler {
         req.setHeader(AUTH_HEADER, AUTH_SCHEME_BEARER + " " + self.config.token);
         return req;
     }
+
+    # Enrich the headers map with the relevant authentication requirements.
+    #
+    # + headers - The headers map
+    # + return - The updated headers map or else an `http:ClientAuthError` in case of an error
+    public isolated function enrichHeaders(map<string|string[]> headers) returns map<string|string[]>|ClientAuthError {
+        headers[AUTH_HEADER] = AUTH_SCHEME_BEARER + " " + self.config.token;
+        return headers;
+    }
+
+    # Returns the headers map with the relevant authentication requirements.
+    #
+    # + return - The updated headers map or else an `http:ClientAuthError` in case of an error
+    public isolated function getHeaders() returns map<string|string[]>|ClientAuthError {
+        map<string|string[]> headers = {
+            AUTH_HEADER: AUTH_SCHEME_BEARER + " " + self.config.token
+        };
+        return headers;
+    }
 }

--- a/http-ballerina/auth_client_oauth2_handler.bal
+++ b/http-ballerina/auth_client_oauth2_handler.bal
@@ -59,4 +59,33 @@ public client class ClientOAuth2Handler {
             return prepareClientAuthError("Failed to enrich request with OAuth2 token.", result);
         }
     }
+
+    # Enrich the headers map with the relevant authentication requirements.
+    #
+    # + headers - The headers map
+    # + return - The updated headers map or else an `http:ClientAuthError` in case of an error
+    public isolated function enrichHeaders(map<string|string[]> headers) returns map<string|string[]>|ClientAuthError {
+        string|oauth2:Error result = self.provider.generateToken();
+        if (result is string) {
+            headers[AUTH_HEADER] = AUTH_SCHEME_BEARER + " " + result;
+            return headers;
+        } else {
+            return prepareClientAuthError("Failed to enrich headers with OAuth2 token.", result);
+        }
+    }
+
+    # Returns the headers map with the relevant authentication requirements.
+    #
+    # + return - The updated headers map or else an `http:ClientAuthError` in case of an error
+    public isolated function getHeaders() returns map<string|string[]>|ClientAuthError {
+        string|oauth2:Error result = self.provider.generateToken();
+        if (result is string) {
+            map<string|string[]> headers = {
+                AUTH_HEADER: AUTH_SCHEME_BEARER + " " + result
+            };
+            return headers;
+        } else {
+            return prepareClientAuthError("Failed to enrich headers with OAuth2 token.", result);
+        }
+    }
 }

--- a/http-ballerina/auth_client_oauth2_handler.bal
+++ b/http-ballerina/auth_client_oauth2_handler.bal
@@ -77,7 +77,7 @@ public client class ClientOAuth2Handler {
     # Returns the headers map with the relevant authentication requirements.
     #
     # + return - The updated headers map or else an `http:ClientAuthError` in case of an error
-    public isolated function getHeaders() returns map<string|string[]>|ClientAuthError {
+    public isolated function getSecurityHeaders() returns map<string|string[]>|ClientAuthError {
         string|oauth2:Error result = self.provider.generateToken();
         if (result is string) {
             map<string|string[]> headers = {};

--- a/http-ballerina/auth_client_oauth2_handler.bal
+++ b/http-ballerina/auth_client_oauth2_handler.bal
@@ -80,9 +80,8 @@ public client class ClientOAuth2Handler {
     public isolated function getHeaders() returns map<string|string[]>|ClientAuthError {
         string|oauth2:Error result = self.provider.generateToken();
         if (result is string) {
-            map<string|string[]> headers = {
-                AUTH_HEADER: AUTH_SCHEME_BEARER + " " + result
-            };
+            map<string|string[]> headers = {};
+            headers[AUTH_HEADER] = AUTH_SCHEME_BEARER + " " + result;
             return headers;
         } else {
             return prepareClientAuthError("Failed to enrich headers with OAuth2 token.", result);

--- a/http-ballerina/auth_client_self_signed_jwt_auth_handler.bal
+++ b/http-ballerina/auth_client_self_signed_jwt_auth_handler.bal
@@ -46,4 +46,33 @@ public class ClientSelfSignedJwtAuthHandler {
             return prepareClientAuthError("Failed to enrich request with JWT.", result);
         }
     }
+
+    # Enrich the headers map with the relevant authentication requirements.
+    #
+    # + headers - The headers map
+    # + return - The updated headers map or else an `http:ClientAuthError` in case of an error
+    public isolated function enrichHeaders(map<string|string[]> headers) returns map<string|string[]>|ClientAuthError {
+        string|jwt:Error result = self.provider.generateToken();
+        if (result is string) {
+            headers[AUTH_HEADER] = AUTH_SCHEME_BEARER + " " + result;
+            return headers;
+        } else {
+            return prepareClientAuthError("Failed to enrich headers with JWT.", result);
+        }
+    }
+
+    # Returns the headers map with the relevant authentication requirements.
+    #
+    # + return - The updated headers map or else an `http:ClientAuthError` in case of an error
+    public isolated function getHeaders() returns map<string|string[]>|ClientAuthError {
+        string|jwt:Error result = self.provider.generateToken();
+        if (result is string) {
+            map<string|string[]> headers = {
+                AUTH_HEADER: AUTH_SCHEME_BEARER + " " + result
+            };
+            return headers;
+        } else {
+            return prepareClientAuthError("Failed to enrich headers with JWT.", result);
+        }
+    }
 }

--- a/http-ballerina/auth_client_self_signed_jwt_auth_handler.bal
+++ b/http-ballerina/auth_client_self_signed_jwt_auth_handler.bal
@@ -67,9 +67,8 @@ public class ClientSelfSignedJwtAuthHandler {
     public isolated function getHeaders() returns map<string|string[]>|ClientAuthError {
         string|jwt:Error result = self.provider.generateToken();
         if (result is string) {
-            map<string|string[]> headers = {
-                AUTH_HEADER: AUTH_SCHEME_BEARER + " " + result
-            };
+            map<string|string[]> headers = {};
+            headers[AUTH_HEADER] = AUTH_SCHEME_BEARER + " " + result;
             return headers;
         } else {
             return prepareClientAuthError("Failed to enrich headers with JWT.", result);

--- a/http-ballerina/auth_client_self_signed_jwt_auth_handler.bal
+++ b/http-ballerina/auth_client_self_signed_jwt_auth_handler.bal
@@ -64,7 +64,7 @@ public class ClientSelfSignedJwtAuthHandler {
     # Returns the headers map with the relevant authentication requirements.
     #
     # + return - The updated headers map or else an `http:ClientAuthError` in case of an error
-    public isolated function getHeaders() returns map<string|string[]>|ClientAuthError {
+    public isolated function getSecurityHeaders() returns map<string|string[]>|ClientAuthError {
         string|jwt:Error result = self.provider.generateToken();
         if (result is string) {
             map<string|string[]> headers = {};


### PR DESCRIPTION
## Purpose
This PR implements enrich header APIs for auth client handlers.
```ballerina
public isolated function enrichHeaders(map<string|string[]> headers) returns map<string|string[]>|ClientAuthError;
public isolated function getSecurityHeaders() returns map<string|string[]>|ClientAuthError;
```

Related to: https://github.com/ballerina-platform/ballerina-standard-library/issues/584