### PR TITLE
Fix dispatching logic to handle repeated and same positioned path templates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ This file contains all the notable changes done to the Ballerina HTTP package th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+###Fixed
+- [Fix the limitation of not supporting different API resources with same end URL Template](https://github.com/ballerina-platform/ballerina-standard-library/issues/1095)
+- [Fix dispatching failure when same path param identifiers exist in a different order](https://github.com/ballerina-platform/ballerina-standard-library/issues/342)
+
 ## [1.1.0-beta.1] - 2021-05-06
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-###Fixed
+### Fixed
 - [Fix the limitation of not supporting different API resources with same end URL Template](https://github.com/ballerina-platform/ballerina-standard-library/issues/1095)
 - [Fix dispatching failure when same path param identifiers exist in a different order](https://github.com/ballerina-platform/ballerina-standard-library/issues/342)
 

--- a/http-ballerina-tests/tests/service_dispatching_uri_template_twisted.bal
+++ b/http-ballerina-tests/tests/service_dispatching_uri_template_twisted.bal
@@ -1,0 +1,118 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+import ballerina/http;
+
+listener http:Listener pathParamCheckListener = new(pathParamCheckTestPort);
+http:Client pathParamTestClient = check new("http://localhost:" + pathParamCheckTestPort.toString());
+
+service / on pathParamCheckListener {
+    
+    // Case 1: `id` is present in both resource and positioned in a simpleString expression
+    resource function get path/[string id]() returns string {
+        return "a-" + id;
+    }
+
+    resource function get path/[string note]/aa/[string id]() returns string {
+        return "b-" + note + " " + id;
+    }
+
+    // Case 2: `aaa` and `bbb` are present in both resource and in twisted positions
+    resource function get [string aaa]/go/[string bbb]() returns string {
+        return "c-" + aaa + " " + bbb;
+    }
+
+    resource function get [string bbb]/go/[string aaa]/[string ccc]() returns string {
+        return "d-" + aaa + " " + bbb + " " + ccc;
+    }
+
+    // Case 3: rest param present along with path param
+    resource function get bar/[string bbb]/go/[string... a]() returns string {
+        return "e-" + a[0] + " " + bbb;
+    }
+
+    // Case 4: rest param has same var as 2nd resource
+    resource function get path/[string id]/aa/[string... note]() returns string {
+        return "f-" + note[1] + " " + id;
+    }
+}
+
+@test:Config {}
+function testSamePositionNodeWithSamePathTemplates() {
+    http:Response|error response = pathParamTestClient->get("/path/hello");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertTextPayload(response.getTextPayload(), "a-hello");
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}
+
+@test:Config {}
+function testSamePositionNodeWithSamePathTemplatesError() {
+    http:Response|error response = pathParamTestClient->get("/path/hello/aa/gone");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertTextPayload(response.getTextPayload(), "b-hello gone");
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}
+
+@test:Config {}
+function testSameTwistedPathTemplate() {
+    http:Response|error response = pathParamTestClient->get("/aa/go/bb");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertTextPayload(response.getTextPayload(), "c-aa bb");
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}
+
+@test:Config {}
+function testSameTwistedPathTemplateError() {
+    http:Response|error response = pathParamTestClient->get("/foo/go/bar/cc");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertTextPayload(response.getTextPayload(), "d-bar foo cc");
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}
+
+@test:Config {}
+function testRestPathParamMatch() {
+    http:Response|error response = pathParamTestClient->get("/bar/bb/go/baz");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertTextPayload(response.getTextPayload(), "e-baz bb");
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}
+
+@test:Config {}
+function testRestPathParamTwistedMatch() {
+    http:Response|error response = pathParamTestClient->get("/path/bb/aa/baz/foo");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertTextPayload(response.getTextPayload(), "f-foo bb");
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}

--- a/http-ballerina-tests/tests/test_service_ports.bal
+++ b/http-ballerina-tests/tests/test_service_ports.bal
@@ -110,6 +110,7 @@ const int responseLimitsTestPort5 = 9561;
 const int headerParamBindingTest = 9562;
 const int outRequestTypeTest = 9563;
 const int outRequestOptionsTest = 9564;
+const int pathParamCheckTestPort = 9565;
 
 //HTTP2
 const int serverPushTestPort1 = 9601;

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -40,6 +40,7 @@ public class HttpConstants {
     public static final String BASE_PATH = "BASE_PATH";
     public static final String SUB_PATH = "SUB_PATH";
     public static final String EXTRA_PATH_INFO = "EXTRA_PATH_INFO";
+    public static final Integer EXTRA_PATH_INDEX = 0;
     public static final String RAW_URI = "RAW_URI";
     public static final String RESOURCE_ARGS = "RESOURCE_ARGS";
     public static final String MATRIX_PARAMS = "MATRIX_PARAMS";

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpResourceArguments.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpResourceArguments.java
@@ -28,13 +28,13 @@ import java.util.Map;
  */
 public class HttpResourceArguments {
 
-    private Map<String, String> resourceArgumentValues = new HashMap<>();
+    private Map<String, Map<Integer, String>> resourceArgumentValues = new HashMap<>();
 
     public HttpResourceArguments() {
         resourceArgumentValues = new HashMap<>();
     }
 
-    public Map<String, String> getMap() {
+    public Map<String, Map<Integer, String>> getMap() {
         return resourceArgumentValues;
     }
 }

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpResourceArguments.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpResourceArguments.java
@@ -22,7 +22,21 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * This class holds the resource signature path parameters.
+ * This class holds the resource signature path parameters. Each path template has an associated map which keeps
+ * URI segment value against the expression position index(initialized during the load time).
+ * Eg :
+ * resource function get [string aaa]/go/[string bbb]() {}
+ * resource function get [string bbb]/go/[string aaa]/[string ccc]() {}
+ *
+ * URL - bal/go/java/c
+ * aaa:
+ *   0: bal
+ *   1: java
+ * bbb:
+ *   0: bal
+ *   1: java
+ * ccc:
+ *   2: c
  *
  * @since 0.995.0
  */

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -728,9 +728,8 @@ public class HttpUtil {
         HttpResourceArguments resourceArgValues = (HttpResourceArguments) inboundRequestMsg.getProperty(
                 HttpConstants.RESOURCE_ARGS);
         if (resourceArgValues != null && resourceArgValues.getMap().get(HttpConstants.EXTRA_PATH_INFO) != null) {
-            inboundRequestObj.set(
-                    HttpConstants.REQUEST_EXTRA_PATH_INFO_FIELD, fromString(
-                            resourceArgValues.getMap().get(HttpConstants.EXTRA_PATH_INFO)));
+            Map<Integer, String> extraPath = resourceArgValues.getMap().get(HttpConstants.EXTRA_PATH_INFO);
+            inboundRequestObj.set(HttpConstants.REQUEST_EXTRA_PATH_INFO_FIELD, fromString(extraPath.get(0)));
         }
     }
 

--- a/http-native/src/main/java/org/ballerinalang/net/uri/parser/Expression.java
+++ b/http-native/src/main/java/org/ballerinalang/net/uri/parser/Expression.java
@@ -36,9 +36,12 @@ import java.util.List;
 public abstract class Expression<DataType, InboundMsgType> extends Node<DataType, InboundMsgType> {
 
     protected List<Variable> variableList = new ArrayList<Variable>(4);
+    private int expressionIndex = -1;
 
-    public Expression(DataElement<DataType, InboundMsgType> dataElement, String token) throws URITemplateException {
+    public Expression(DataElement<DataType, InboundMsgType> dataElement, String token, int index)
+            throws URITemplateException {
         super(dataElement, token);
+        this.expressionIndex = index;
         int startIndex = 0;
         for (int i = 0; i < token.length(); i++) {
             if (token.charAt(i) == ',') {
@@ -86,5 +89,9 @@ public abstract class Expression<DataType, InboundMsgType> extends Node<DataType
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("Error while encoding value: " + value, e);
         }
+    }
+
+    public int getExpressionIndex() {
+        return expressionIndex;
     }
 }

--- a/http-native/src/main/java/org/ballerinalang/net/uri/parser/Node.java
+++ b/http-native/src/main/java/org/ballerinalang/net/uri/parser/Node.java
@@ -22,10 +22,12 @@ import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpResourceArguments;
 import org.ballerinalang.net.uri.URITemplateException;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import static org.ballerinalang.net.http.HttpConstants.EXTRA_PATH_INDEX;
 import static org.ballerinalang.net.uri.URIUtil.URI_PATH_DELIMITER;
 
 /**
@@ -128,7 +130,9 @@ public abstract class Node<DataType, InboundMsgType> {
     }
 
     private void setUriPostFix(HttpResourceArguments variables, String subUriFragment) {
-        variables.getMap().putIfAbsent(HttpConstants.EXTRA_PATH_INFO, URI_PATH_DELIMITER + subUriFragment);
+        Map<Integer, String> indexValueMap =
+                Collections.singletonMap(EXTRA_PATH_INDEX, URI_PATH_DELIMITER + subUriFragment);
+        variables.getMap().putIfAbsent(HttpConstants.EXTRA_PATH_INFO, indexValueMap);
     }
 
     abstract String expand(Map<String, String> variables);

--- a/http-native/src/main/java/org/ballerinalang/net/uri/parser/SimpleStringExpression.java
+++ b/http-native/src/main/java/org/ballerinalang/net/uri/parser/SimpleStringExpression.java
@@ -21,6 +21,7 @@ package org.ballerinalang.net.uri.parser;
 import org.ballerinalang.net.http.HttpResourceArguments;
 import org.ballerinalang.net.uri.URITemplateException;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -36,9 +37,9 @@ public class SimpleStringExpression<DataType, InboundMsgType> extends Expression
             ':', '/', '?', '#', '[', ']', '@', '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '='
     };
 
-    SimpleStringExpression(DataElement<DataType, InboundMsgType> dataElement, String token)
+    SimpleStringExpression(DataElement<DataType, InboundMsgType> dataElement, String token, int index)
             throws URITemplateException {
-        super(dataElement, token);
+        super(dataElement, token, index);
     }
 
     @Override
@@ -107,11 +108,15 @@ public class SimpleStringExpression<DataType, InboundMsgType> extends Expression
         String finalValue = decodeValue(expressionValue);
         for (Variable var : variableList) {
             String name = var.getName();
-            if (variables.getMap().containsKey(name) && !finalValue.equals(variables.getMap().get(name))) {
-                return false;
+            Map<Integer, String> indexValueMap;
+            if (variables.getMap().containsKey(name)) {
+                indexValueMap = variables.getMap().get(name);
+            } else {
+                indexValueMap = new HashMap<>();
+                variables.getMap().put(name, indexValueMap);
             }
             if (var.checkModifier(finalValue)) {
-                variables.getMap().put(name, finalValue);
+                indexValueMap.put(getExpressionIndex(), finalValue);
             } else {
                 return false;
             }

--- a/http-native/src/main/java/org/ballerinalang/net/uri/parser/URITemplateParser.java
+++ b/http-native/src/main/java/org/ballerinalang/net/uri/parser/URITemplateParser.java
@@ -52,6 +52,7 @@ public class URITemplateParser<DataType, InboundMgsType> {
             this.syntaxTree.getDataElement().setData(resource);
             return syntaxTree;
         }
+        int expressionIndex = 0;
         String[] segments = template.split("/");
         for (int currentElement = 0; currentElement < segments.length; currentElement++) {
             String segment = segments[currentElement];
@@ -89,7 +90,7 @@ public class URITemplateParser<DataType, InboundMgsType> {
                         }
                         expression = false;
                         String token = segment.substring(startIndex, pointerIndex);
-                        createExpressionNode(token, segment, maxIndex, pointerIndex);
+                        createExpressionNode(token, segment, maxIndex, pointerIndex, expressionIndex++);
                         startIndex = pointerIndex + 1;
                         break;
                     case '*':
@@ -102,7 +103,7 @@ public class URITemplateParser<DataType, InboundMgsType> {
                         if (pointerIndex == maxIndex) {
                             String tokenVal = segment.substring(startIndex);
                             if (expression) {
-                                createExpressionNode(tokenVal, segment, maxIndex, pointerIndex);
+                                createExpressionNode(tokenVal, segment, maxIndex, pointerIndex, expressionIndex++);
                             } else {
                                 addNode(new Literal<>(createElement(), tokenVal));
                             }
@@ -122,11 +123,11 @@ public class URITemplateParser<DataType, InboundMgsType> {
         currentNode = currentNode.addChild(node);
     }
 
-    private void createExpressionNode(String expression, String segment, int maxIndex, int pointerIndex)
-            throws URITemplateException {
+    private void createExpressionNode(String expression, String segment, int maxIndex, int pointerIndex,
+                                      int expressionIndex) throws URITemplateException {
         Node<DataType, InboundMgsType> node;
         if (maxIndex == pointerIndex) {
-            node = new SimpleStringExpression<>(createElement(), expression);
+            node = new SimpleStringExpression<>(createElement(), expression, expressionIndex);
         } else {
             throw new URITemplateException("Template expression: " + segment + " is not implemented");
         }


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1095
> Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/342

## Examples
```ballerina
    // Case 1: `id` is present in 1 & 2 resources and positioned as a simpleString expression
    resource function get path/[string id]() returns string {
        return "a-" + id;
    }

    resource function get path/[string note]/aa/[string id]() returns string {
        return "b-" + note + " " + id;
    }

    // Case 2: `aaa` and `bbb` are present in both resource and in twisted positions
    resource function get [string aaa]/go/[string bbb]() returns string {
        return "c-" + aaa + " " + bbb;
    }

    resource function get [string bbb]/go/[string aaa]/[string ccc]() returns string {
        return "d-" + aaa + " " + bbb + " " + ccc;
    }

    // Case 3: rest param present along with path param
    resource function get bar/[string bbb]/go/[string... a]() returns string {
        return "e-" + a[0] + " " + bbb;
    }

    // Case 4: rest param has same var as 2nd resource
    resource function get path/[string id]/aa/[string... note]() returns string {
        return "f-" + note[1] + " " + id;
    }
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests