### PR TITLE
Sanitize client resource path with slash

### DIFF
--- a/http-ballerina-tests/tests/http_url_double_slash.bal
+++ b/http-ballerina-tests/tests/http_url_double_slash.bal
@@ -59,3 +59,29 @@ function testUrlDoubleSlash() {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }
 }
+
+@test:Config {}
+function testResourcePathWithoutStartingSlash() returns error? {
+    http:Client httpUrlClient = check new("http://localhost:" + httpUrlTestPort1.toString() + "/");
+    var response = httpUrlClient->get("url");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+        assertTextPayload(response.getTextPayload(), "Hello");
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}
+
+@test:Config {}
+function testResourcePathWithEmptyPath() returns error? {
+    http:Client httpUrlClient = check new("http://localhost:" + httpUrlTestPort1.toString() + "/url/");
+    var response = httpUrlClient->get("");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+        assertTextPayload(response.getTextPayload(), "Hello");
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}

--- a/http-native/src/main/java/org/ballerinalang/net/http/client/actions/AbstractHTTPAction.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/client/actions/AbstractHTTPAction.java
@@ -70,6 +70,7 @@ import java.nio.charset.StandardCharsets;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.BALLERINA_VERSION;
 import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT_ENCODING;
 import static org.ballerinalang.net.http.HttpConstants.ANN_CONFIG_ATTR_COMPRESSION;
+import static org.ballerinalang.net.http.HttpConstants.SINGLE_SLASH;
 import static org.ballerinalang.net.http.HttpUtil.extractEntity;
 import static org.ballerinalang.net.http.HttpUtil.getCompressionState;
 import static org.ballerinalang.net.transport.contract.Constants.ENCODING_DEFLATE;
@@ -125,7 +126,7 @@ public abstract class AbstractHTTPAction {
                     getTrxInfoRecordJson(transactionLocalContext.getInfoRecord()));
         }
         try {
-            String uri = getServiceUri(serviceUri) + path;
+            String uri = getServiceUri(serviceUri) + sanitizeResourcePath(path);
             URL url = new URL(encodeWhitespacesInUri(uri));
 
             int port = getOutboundReqPort(url);
@@ -312,6 +313,13 @@ public abstract class AbstractHTTPAction {
         } else {
             outboundRequestMsg.addHttpContent(new DefaultLastHttpContent());
         }
+    }
+
+    private static String sanitizeResourcePath(String path) {
+        if (!path.isEmpty() && !path.startsWith(SINGLE_SLASH)) {
+            path = SINGLE_SLASH.concat(path);
+        }
+        return path;
     }
 
     static boolean isNoEntityBodyRequest(BObject request) {


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1354

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests