### PR TITLE
Enable add header APIs for the HttpCarbonMessage

### DIFF
--- a/http-native/src/main/java/org/ballerinalang/net/transport/message/HttpCarbonMessage.java
+++ b/http-native/src/main/java/org/ballerinalang/net/transport/message/HttpCarbonMessage.java
@@ -252,6 +252,38 @@ public class HttpCarbonMessage {
     }
 
     /**
+     * Add a new header value for the given name.
+     *
+     * @param key   header name.
+     * @param value header value as a string.
+     */
+    public void addHeader(String key, String value) {
+
+        this.httpMessage.headers().add(key, value);
+    }
+
+    /**
+     * Add a new header value for the given name.
+     *
+     * @param key   header name.
+     * @param value header value as an object.
+     */
+    public void addHeader(String key, Object value) {
+
+        this.httpMessage.headers().add(key, value);
+    }
+
+    /**
+     * Add a set of headers to the HTTP message.
+     *
+     * @param httpHeaders set of headers that needs to be set.
+     */
+    public void addHeaders(HttpHeaders httpHeaders) {
+
+        this.httpMessage.headers().add(httpHeaders);
+    }
+
+    /**
      * Remove the header using header name.
      *
      * @param key header name.


### PR DESCRIPTION
## Purpose

Addresses https://github.com/ballerina-platform/ballerina-standard-library/issues/1510#issuecomment-864778428

Set header APIs override when there is more than one header value for a given key. But, add headers APIs just add a new one rather than overriding it. The gRPC package needs such adding APIs to support header lists.

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests