### PR TITLE
Move Ballerina build, test and publish into a single task

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -1,0 +1,25 @@
+name: Publish to the Ballerina central
+
+on:
+    workflow_dispatch:
+
+jobs:
+    publish-release:
+        runs-on: ubuntu-latest
+        if: github.repository_owner == 'ballerina-platform'
+        steps:
+            -   uses: actions/checkout@v2
+            -   name: Set up JDK 11
+                uses: actions/setup-java@v1
+                with:
+                    java-version: 11
+            -   name: Grant execute permission for gradlew
+                run: chmod +x gradlew
+            -   name: Publish artifact
+                env:
+                    BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
+                    packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+                    packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+                    GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+                run: |
+                    ./gradlew clean build -PpublishToCentral=true

--- a/README.md
+++ b/README.md
@@ -43,20 +43,44 @@ This repository only contains the source code for the package.
 Execute the commands below to build from source.
 
 1. To build the library:
-        
-        ./gradlew clean build
-
+    ```
+    ./gradlew clean build
+    ```
+   
 2. To run the integration tests:
+    ```
+    ./gradlew clean test
+    ```
 
-        ./gradlew clean test
+3. To run a group of tests
+    ```
+    ./gradlew clean test -Pgroups=<test_group_names>
+    ```
 
-3. To build the package without the tests:
+4. To build the package without the tests:
+    ```
+    ./gradlew clean build -x test
+    ```
+   
+5. To debug the tests:
+    ```
+    ./gradlew clean test -Pdebug=<port>
+    ```
+   
+6. To debug with Ballerina language:
+    ```
+    ./gradlew clean build -PbalJavaDebug=<port>
+    ```
 
-        ./gradlew clean build -x test
+7. Publish the generated artifacts to the local Ballerina central repository:
+    ```
+    ./gradlew clean build -PpublishToLocalCentral=true
+    ```
 
-4. To debug the tests:
-
-        ./gradlew clean test -Pdebug=<port>
+8. Publish the generated artifacts to the Ballerina central repository:
+    ```
+    ./gradlew clean build -PpublishToCentral=true
+    ```
 
 ## Contributing to Ballerina
 

--- a/http-ballerina-tests/build.gradle
+++ b/http-ballerina-tests/build.gradle
@@ -156,6 +156,7 @@ def groupParams = ""
 def disableGroups = ""
 def debugParams = ""
 def balJavaDebugParam = ""
+def testParams = ""
 
 task initializeVariables {
     if (project.hasProperty("groups")) {
@@ -177,6 +178,14 @@ task initializeVariables {
             ballerinaTest.enabled = false
         }
     }
+
+    gradle.taskGraph.whenReady { graph ->
+        if (graph.hasTask(":${packageName}-ballerina:test")) {
+            testParams = "${testCoverageParam}"
+        } else {
+            testParams = "--skip-tests"
+        }
+    }
 }
 
 task ballerinaTest {
@@ -196,14 +205,13 @@ task ballerinaTest {
         exec {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-            // code coverage is not added due to issue https://github.com/ballerina-platform/ballerina-lang/issues/25399
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/bal.bat test " +
-                        "${testCoverageParam} ${groupParams} ${disableGroups} ${debugParams} ${certsAndKeys} && " +
+                commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat test " +
+                        "${testParams} ${groupParams} ${disableGroups} ${debugParams} ${certsAndKeys} && " +
                         "exit %%ERRORLEVEL%%"
             } else {
-                commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal test " +
-                        "${testCoverageParam} ${groupParams} ${disableGroups} ${debugParams} ${certsAndKeys}"
+                commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal test " +
+                        "${testParams} ${groupParams} ${disableGroups} ${debugParams} ${certsAndKeys}"
             }
         }
     }

--- a/http-ballerina/build.gradle
+++ b/http-ballerina/build.gradle
@@ -33,6 +33,7 @@ def ballerinaCentralAccessToken = System.getenv('BALLERINA_CENTRAL_ACCESS_TOKEN'
 def originalConfig = ballerinaConfigFile.text
 def originalDependency = ballerinaDependencyFile.text
 def originalCompilerPluginToml = compilerPluginTomlFile.text
+def testCoverageParam = "--code-coverage --includes=io.ballerina.stdlib.http.*:ballerina.*"
 def distributionBinPath =  project.projectDir.absolutePath + "/build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin"
 
 def stripBallerinaExtensionVersion(String extVersion) {
@@ -226,6 +227,11 @@ def groupParams = ""
 def disableGroups = ""
 def debugParams = ""
 def balJavaDebugParam = ""
+def testParams = ""
+def needSeparateTest = false
+def needBuildWithTest = false
+def needPublishToCentral = false
+def needPublishToLocalCentral = false
 
 task initializeVariables {
     if (project.hasProperty("groups")) {
@@ -240,88 +246,127 @@ task initializeVariables {
     if (project.hasProperty("balJavaDebug")) {
         balJavaDebugParam = "BAL_JAVA_DEBUG=${project.findProperty("balJavaDebug")}"
     }
+    if (project.hasProperty("publishToLocalCentral") && (project.findProperty("publishToLocalCentral") == "true")) {
+        needPublishToLocalCentral = true
+    }
+    if (project.hasProperty("publishToCentral") && (project.findProperty("publishToCentral") == "true")) {
+        needPublishToCentral = true
+    }
 
     gradle.taskGraph.whenReady { graph ->
-        if (graph.hasTask(":${packageName}-ballerina:publish")) {
-            ballerinaPublish.enabled = true
+        if (graph.hasTask(":${packageName}-ballerina:build") || graph.hasTask(":${packageName}-ballerina:publish")
+                || graph.hasTask(":${packageName}-ballerina:publishToMavenLocal")) {
+            needSeparateTest = false
+            needBuildWithTest = true
+            if (graph.hasTask(":${packageName}-ballerina:publish")) {
+                needPublishToCentral = true
+            }
         } else {
-            ballerinaPublish.enabled = false
+            needSeparateTest = true
+        }
+
+        if (graph.hasTask(":${packageName}-ballerina:test")) {
+            testParams = "${testCoverageParam}"
+        } else {
+            testParams = "--skip-tests"
         }
     }
 }
 
 task ballerinaBuild {
     inputs.dir file(project.projectDir)
-    dependsOn(initializeVariables)
-    finalizedBy(revertTomlFile)
     finalizedBy(':http-ballerina-tests:build')
 
     doLast {
-        exec {
-            workingDir project.projectDir
-            environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/bal.bat build -c --skip-tests " +
-                        "${debugParams} && exit %%ERRORLEVEL%%"
-            } else {
-                commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal build -c --skip-tests ${debugParams}"
+        if (needSeparateTest) {
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat test " +
+                            "${testCoverageParam} ${groupParams} ${disableGroups} ${debugParams} && exit %%ERRORLEVEL%%"
+                } else {
+                    commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal test -c " +
+                            "${testCoverageParam} ${groupParams} ${disableGroups} ${debugParams}"
+                }
             }
-        }
-        // extract bala file to artifact cache directory
-        file("$project.projectDir/target/bala").eachFileMatch(~/.*.bala/) { balaFile ->
+        } else if (needBuildWithTest) {
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat build -c " +
+                            "${testParams} ${debugParams} && exit %%ERRORLEVEL%%"
+                } else {
+                    commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal build -c ${testParams} " +
+                            "${debugParams}"
+                }
+            }
+
+            // extract bala file to artifact cache directory
+            file("$project.projectDir/target/bala").eachFileMatch(~/.*.bala/) { balaFile ->
+                copy {
+                    from zipTree(balaFile)
+                    into file("$artifactCacheParent/bala/${packageOrg}/${packageName}/${tomlVersion}/${platform}")
+                }
+            }
             copy {
-                from zipTree(balaFile)
-                into file("$artifactCacheParent/bala/${packageOrg}/${packageName}/${tomlVersion}/${platform}")
+                from file("$project.projectDir/target/cache")
+                exclude '**/*-testable.jar'
+                exclude '**/tests_cache/'
+                into file("$artifactCacheParent/cache/")
             }
-        }
-        copy {
-            from file("$project.projectDir/target/cache")
-            exclude '**/*-testable.jar'
-            exclude '**/tests_cache/'
-            into file("$artifactCacheParent/cache/")
-        }
-        // Doc creation and packing
-        exec {
-            workingDir project.projectDir
-            environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$distributionBinPath/bal.bat doc && exit %%ERRORLEVEL%%"
-            } else {
-                commandLine 'sh', '-c', "$distributionBinPath/bal doc"
+            // Doc creation and packing
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat doc && exit %%ERRORLEVEL%%"
+                } else {
+                    commandLine 'sh', '-c', "$distributionBinPath/bal doc"
+                }
             }
-        }
-        copy {
-            from file("$project.projectDir/target/apidocs/${packageName}")
-            into file("$project.projectDir/build/docs_parent/docs/${packageName}")
+            copy {
+                from file("$project.projectDir/target/apidocs/${packageName}")
+                into file("$project.projectDir/build/docs_parent/docs/${packageName}")
+            }
+            if (needPublishToCentral) {
+                if (project.version.endsWith('-SNAPSHOT') ||
+                        project.version.matches(project.ext.timestampedVersionRegex)) {
+                    return
+                }
+                if (ballerinaCentralAccessToken != null) {
+                    println("Publishing to the ballerina central...")
+                    exec {
+                        workingDir project.projectDir
+                        environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                            commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%%"
+                        } else {
+                            commandLine 'sh', '-c', "$distributionBinPath/bal push"
+                        }
+                    }
+                } else {
+                    throw new InvalidUserDataException("Central Access Token is not present")
+                }
+            } else if (needPublishToLocalCentral) {
+                println("Publishing to the ballerina local central repository..")
+                exec {
+                    workingDir project.projectDir
+                    environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                        commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%% --repository=local"
+                    } else {
+                        commandLine 'sh', '-c', "$distributionBinPath/bal push --repository=local"
+                    }
+                }
+            }
         }
     }
 
     outputs.dir artifactCacheParent
     outputs.dir artifactBallerinaDocs
     outputs.dir artifactLibParent
-}
-
-task ballerinaPublish {
-    doLast {
-        if (project.version.endsWith('-SNAPSHOT') ||
-                project.version.matches(project.ext.timestampedVersionRegex)) {
-            return
-        }
-        if (ballerinaCentralAccessToken != null) {
-            println("Publishing to the ballerina central...")
-            exec {
-                workingDir project.projectDir
-                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%%"
-                } else {
-                    commandLine 'sh', '-c', "$distributionBinPath/bal push"
-                }
-            }
-        } else {
-            throw new InvalidUserDataException("Central Access Token is not present")
-        }
-    }
 }
 
 task createArtifactZip(type: Zip) {
@@ -348,22 +393,18 @@ publishing {
     }
 }
 
-ballerinaBuild.dependsOn ":${packageName}-native:build"
-ballerinaBuild.dependsOn ":${packageName}-compiler-plugin:build"
 unpackJballerinaTools.dependsOn copyToLib
 unpackStdLibs.dependsOn unpackJballerinaTools
 copyStdlibs.dependsOn unpackStdLibs
 updateTomlVersions.dependsOn copyStdlibs
+
+ballerinaBuild.dependsOn ":${packageName}-native:build"
+ballerinaBuild.dependsOn ":${packageName}-compiler-plugin:build"
 ballerinaBuild.dependsOn updateTomlVersions
+ballerinaBuild.dependsOn initializeVariables
+ballerinaBuild.finalizedBy revertTomlFile
+test.dependsOn ballerinaBuild
 build.dependsOn ballerinaBuild
 
-ballerinaPublish.finalizedBy revertTomlFile
-ballerinaPublish.dependsOn initializeVariables
-ballerinaPublish.dependsOn updateTomlVersions
-ballerinaPublish.dependsOn ":${packageName}-native:build"
-ballerinaPublish.dependsOn ":${packageName}-native:test"
-ballerinaPublish.dependsOn ":${packageName}-compiler-plugin:build"
-ballerinaPublish.dependsOn ballerinaBuild
-publish.dependsOn ":${packageName}-ballerina-tests:build"
-publish.dependsOn ":${packageName}-ballerina-tests:test"
-publish.dependsOn ballerinaPublish
+publishToMavenLocal.dependsOn build
+publish.dependsOn build


### PR DESCRIPTION
## Purpose
Move ballerina build, test, and publish tasks under a single task to avoid running the update and revert toml file tasks multiple times.

Part of https://github.com/ballerina-platform/ballerina-standard-library/issues/1247

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
