### PR TITLE
Respond with 500 when nil is returned in the presence of caller

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - [Fix the limitation of not supporting different API resources with same end URL Template](https://github.com/ballerina-platform/ballerina-standard-library/issues/1095)
 - [Fix dispatching failure when same path param identifiers exist in a different order](https://github.com/ballerina-platform/ballerina-standard-library/issues/342)
+- [Respond with 500 response when nil is returned in the presence of the http:Caller as a resource argument](https://github.com/ballerina-platform/ballerina-standard-library/issues/1524)
 
 ## [1.1.0-beta.1] - 2021-05-06
 

--- a/http-ballerina/http_connection.bal
+++ b/http-ballerina/http_connection.bal
@@ -30,6 +30,7 @@ public client class Caller {
     public Remote remoteAddress = {};
     public Local localAddress = {};
     public string protocol = "";
+    private boolean present = false;
 
     # Sends the outbound response to the caller.
     #
@@ -116,8 +117,13 @@ public client class Caller {
             returns ListenerError? {
         Response response = new;
         if (message is ()) {
-            Accepted AcceptedResponse = {};
-            response = createStatusCodeResponse(AcceptedResponse);
+            if (self.present) {
+                InternalServerError errResponse = {};
+                response = createStatusCodeResponse(errResponse);
+            } else {
+                Accepted AcceptedResponse = {};
+                response = createStatusCodeResponse(AcceptedResponse);
+            }
         } else if (message is error) {
             if (message is ApplicationResponseError) {
                 InternalServerError err = {

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -454,6 +454,7 @@ public class HttpConstants {
     public static final String RETRY_INTERVAL = "intervalInMillis";
 
     public static final BString SERVICE_ENDPOINT_PROTOCOL_FIELD = StringUtils.fromString("protocol");
+    public static final BString CALLER_PRESENT_FIELD = StringUtils.fromString("present");
 
     //Remote struct field names
     public static final BString REMOTE_STRUCT_FIELD = StringUtils.fromString("remoteAddress");

--- a/http-native/src/main/java/org/ballerinalang/net/http/HttpDispatcher.java
+++ b/http-native/src/main/java/org/ballerinalang/net/http/HttpDispatcher.java
@@ -191,6 +191,7 @@ public class HttpDispatcher {
             switch (typeName) {
                 case HttpConstants.CALLER:
                     int index = ((NonRecurringParam) param).getIndex();
+                    httpCaller.set(HttpConstants.CALLER_PRESENT_FIELD, true);
                     paramFeed[index++] = httpCaller;
                     paramFeed[index] = true;
                     break;


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1524

## Examples
```ballerina
    resource function get errorCaller(http:Caller caller, boolean err) returns error? {
        if err {
            return; //500 response
        }
        check caller->respond("success");
    }
```    

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests