### PR TITLE
Add vscode tooling support via code actions in compiler plugin

### DIFF
--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -22,7 +22,6 @@ import io.ballerina.projects.CodeActionManager;
 import io.ballerina.projects.DiagnosticResult;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.DocumentId;
-import io.ballerina.projects.Package;
 import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.directory.BuildProject;
@@ -36,13 +35,10 @@ import io.ballerina.tools.text.LinePosition;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This class includes tests for Ballerina Http compiler plugin.

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpCompilerPlugin.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpCompilerPlugin.java
@@ -20,13 +20,30 @@ package io.ballerina.stdlib.http.compiler;
 
 import io.ballerina.projects.plugins.CompilerPlugin;
 import io.ballerina.projects.plugins.CompilerPluginContext;
+import io.ballerina.projects.plugins.codeaction.CodeAction;
+import io.ballerina.stdlib.http.compiler.codeaction.AddResourceConfigAnnotation;
+import io.ballerina.stdlib.http.compiler.codeaction.ChangeHeaderParamTypeToString;
+import io.ballerina.stdlib.http.compiler.codeaction.ChangeHeaderParamTypeToStringArray;
+
+import java.util.List;
 
 /**
  * The compiler plugin implementation for Ballerina Http package.
  */
 public class HttpCompilerPlugin extends CompilerPlugin {
+
     @Override
-    public void init(CompilerPluginContext compilerPluginContext) {
-        compilerPluginContext.addCodeAnalyzer(new HttpServiceAnalyzer());
+    public void init(CompilerPluginContext context) {
+        context.addCodeAnalyzer(new HttpServiceAnalyzer());
+
+        getCodeActions().forEach(context::addCodeAction);
+    }
+
+    private List<CodeAction> getCodeActions() {
+        return List.of(
+                new ChangeHeaderParamTypeToString(),
+                new ChangeHeaderParamTypeToStringArray(),
+                new AddResourceConfigAnnotation()
+        );
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
@@ -23,6 +23,7 @@ import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import static io.ballerina.stdlib.http.compiler.Constants.ALLOWED_RETURN_UNION;
 import static io.ballerina.stdlib.http.compiler.Constants.RESOURCE_CONFIG_ANNOTATION;
 import static io.ballerina.tools.diagnostics.DiagnosticSeverity.ERROR;
+import static io.ballerina.tools.diagnostics.DiagnosticSeverity.INTERNAL;
 
 /**
  * {@code DiagnosticCodes} is used to hold diagnostic codes.
@@ -56,6 +57,8 @@ public enum HttpDiagnosticCodes {
     HTTP_118("HTTP_118", "invalid resource method return type: can not use 'http:Caller' " +
             "and return '%s' from a resource : expected 'error' or nil",
             ERROR);
+
+    HTTP_HINT_101("HTTP_HINT_101", "No resource annotation present", INTERNAL);
 
     private final String code;
     private final String message;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
@@ -48,7 +48,11 @@ import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.tools.diagnostics.DiagnosticFactory;
 import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.DiagnosticProperty;
+import org.wso2.ballerinalang.compiler.diagnostic.properties.BSymbolicProperty;
+import org.wso2.ballerinalang.compiler.diagnostic.properties.NonCatProperty;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -82,9 +86,14 @@ class HttpResourceValidator {
                                                              FunctionDefinitionNode member) {
         Optional<MetadataNode> metadataNodeOptional = member.metadata();
         if (metadataNodeOptional.isEmpty()) {
+            reportNoResourceAnnotationHint(ctx, member);
             return;
         } else {
             NodeList<AnnotationNode> annotations = metadataNodeOptional.get().annotations();
+            if (annotations.isEmpty()) {
+                reportNoResourceAnnotationHint(ctx, member);
+            }
+            
             for (AnnotationNode annotation : annotations) {
                 Node annotReference = annotation.annotReference();
                 String annotName = annotReference.toString();
@@ -365,14 +374,14 @@ class HttpResourceValidator {
                                     TypeSymbol arrTypeSymbol = ((ArrayTypeSymbol) type).memberTypeDescriptor();
                                     TypeDescKind arrElementKind = arrTypeSymbol.typeKind();
                                     if (arrElementKind != TypeDescKind.STRING) {
-                                        reportInvalidHeaderParameterType(ctx, member, paramName);
+                                        reportInvalidHeaderParameterType(ctx, member, paramName, param);
                                     }
                                 } else if (elementKind != TypeDescKind.NIL && elementKind != TypeDescKind.STRING) {
-                                    reportInvalidHeaderParameterType(ctx, member, paramName);
+                                    reportInvalidHeaderParameterType(ctx, member, paramName, param);
                                 }
                             }
                         } else {
-                            reportInvalidHeaderParameterType(ctx, member, paramName);
+                            reportInvalidHeaderParameterType(ctx, member, paramName, param);
                         }
                         break;
                     }
@@ -596,6 +605,11 @@ class HttpResourceValidator {
         updateDiagnostic(ctx, node, returnType, HttpDiagnosticCodes.HTTP_102);
     }
 
+    private static void reportNoResourceAnnotationHint(SyntaxNodeAnalysisContext ctx, FunctionDefinitionNode node) {
+        updateDiagnostic(ctx, node, null, HttpDiagnosticCodes.HTTP_HINT_101,
+                List.of(new NonCatProperty(node)));
+    }
+
     private static void reportInvalidResourceAnnotation(SyntaxNodeAnalysisContext ctx, FunctionDefinitionNode node,
                                                         String annotName) {
         updateDiagnostic(ctx, node, annotName, HttpDiagnosticCodes.HTTP_103);
@@ -627,8 +641,9 @@ class HttpResourceValidator {
     }
 
     private static void reportInvalidHeaderParameterType(SyntaxNodeAnalysisContext ctx, FunctionDefinitionNode node,
-                                                         String paramName) {
-        updateDiagnostic(ctx, node, paramName, HttpDiagnosticCodes.HTTP_109);
+                                                         String paramName, ParameterSymbol parameterSymbol) {
+        updateDiagnostic(ctx, node, paramName, HttpDiagnosticCodes.HTTP_109,
+                List.of(new BSymbolicProperty(parameterSymbol)));
     }
 
     private static void reportInvalidUnionHeaderType(SyntaxNodeAnalysisContext ctx, FunctionDefinitionNode node,
@@ -658,8 +673,19 @@ class HttpResourceValidator {
 
     private static void updateDiagnostic(SyntaxNodeAnalysisContext ctx, Node node, String argName,
                                          HttpDiagnosticCodes httpDiagnosticCodes) {
-        DiagnosticInfo diagnosticInfo = getDiagnosticInfo(httpDiagnosticCodes, argName);
-        ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(diagnosticInfo, node.location()));
+        updateDiagnostic(ctx, node, argName, httpDiagnosticCodes, Collections.emptyList());
+    }
+
+    private static void updateDiagnostic(SyntaxNodeAnalysisContext ctx, Node node, String argName,
+                                         HttpDiagnosticCodes httpDiagnosticCodes,
+                                         List<DiagnosticProperty<?>> diagnosticProperties) {
+        DiagnosticInfo diagnosticInfo;
+        if (argName == null) {
+            diagnosticInfo = getDiagnosticInfo(httpDiagnosticCodes);
+        } else {
+            diagnosticInfo = getDiagnosticInfo(httpDiagnosticCodes, argName);
+        }
+        ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(diagnosticInfo, node.location(), diagnosticProperties));
     }
 
     private static DiagnosticInfo getDiagnosticInfo(HttpDiagnosticCodes diagnostic, Object... args) {

--- a/http-compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/AddResourceConfigAnnotation.java
+++ b/http-compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/AddResourceConfigAnnotation.java
@@ -1,0 +1,97 @@
+package io.ballerina.stdlib.http.compiler.codeaction;
+
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.plugins.codeaction.CodeAction;
+import io.ballerina.projects.plugins.codeaction.CodeActionArgument;
+import io.ballerina.projects.plugins.codeaction.CodeActionContext;
+import io.ballerina.projects.plugins.codeaction.CodeActionExecutionContext;
+import io.ballerina.projects.plugins.codeaction.CodeActionInfo;
+import io.ballerina.projects.plugins.codeaction.DocumentEdit;
+import io.ballerina.stdlib.http.compiler.HttpDiagnosticCodes;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticProperty;
+import io.ballerina.tools.text.LineRange;
+import io.ballerina.tools.text.TextDocumentChange;
+import io.ballerina.tools.text.TextEdit;
+import io.ballerina.tools.text.TextRange;
+import org.wso2.ballerinalang.compiler.diagnostic.properties.NonCatProperty;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Code action to add resource config to a resource method.
+ */
+public class AddResourceConfigAnnotation implements CodeAction {
+
+    @Override
+    public List<String> supportedDiagnosticCodes() {
+        return List.of(HttpDiagnosticCodes.HTTP_HINT_101.getCode());
+    }
+
+    @Override
+    public Optional<CodeActionInfo> codeActionInfo(CodeActionContext context) {
+        Diagnostic diagnostic = context.diagnostic();
+        List<DiagnosticProperty<?>> properties = diagnostic.properties();
+        if (properties.isEmpty()) {
+            return Optional.empty();
+        }
+
+        DiagnosticProperty<?> diagnosticProperty = properties.get(0);
+        if (!(diagnosticProperty instanceof NonCatProperty) ||
+                !(diagnosticProperty.value() instanceof FunctionDefinitionNode)) {
+            return Optional.empty();
+        }
+
+        FunctionDefinitionNode functionDefinitionNode = (FunctionDefinitionNode) diagnosticProperty.value();
+
+        CodeActionArgument locationArg = CodeActionArgument.from(CodeActionUtil.NODE_LOCATION_KEY,
+                functionDefinitionNode.location().lineRange());
+        return Optional.of(CodeActionInfo.from("Add `http:ResourceConfig` annotation", List.of(locationArg)));
+    }
+
+    @Override
+    public List<DocumentEdit> execute(CodeActionExecutionContext context) {
+        LineRange lineRange = null;
+        for (CodeActionArgument argument : context.arguments()) {
+            if (CodeActionUtil.NODE_LOCATION_KEY.equals(argument.key())) {
+                lineRange = argument.valueAs(LineRange.class);
+            }
+        }
+
+        if (lineRange == null) {
+            return Collections.emptyList();
+        }
+
+        SyntaxTree syntaxTree = context.currentDocument().syntaxTree();
+        NonTerminalNode node = CodeActionUtil.findNode(syntaxTree, lineRange);
+        if (!(node instanceof FunctionDefinitionNode)) {
+            return Collections.emptyList();
+        }
+
+        FunctionDefinitionNode functionDefinitionNode = (FunctionDefinitionNode) node;
+        if (functionDefinitionNode.metadata().isPresent() &&
+                !functionDefinitionNode.metadata().get().annotations().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<TextEdit> textEdits = new ArrayList<>();
+
+        String insertText = "@http:ResourceConfig {}" +
+                System.lineSeparator() +
+                " ".repeat(Math.max(0, functionDefinitionNode.lineRange().startLine().offset()));
+        TextRange textRange = TextRange.from(functionDefinitionNode.textRange().startOffset(), 0);
+        textEdits.add(TextEdit.from(textRange, insertText));
+        TextDocumentChange change = TextDocumentChange.from(textEdits.toArray(new TextEdit[0]));
+        return Collections.singletonList(new DocumentEdit(context.fileUri(), SyntaxTree.from(syntaxTree, change)));
+    }
+
+    @Override
+    public String name() {
+        return "ADD_RESOURCE_CONFIG_ANNOTATION";
+    }
+}

--- a/http-compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/ChangeHeaderParamType.java
+++ b/http-compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/ChangeHeaderParamType.java
@@ -1,0 +1,105 @@
+package io.ballerina.stdlib.http.compiler.codeaction;
+
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
+import io.ballerina.compiler.syntax.tree.IncludedRecordParameterNode;
+import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
+import io.ballerina.compiler.syntax.tree.RestParameterNode;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.plugins.codeaction.CodeAction;
+import io.ballerina.projects.plugins.codeaction.CodeActionArgument;
+import io.ballerina.projects.plugins.codeaction.CodeActionContext;
+import io.ballerina.projects.plugins.codeaction.CodeActionExecutionContext;
+import io.ballerina.projects.plugins.codeaction.CodeActionInfo;
+import io.ballerina.projects.plugins.codeaction.DocumentEdit;
+import io.ballerina.stdlib.http.compiler.HttpDiagnosticCodes;
+import io.ballerina.tools.diagnostics.DiagnosticProperty;
+import io.ballerina.tools.text.LineRange;
+import io.ballerina.tools.text.TextDocumentChange;
+import io.ballerina.tools.text.TextEdit;
+import io.ballerina.tools.text.TextRange;
+import org.wso2.ballerinalang.compiler.diagnostic.properties.BSymbolicProperty;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Abstract implementation of code action to change a resource header param's type.
+ */
+public abstract class ChangeHeaderParamType implements CodeAction {
+
+    @Override
+    public List<String> supportedDiagnosticCodes() {
+        return List.of(HttpDiagnosticCodes.HTTP_109.getCode());
+    }
+
+    @Override
+    public Optional<CodeActionInfo> codeActionInfo(CodeActionContext context) {
+        SyntaxTree syntaxTree = context.currentDocument().syntaxTree();
+        List<DiagnosticProperty<?>> properties = context.diagnostic().properties();
+        if (properties.isEmpty()) {
+            return Optional.empty();
+        }
+
+        DiagnosticProperty<?> diagnosticProperty = properties.get(0);
+        if (!(diagnosticProperty instanceof BSymbolicProperty) || !(diagnosticProperty.value() instanceof ParameterSymbol)) {
+            return Optional.empty();
+        }
+
+        ParameterSymbol parameterSymbol = (ParameterSymbol) diagnosticProperty.value();
+        Optional<NonTerminalNode> nonTerminalNode = parameterSymbol.getLocation()
+                .flatMap(location -> Optional.ofNullable(CodeActionUtil.findNode(syntaxTree, parameterSymbol)));
+        if (nonTerminalNode.isEmpty()) {
+            return Optional.empty();
+        }
+
+        CodeActionArgument locationArg = CodeActionArgument.from(CodeActionUtil.NODE_LOCATION_KEY, nonTerminalNode.get().location().lineRange());
+        return Optional.of(CodeActionInfo.from(String.format("Change header param to '%s'", headerParamType()),
+                List.of(locationArg)));
+    }
+
+    @Override
+    public List<DocumentEdit> execute(CodeActionExecutionContext context) {
+        LineRange lineRange = null;
+        for (CodeActionArgument argument : context.arguments()) {
+            if (CodeActionUtil.NODE_LOCATION_KEY.equals(argument.key())) {
+                lineRange = argument.valueAs(LineRange.class);
+            }
+        }
+
+        if (lineRange == null) {
+            return Collections.emptyList();
+        }
+
+        SyntaxTree syntaxTree = context.currentDocument().syntaxTree();
+        NonTerminalNode node = CodeActionUtil.findNode(syntaxTree, lineRange);
+
+        TextRange typeNodeTextRange = null;
+        switch (node.kind()) {
+            case REQUIRED_PARAM:
+                typeNodeTextRange = ((RequiredParameterNode) node).typeName().textRange();
+                break;
+            case REST_PARAM:
+                typeNodeTextRange = ((RestParameterNode) node).typeName().textRange();
+                break;
+            case INCLUDED_RECORD_PARAM:
+                typeNodeTextRange = ((IncludedRecordParameterNode) node).typeName().textRange();
+                break;
+            default:
+                return Collections.emptyList();
+        }
+
+        List<TextEdit> textEdits = new ArrayList<>();
+        textEdits.add(TextEdit.from(typeNodeTextRange, headerParamType()));
+        TextDocumentChange change = TextDocumentChange.from(textEdits.toArray(new TextEdit[0]));
+        return Collections.singletonList(new DocumentEdit(context.fileUri(), SyntaxTree.from(syntaxTree, change)));
+    }
+
+    private void checkInvalidHeaderParameterNode(NonTerminalNode node) {
+
+    }
+
+    protected abstract String headerParamType();
+}

--- a/http-compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/ChangeHeaderParamTypeToString.java
+++ b/http-compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/ChangeHeaderParamTypeToString.java
@@ -1,0 +1,17 @@
+package io.ballerina.stdlib.http.compiler.codeaction;
+
+/**
+ * Change header paramer type to string code action.
+ */
+public class ChangeHeaderParamTypeToString extends ChangeHeaderParamType{
+
+    @Override
+    protected String headerParamType() {
+        return "string";
+    }
+
+    @Override
+    public String name() {
+        return "CHANGE_HEADER_PARAM_STRING";
+    }
+}

--- a/http-compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/ChangeHeaderParamTypeToStringArray.java
+++ b/http-compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/ChangeHeaderParamTypeToStringArray.java
@@ -1,0 +1,17 @@
+package io.ballerina.stdlib.http.compiler.codeaction;
+
+/**
+ * Code action to change header parameter's type to string[].
+ */
+public class ChangeHeaderParamTypeToStringArray extends ChangeHeaderParamType {
+
+    @Override
+    protected String headerParamType() {
+        return "string[]";
+    }
+
+    @Override
+    public String name() {
+        return "CHANGE_HEADER_PARAM_STRING_ARRAY";
+    }
+}

--- a/http-compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/CodeActionUtil.java
+++ b/http-compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/CodeActionUtil.java
@@ -1,0 +1,44 @@
+package io.ballerina.stdlib.http.compiler.codeaction;
+
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.syntax.tree.ModulePartNode;
+import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.tools.text.LineRange;
+import io.ballerina.tools.text.TextDocument;
+import io.ballerina.tools.text.TextRange;
+
+/**
+ * Utilities for code actions.
+ */
+public class CodeActionUtil {
+
+    public static final String NODE_LOCATION_KEY = "node.location";
+
+    private CodeActionUtil() {
+    }
+
+    public static NonTerminalNode findNode(SyntaxTree syntaxTree, Symbol symbol) {
+        if (symbol.getLocation().isEmpty()) {
+            return null;
+        }
+
+        TextDocument textDocument = syntaxTree.textDocument();
+        LineRange symbolRange = symbol.getLocation().get().lineRange();
+        int start = textDocument.textPositionFrom(symbolRange.startLine());
+        int end = textDocument.textPositionFrom(symbolRange.endLine());
+        return ((ModulePartNode) syntaxTree.rootNode()).findNode(TextRange.from(start, end - start), true);
+    }
+
+    public static NonTerminalNode findNode(SyntaxTree syntaxTree, LineRange lineRange) {
+        if (lineRange == null) {
+            return null;
+        }
+
+        TextDocument textDocument = syntaxTree.textDocument();
+        int start = textDocument.textPositionFrom(lineRange.startLine());
+        int end = textDocument.textPositionFrom(lineRange.endLine());
+        return ((ModulePartNode) syntaxTree.rootNode()).findNode(TextRange.from(start, end - start), true);
+    }
+
+}


### PR DESCRIPTION
## Purpose
$subject
As the initial step, added code actions to:
1. Change header parameter type to `string` or `string[]`
2. Add `@http:ResourceConfig` annotation to resource methods

This can only be merged once https://github.com/ballerina-platform/ballerina-lang/pull/30638 is merged.

## Examples
See the demo below:

https://user-images.githubusercontent.com/11285165/122214367-a4956500-cec7-11eb-899a-a678feabb834.mp4

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests