### PR TITLE
Implement WebSocket handshake timeout

### DIFF
--- a/http-native/src/main/java/org/ballerinalang/net/transport/contractimpl/sender/websocket/WebSocketClientHandshakeHandler.java
+++ b/http-native/src/main/java/org/ballerinalang/net/transport/contractimpl/sender/websocket/WebSocketClientHandshakeHandler.java
@@ -80,7 +80,7 @@ public class WebSocketClientHandshakeHandler extends ChannelInboundHandlerAdapte
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
         if (evt instanceof IdleStateEvent) {
-            handshakeFuture.notifyError(new WebSocketConnectorException("Handshake timedout"), null);
+            handshakeFuture.notifyError(new WebSocketConnectorException("Handshake timed out"), null);
         }
     }
 

--- a/http-native/src/main/java/org/ballerinalang/net/transport/contractimpl/sender/websocket/WebSocketClientHandshakeHandler.java
+++ b/http-native/src/main/java/org/ballerinalang/net/transport/contractimpl/sender/websocket/WebSocketClientHandshakeHandler.java
@@ -29,6 +29,7 @@ import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketFrameDecoder;
 import io.netty.handler.timeout.IdleStateEvent;
 import org.ballerinalang.net.transport.contract.Constants;
+import org.ballerinalang.net.transport.contract.websocket.WebSocketConnectorException;
 import org.ballerinalang.net.transport.contract.websocket.WebSocketConnectorFuture;
 import org.ballerinalang.net.transport.contractimpl.listener.WebSocketMessageQueueHandler;
 import org.ballerinalang.net.transport.contractimpl.websocket.DefaultClientHandshakeFuture;
@@ -79,7 +80,7 @@ public class WebSocketClientHandshakeHandler extends ChannelInboundHandlerAdapte
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
         if (evt instanceof IdleStateEvent) {
-            handshakeFuture.notifyError(new Throwable("Idle timeout triggered"), null);
+            handshakeFuture.notifyError(new WebSocketConnectorException("Handshake timedout"), null);
         }
     }
 

--- a/http-native/src/main/java/org/ballerinalang/net/transport/contractimpl/sender/websocket/WebSocketClientHandshakeHandler.java
+++ b/http-native/src/main/java/org/ballerinalang/net/transport/contractimpl/sender/websocket/WebSocketClientHandshakeHandler.java
@@ -27,6 +27,7 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.websocketx.WebSocket13FrameDecoder;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketFrameDecoder;
+import io.netty.handler.timeout.IdleStateEvent;
 import org.ballerinalang.net.transport.contract.Constants;
 import org.ballerinalang.net.transport.contract.websocket.WebSocketConnectorFuture;
 import org.ballerinalang.net.transport.contractimpl.listener.WebSocketMessageQueueHandler;
@@ -70,9 +71,17 @@ public class WebSocketClientHandshakeHandler extends ChannelInboundHandlerAdapte
         return httpCarbonResponse;
     }
 
+
     @Override
     public void channelActive(ChannelHandlerContext ctx) {
         handshaker.handshake(ctx.channel());
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        if (evt instanceof IdleStateEvent) {
+            handshakeFuture.notifyError(new Throwable("Idle timeout triggered"), null);
+        }
     }
 
     @Override

--- a/http-native/src/main/java/org/ballerinalang/net/transport/contractimpl/sender/websocket/WebSocketClientHandshakeHandler.java
+++ b/http-native/src/main/java/org/ballerinalang/net/transport/contractimpl/sender/websocket/WebSocketClientHandshakeHandler.java
@@ -71,7 +71,6 @@ public class WebSocketClientHandshakeHandler extends ChannelInboundHandlerAdapte
         return httpCarbonResponse;
     }
 
-
     @Override
     public void channelActive(ChannelHandlerContext ctx) {
         handshaker.handshake(ctx.channel());

--- a/http-native/src/test/java/org/ballerinalang/net/transport/util/TestUtil.java
+++ b/http-native/src/test/java/org/ballerinalang/net/transport/util/TestUtil.java
@@ -80,6 +80,7 @@ public class TestUtil {
     public static final int SERVER_PORT3 = 9003;
     public static final int SERVER_CONNECTOR_PORT = 8490;
     public static final int WEBSOCKET_REMOTE_SERVER_PORT = 9010;
+    public static final int WEBSOCKET_HANDSHAKE_TIMEOUT_REMOTE_SERVER_PORT = 9011;
     public static final int WEBSOCKET_TEST_IDLE_TIMEOUT = 30;
     public static final long HTTP2_RESPONSE_TIME_OUT = 30;
     public static final long SSL_HANDSHAKE_TIMEOUT = 20;
@@ -94,6 +95,8 @@ public class TestUtil {
     public static final TimeUnit HTTP2_RESPONSE_TIME_UNIT = TimeUnit.SECONDS;
     public static final String WEBSOCKET_REMOTE_SERVER_URL =
             String.format("ws://%s:%d/%s", TEST_HOST, WEBSOCKET_REMOTE_SERVER_PORT, "websocket");
+    public static final String WEBSOCKET_HANDSHAKE_TIMEOUT_REMOTE_SERVER_URL = String
+            .format("ws://%s:%d/%s", TEST_HOST, WEBSOCKET_HANDSHAKE_TIMEOUT_REMOTE_SERVER_PORT, "websocket");
     public static final String WEBSOCKET_SECURE_REMOTE_SERVER_URL =
             String.format("wss://%s:%d/%s", TEST_HOST, WEBSOCKET_REMOTE_SERVER_PORT, "websocket");
     public static final String KEY_FILE = "/simple-test-config/certsAndKeys/private.key";

--- a/http-native/src/test/java/org/ballerinalang/net/transport/util/server/websocket/WebSocketHandshakeTimeoutServer.java
+++ b/http-native/src/test/java/org/ballerinalang/net/transport/util/server/websocket/WebSocketHandshakeTimeoutServer.java
@@ -1,3 +1,22 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
 package org.ballerinalang.net.transport.util.server.websocket;
 
 import io.netty.bootstrap.ServerBootstrap;
@@ -7,6 +26,9 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * WebSocket server used to test initial WebSocket handshake timeout.
+ */
 public class WebSocketHandshakeTimeoutServer {
     private static final Logger LOG = LoggerFactory.getLogger(WebSocketRemoteServer.class);
 
@@ -25,7 +47,7 @@ public class WebSocketHandshakeTimeoutServer {
         ServerBootstrap serverBootstrap = new ServerBootstrap();
         serverBootstrap.group(bossGroup, workerGroup)
                 .channel(NioServerSocketChannel.class)
-                .childHandler(new WebSocketIdleTimeoutRemoteServerInitializer());
+                .childHandler(new WebSocketIdleTimeoutServerInitializer());
 
         serverBootstrap.bind(port).sync();
         LOG.info("WebSocket remote server started listening on port " + port);

--- a/http-native/src/test/java/org/ballerinalang/net/transport/util/server/websocket/WebSocketHandshakeTimeoutServer.java
+++ b/http-native/src/test/java/org/ballerinalang/net/transport/util/server/websocket/WebSocketHandshakeTimeoutServer.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * WebSocket server used to test initial WebSocket handshake timeout.
  */
 public class WebSocketHandshakeTimeoutServer {
-    private static final Logger LOG = LoggerFactory.getLogger(WebSocketRemoteServer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(WebSocketHandshakeTimeoutServer.class);
 
     private final int port;
     private EventLoopGroup bossGroup;

--- a/http-native/src/test/java/org/ballerinalang/net/transport/util/server/websocket/WebSocketHandshakeTimeoutServer.java
+++ b/http-native/src/test/java/org/ballerinalang/net/transport/util/server/websocket/WebSocketHandshakeTimeoutServer.java
@@ -1,0 +1,40 @@
+package org.ballerinalang.net.transport.util.server.websocket;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WebSocketHandshakeTimeoutServer {
+    private static final Logger LOG = LoggerFactory.getLogger(WebSocketRemoteServer.class);
+
+    private final int port;
+    private EventLoopGroup bossGroup;
+    private EventLoopGroup workerGroup;
+
+    public WebSocketHandshakeTimeoutServer(int port) {
+        this.port = port;
+    }
+
+    public void run() throws InterruptedException {
+        bossGroup = new NioEventLoopGroup();
+        workerGroup = new NioEventLoopGroup();
+
+        ServerBootstrap serverBootstrap = new ServerBootstrap();
+        serverBootstrap.group(bossGroup, workerGroup)
+                .channel(NioServerSocketChannel.class)
+                .childHandler(new WebSocketIdleTimeoutRemoteServerInitializer());
+
+        serverBootstrap.bind(port).sync();
+        LOG.info("WebSocket remote server started listening on port " + port);
+    }
+
+    public void stop() {
+        bossGroup.shutdownGracefully();
+        workerGroup.shutdownGracefully();
+        LOG.info("WebSocket remote server stopped listening  on port " + port);
+    }
+}
+

--- a/http-native/src/test/java/org/ballerinalang/net/transport/util/server/websocket/WebSocketIdleTimeoutRemoteServerInitializer.java
+++ b/http-native/src/test/java/org/ballerinalang/net/transport/util/server/websocket/WebSocketIdleTimeoutRemoteServerInitializer.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.ballerinalang.net.transport.util.server.websocket;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler;
+import org.ballerinalang.net.transport.contract.Constants;
+
+public class WebSocketIdleTimeoutRemoteServerInitializer extends ChannelInitializer<SocketChannel> {
+
+    private static final String WEBSOCKET_PATH = "/websocket";
+
+    @Override
+    public void initChannel(SocketChannel ch) throws InterruptedException {
+        Thread.sleep(3000);
+        ChannelPipeline pipeline = ch.pipeline();
+        pipeline.addLast(new HttpServerCodec());
+        pipeline.addLast(new HttpObjectAggregator(Constants.WEBSOCKET_REQUEST_SIZE));
+        pipeline.addLast(new WebSocketServerCompressionHandler());
+        pipeline.addLast(new WebSocketServerCustomHeadersHandler());
+        pipeline.addLast(new WebSocketServerProtocolHandler(WEBSOCKET_PATH, null, true));
+        pipeline.addLast(new WebSocketRemoteServerFrameHandler());
+    }
+}

--- a/http-native/src/test/java/org/ballerinalang/net/transport/util/server/websocket/WebSocketIdleTimeoutServerInitializer.java
+++ b/http-native/src/test/java/org/ballerinalang/net/transport/util/server/websocket/WebSocketIdleTimeoutServerInitializer.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -27,7 +27,10 @@ import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
 import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler;
 import org.ballerinalang.net.transport.contract.Constants;
 
-public class WebSocketIdleTimeoutRemoteServerInitializer extends ChannelInitializer<SocketChannel> {
+/**
+ * Initializer for WebSocket handshake timeout server for Testing.
+ */
+public class WebSocketIdleTimeoutServerInitializer extends ChannelInitializer<SocketChannel> {
 
     private static final String WEBSOCKET_PATH = "/websocket";
 

--- a/http-native/src/test/java/org/ballerinalang/net/transport/util/server/websocket/WebSocketIdleTimeoutServerInitializer.java
+++ b/http-native/src/test/java/org/ballerinalang/net/transport/util/server/websocket/WebSocketIdleTimeoutServerInitializer.java
@@ -36,6 +36,7 @@ public class WebSocketIdleTimeoutServerInitializer extends ChannelInitializer<So
 
     @Override
     public void initChannel(SocketChannel ch) throws InterruptedException {
+        // Intention of having this is to exceed the idle timeout of test client which is set to 1 second.
         Thread.sleep(3000);
         ChannelPipeline pipeline = ch.pipeline();
         pipeline.addLast(new HttpServerCodec());

--- a/http-native/src/test/java/org/ballerinalang/net/transport/util/server/websocket/WebSocketIdleTimeoutServerInitializer.java
+++ b/http-native/src/test/java/org/ballerinalang/net/transport/util/server/websocket/WebSocketIdleTimeoutServerInitializer.java
@@ -24,7 +24,6 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
-import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler;
 import org.ballerinalang.net.transport.contract.Constants;
 
 /**
@@ -41,9 +40,6 @@ public class WebSocketIdleTimeoutServerInitializer extends ChannelInitializer<So
         ChannelPipeline pipeline = ch.pipeline();
         pipeline.addLast(new HttpServerCodec());
         pipeline.addLast(new HttpObjectAggregator(Constants.WEBSOCKET_REQUEST_SIZE));
-        pipeline.addLast(new WebSocketServerCompressionHandler());
-        pipeline.addLast(new WebSocketServerCustomHeadersHandler());
         pipeline.addLast(new WebSocketServerProtocolHandler(WEBSOCKET_PATH, null, true));
-        pipeline.addLast(new WebSocketRemoteServerFrameHandler());
     }
 }

--- a/http-native/src/test/java/org/ballerinalang/net/transport/util/server/websocket/WebSocketIdleTimeoutServerInitializer.java
+++ b/http-native/src/test/java/org/ballerinalang/net/transport/util/server/websocket/WebSocketIdleTimeoutServerInitializer.java
@@ -28,7 +28,7 @@ import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketSe
 import org.ballerinalang.net.transport.contract.Constants;
 
 /**
- * Initializer for WebSocket handshake timeout server for Testing.
+ * Initializer for WebSocket handshake timeout server for testing.
  */
 public class WebSocketIdleTimeoutServerInitializer extends ChannelInitializer<SocketChannel> {
 

--- a/http-native/src/test/java/org/ballerinalang/net/transport/websocket/client/WebSocketClientHandshakeFunctionalityTestCase.java
+++ b/http-native/src/test/java/org/ballerinalang/net/transport/websocket/client/WebSocketClientHandshakeFunctionalityTestCase.java
@@ -28,6 +28,7 @@ import org.ballerinalang.net.transport.contract.websocket.WebSocketConnection;
 import org.ballerinalang.net.transport.contract.websocket.WebSocketConnectorListener;
 import org.ballerinalang.net.transport.contractimpl.DefaultHttpWsConnectorFactory;
 import org.ballerinalang.net.transport.message.HttpCarbonResponse;
+import org.ballerinalang.net.transport.util.server.websocket.WebSocketHandshakeTimeoutServer;
 import org.ballerinalang.net.transport.util.server.websocket.WebSocketRemoteServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +45,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.ballerinalang.net.transport.util.TestUtil.WEBSOCKET_HANDSHAKE_TIMEOUT_REMOTE_SERVER_PORT;
+import static org.ballerinalang.net.transport.util.TestUtil.WEBSOCKET_HANDSHAKE_TIMEOUT_REMOTE_SERVER_URL;
 import static org.ballerinalang.net.transport.util.TestUtil.WEBSOCKET_REMOTE_SERVER_PORT;
 import static org.ballerinalang.net.transport.util.TestUtil.WEBSOCKET_REMOTE_SERVER_URL;
 import static org.ballerinalang.net.transport.util.TestUtil.WEBSOCKET_TEST_IDLE_TIMEOUT;
@@ -57,18 +60,21 @@ public class WebSocketClientHandshakeFunctionalityTestCase {
 
     private DefaultHttpWsConnectorFactory httpConnectorFactory;
     private WebSocketRemoteServer remoteServer;
+    private WebSocketHandshakeTimeoutServer handshakeTimeoutServer;
 
     @BeforeClass
     public void setup() throws InterruptedException {
         remoteServer = new WebSocketRemoteServer(WEBSOCKET_REMOTE_SERVER_PORT, "xml, json");
+        handshakeTimeoutServer = new WebSocketHandshakeTimeoutServer(WEBSOCKET_HANDSHAKE_TIMEOUT_REMOTE_SERVER_PORT);
         remoteServer.run();
+        handshakeTimeoutServer.run();
         httpConnectorFactory = new DefaultHttpWsConnectorFactory();
     }
 
     @Test(description = "Test the idle timeout for WebSocket")
     public void testIdleTimeout() throws Throwable {
         WebSocketClientConnectorConfig configuration = new WebSocketClientConnectorConfig(WEBSOCKET_REMOTE_SERVER_URL);
-        configuration.setIdleTimeoutInMillis(3000);
+        configuration.setIdleTimeoutInMillis(1000);
         HandshakeResult result = connectAndGetHandshakeResult(configuration);
 
         CountDownLatch countDownLatch = new CountDownLatch(1);
@@ -77,6 +83,20 @@ public class WebSocketClientHandshakeFunctionalityTestCase {
 
         Assert.assertNull(result.getThrowable());
         Assert.assertTrue(result.getConnectorListener().isIdleTimeout(), "Should reach idle timeout");
+    }
+
+    @Test(description = "Test the idle timeout for WebSocket")
+    public void testHandshakeTimeout() throws Throwable {
+        WebSocketClientConnectorConfig configuration = new WebSocketClientConnectorConfig(WEBSOCKET_HANDSHAKE_TIMEOUT_REMOTE_SERVER_URL);
+        configuration.setIdleTimeoutInMillis(1000);
+        HandshakeResult result = connectAndGetHandshakeResult(configuration);
+
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        result.getConnectorListener().setCountDownLatch(countDownLatch);
+        countDownLatch.await(WEBSOCKET_TEST_IDLE_TIMEOUT, TimeUnit.SECONDS);
+
+        Assert.assertNotNull(result.getThrowable());
+        Assert.assertEquals(result.getThrowable().getMessage(), "Idle timeout triggered");
     }
 
     @Test(description = "Test the sub protocol negotiation with the remote server")
@@ -343,6 +363,7 @@ public class WebSocketClientHandshakeFunctionalityTestCase {
     @AfterClass
     public void cleanUp() throws ServerConnectorException, InterruptedException {
         remoteServer.stop();
+        handshakeTimeoutServer.stop();
         httpConnectorFactory.shutdown();
     }
 

--- a/http-native/src/test/java/org/ballerinalang/net/transport/websocket/client/WebSocketClientHandshakeFunctionalityTestCase.java
+++ b/http-native/src/test/java/org/ballerinalang/net/transport/websocket/client/WebSocketClientHandshakeFunctionalityTestCase.java
@@ -74,7 +74,7 @@ public class WebSocketClientHandshakeFunctionalityTestCase {
     @Test(description = "Test the idle timeout for WebSocket")
     public void testIdleTimeout() throws Throwable {
         WebSocketClientConnectorConfig configuration = new WebSocketClientConnectorConfig(WEBSOCKET_REMOTE_SERVER_URL);
-        configuration.setIdleTimeoutInMillis(1000);
+        configuration.setIdleTimeoutInMillis(3000);
         HandshakeResult result = connectAndGetHandshakeResult(configuration);
 
         CountDownLatch countDownLatch = new CountDownLatch(1);
@@ -85,9 +85,10 @@ public class WebSocketClientHandshakeFunctionalityTestCase {
         Assert.assertTrue(result.getConnectorListener().isIdleTimeout(), "Should reach idle timeout");
     }
 
-    @Test(description = "Test the idle timeout for WebSocket")
+    @Test(description = "Test the handhshake timeout")
     public void testHandshakeTimeout() throws Throwable {
-        WebSocketClientConnectorConfig configuration = new WebSocketClientConnectorConfig(WEBSOCKET_HANDSHAKE_TIMEOUT_REMOTE_SERVER_URL);
+        WebSocketClientConnectorConfig configuration = new WebSocketClientConnectorConfig(
+                WEBSOCKET_HANDSHAKE_TIMEOUT_REMOTE_SERVER_URL);
         configuration.setIdleTimeoutInMillis(1000);
         HandshakeResult result = connectAndGetHandshakeResult(configuration);
 

--- a/http-native/src/test/java/org/ballerinalang/net/transport/websocket/client/WebSocketClientHandshakeFunctionalityTestCase.java
+++ b/http-native/src/test/java/org/ballerinalang/net/transport/websocket/client/WebSocketClientHandshakeFunctionalityTestCase.java
@@ -97,7 +97,7 @@ public class WebSocketClientHandshakeFunctionalityTestCase {
         countDownLatch.await(WEBSOCKET_TEST_IDLE_TIMEOUT, TimeUnit.SECONDS);
 
         Assert.assertNotNull(result.getThrowable());
-        Assert.assertEquals(result.getThrowable().getMessage(), "Handshake timedout");
+        Assert.assertEquals(result.getThrowable().getMessage(), "Handshake timed out");
     }
 
     @Test(description = "Test the sub protocol negotiation with the remote server")

--- a/http-native/src/test/java/org/ballerinalang/net/transport/websocket/client/WebSocketClientHandshakeFunctionalityTestCase.java
+++ b/http-native/src/test/java/org/ballerinalang/net/transport/websocket/client/WebSocketClientHandshakeFunctionalityTestCase.java
@@ -97,7 +97,7 @@ public class WebSocketClientHandshakeFunctionalityTestCase {
         countDownLatch.await(WEBSOCKET_TEST_IDLE_TIMEOUT, TimeUnit.SECONDS);
 
         Assert.assertNotNull(result.getThrowable());
-        Assert.assertEquals(result.getThrowable().getMessage(), "Idle timeout triggered");
+        Assert.assertEquals(result.getThrowable().getMessage(), "Handshake timedout");
     }
 
     @Test(description = "Test the sub protocol negotiation with the remote server")


### PR DESCRIPTION
## Purpose
This is to handle the timeout in initial WebSocket handshake. 
Related issue: https://github.com/ballerina-platform/ballerina-standard-library/issues/1478

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests