### PR TITLE
Fix NPE, unresponsive service and returned error log

### DIFF
--- a/http-ballerina-tests/tests/resource_return_statment_test.bal
+++ b/http-ballerina-tests/tests/resource_return_statment_test.bal
@@ -191,6 +191,24 @@ service http:Service /mytest on resourceReturnTestEP {
         }
         return "hello";
     }
+
+    resource function get test29(http:Caller caller) {
+        error? a = caller->respond("Hello");
+        error? b = caller->respond("Hello2"); // return error
+    }
+
+    resource function get test30(http:Caller caller) returns string? {
+        error? a = caller->respond("Hello");
+        return "Hello2"; // log error
+    }
+
+    resource function get test31(http:Caller caller) returns error? {
+        check caller->respond("Hello"); // log error
+    }
+
+    resource function get test32(http:Caller caller) {
+        checkpanic caller->respond("Hello"); // log error
+    }
 }
 
 @test:Config {}
@@ -600,6 +618,50 @@ public function testReturnMultipleTypes() {
         test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
         test:assertEquals(checkpanic resp.getHeader(CONTENT_TYPE), "application/custom+json");
         assertTextPayload(resp.getTextPayload(), "hello");
+    } else {
+        test:assertFail(msg = "Found unexpected output: " +  resp.message());
+    }
+}
+
+@test:Config {}
+public function testDoubleResponse() {
+    http:Response|error resp = resourceReturnTestClient->get("/mytest/test29");
+    if (resp is http:Response) {
+        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
+        assertTextPayload(resp.getTextPayload(), "Hello");
+    } else {
+        test:assertFail(msg = "Found unexpected output: " +  resp.message());
+    }
+}
+
+@test:Config {}
+public function testReturnAfterResponse() {
+    http:Response|error resp = resourceReturnTestClient->get("/mytest/test30");
+    if (resp is http:Response) {
+        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
+        assertTextPayload(resp.getTextPayload(), "Hello");
+    } else {
+        test:assertFail(msg = "Found unexpected output: " +  resp.message());
+    }
+}
+
+@test:Config {}
+public function testCheckErrorAfterResponse() {
+    http:Response|error resp = resourceReturnTestClient->get("/mytest/test31");
+    if (resp is http:Response) {
+        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
+        assertTextPayload(resp.getTextPayload(), "Hello");
+    } else {
+        test:assertFail(msg = "Found unexpected output: " +  resp.message());
+    }
+}
+
+@test:Config {}
+public function testCheckPanicErrorAfterResponse() {
+    http:Response|error resp = resourceReturnTestClient->get("/mytest/test32");
+    if (resp is http:Response) {
+        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
+        assertTextPayload(resp.getTextPayload(), "Hello");
     } else {
         test:assertFail(msg = "Found unexpected output: " +  resp.message());
     }

--- a/http-ballerina-tests/tests/service_dispatching_data_binding_test.bal
+++ b/http-ballerina-tests/tests/service_dispatching_data_binding_test.bal
@@ -95,16 +95,18 @@ service /echo on dataBindingEP {
         var err = dataBindingEP.attach(multipleAnnot1, "multipleAnnot1");
         if err is error {
             checkpanic caller->respond(err.message());
+        } else {
+            checkpanic caller->respond("ok");
         }
-        checkpanic caller->respond("ok");
     }
 
     resource function get negative2(http:Caller caller) {
         var err = dataBindingEP.attach(multipleAnnot2, "multipleAnnot2");
         if err is error {
             checkpanic caller->respond(err.message());
+        } else {
+            checkpanic caller->respond("ok");
         }
-        checkpanic caller->respond("ok");
     }
 }
 

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpCallableUnitCallback.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpCallableUnitCallback.java
@@ -34,7 +34,7 @@ public class HttpCallableUnitCallback implements Callback {
     private final Runtime runtime;
     private final String returnMediaType;
     private HttpCarbonMessage requestMessage;
-    private static final String ILLEGAL_FUNCTION_INVOKED = "illegal return: request has already been responded";
+    private static final String ILLEGAL_FUNCTION_INVOKED = "illegal return: response has already been sent";
 
     HttpCallableUnitCallback(HttpCarbonMessage requestMessage, Runtime runtime, String returnMediaType) {
         this.requestMessage = requestMessage;

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -483,7 +483,7 @@ public class HttpUtil {
 
     private static String getErrorMessage(BError error) {
         BMap errorDetails = (BMap) error.getDetails();
-        if (errorDetails.get(HTTP_ERROR_MESSAGE) != null) {
+        if (errorDetails != null && errorDetails.get(HTTP_ERROR_MESSAGE) != null) {
             return errorDetails.get(HTTP_ERROR_MESSAGE).toString();
         }
         return error.getErrorMessage().getValue();

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -218,7 +218,7 @@ public class HttpUtil {
     private static final String METHOD_ACCESSED = "isMethodAccessed";
     private static final String IO_EXCEPTION_OCCURRED = "I/O exception occurred";
     private static final String CHUNKING_CONFIG = "chunking_config";
-    private static final String ILLEGAL_FUNCTION_INVOKED = "illegal function invocation";
+    private static final String ILLEGAL_FUNCTION_INVOKED = "illegal respond: response has already been sent";
 
     /**
      * Set new entity to in/out request/response struct.
@@ -1097,8 +1097,7 @@ public class HttpUtil {
         return httpCarbonMessage;
     }
 
-    public static void checkFunctionValidity(BObject connectionObj, HttpCarbonMessage reqMsg,
-                                             HttpCarbonMessage outboundResponseMsg) {
+    public static void checkFunctionValidity(HttpCarbonMessage reqMsg, HttpCarbonMessage outboundResponseMsg) {
         serverConnectionStructCheck(reqMsg);
         int statusCode = outboundResponseMsg.getHttpStatusCode();
         methodInvocationCheck(reqMsg, statusCode, ILLEGAL_FUNCTION_INVOKED);
@@ -1106,7 +1105,7 @@ public class HttpUtil {
 
     static void methodInvocationCheck(HttpCarbonMessage reqMsg, int statusCode, String errMsg) {
         if (reqMsg == null || reqMsg.getProperty(METHOD_ACCESSED) != null) {
-            throw createHttpError(errMsg, HttpErrorType.GENERIC_CLIENT_ERROR);
+            throw createHttpError(errMsg, HttpErrorType.GENERIC_LISTENER_ERROR);
         }
 
         if (is100ContinueRequest(reqMsg, statusCode) || statusCode == HttpConstants.INVALID_STATUS_CODE) {

--- a/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/Respond.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/Respond.java
@@ -73,7 +73,14 @@ public class Respond extends ConnectionAction {
         outboundResponseMsg.setSequenceId(inboundRequestMsg.getSequenceId());
         setCacheControlHeader(outboundResponseObj, outboundResponseMsg);
         HttpUtil.prepareOutboundResponse(connectionObj, inboundRequestMsg, outboundResponseMsg, outboundResponseObj);
-        HttpUtil.checkFunctionValidity(connectionObj, inboundRequestMsg, outboundResponseMsg);
+
+        try {
+            HttpUtil.checkFunctionValidity(inboundRequestMsg, outboundResponseMsg);
+        } catch (BError e) {
+            log.debug(e.getPrintableStackTrace(), e);
+            dataContext.getFuture().complete(e);
+            return null;
+        }
 
         // Based on https://tools.ietf.org/html/rfc7232#section-4.1
         if (CacheUtils.isValidCachedResponse(outboundResponseMsg, inboundRequestMsg)) {


### PR DESCRIPTION
## Purpose
> Fixes ballerina-platform/ballerina-standard-library#1167
> Log error when the return from the resource leads to an error
> Fixes ballerina-platform/ballerina-standard-library#1509

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests