### PR TITLE
Log error when the return from the resource leads to an error

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=org.ballerinalang
-version=1.1.0-alpha8
+version=1.1.0-alpha9
 ballerinaLangVersion=2.0.0-alpha8-20210423-135000-530658ec
 ballerinaTomlParserVersion=1.2.2
 commonsLang3Version=3.8.1

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpCallableUnitCallback.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpCallableUnitCallback.java
@@ -64,6 +64,9 @@ public class HttpCallableUnitCallback implements Callback {
         Callback returnCallback = new Callback() {
             @Override
             public void notifySuccess(Object result) {
+                if (result instanceof BError) {
+                    ((BError) result).printStackTrace();
+                }
                 requestMessage.waitAndReleaseAllEntities();
             }
 


### PR DESCRIPTION
## Purpose
Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/1412

## Examples
```
error: Connection between remote client and host is closed
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests