### PR TITLE
Add validation for invalid array types for header parameters in resource functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Fix the limitation of not supporting different API resources with same end URL Template](https://github.com/ballerina-platform/ballerina-standard-library/issues/1095)
 - [Fix dispatching failure when same path param identifiers exist in a different order](https://github.com/ballerina-platform/ballerina-standard-library/issues/342)
 - [Respond with 500 response when nil is returned in the presence of the http:Caller as a resource argument](https://github.com/ballerina-platform/ballerina-standard-library/issues/1524)
+- [Http compiler-plugin should validate header value type](https://github.com/ballerina-platform/ballerina-standard-library/issues/1480)
 
 ## [1.1.0-beta.1] - 2021-05-06
 

--- a/http-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/http-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -146,7 +146,7 @@ public class CompilerPluginTest {
         Package currentPackage = loadPackage("sample_package_5");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
-        Assert.assertEquals(diagnosticResult.diagnosticCount(), 6);
+        Assert.assertEquals(diagnosticResult.diagnosticCount(), 7);
         assertError(diagnosticResult, 0, "invalid type of header param 'abc': expected 'string' or 'string[]'",
                     HTTP_109);
         assertError(diagnosticResult, 1, "invalid multiple resource parameter annotations for 'abc': expected one of " +
@@ -163,6 +163,9 @@ public class CompilerPluginTest {
                     "invalid union type of header param 'abc': a string or an array of a string can only be union " +
                             "with '()'. Eg: string|() or string[]|()",
                     HTTP_110);
+        assertError(diagnosticResult, 6,
+                "invalid type of header param 'abc': expected 'string' or 'string[]'",
+                HTTP_109);
     }
 
     @Test

--- a/http-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_5/service.bal
+++ b/http-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_5/service.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 
 service http:Service on new http:Listener(9090) {

--- a/http-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_5/service.bal
+++ b/http-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_5/service.bal
@@ -41,4 +41,8 @@ service http:Service on new http:Listener(9090) {
     resource function get headerErr6(@http:Header {name: "x-type"} string|json|xml abc) returns string {
         return "done"; //error
     }
+
+    resource function get headerErr7(@http:Header {name: "x-type"} int[] abc) returns string {
+        return "done"; //error
+    }
 }

--- a/http-compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
+++ b/http-compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
@@ -344,6 +344,8 @@ class HttpResourceValidator {
                             TypeDescKind arrElementKind = arrTypeSymbol.typeKind();
                             if (arrElementKind == TypeDescKind.STRING) {
                                 continue;
+                            } else {
+                                reportInvalidHeaderParameterType(ctx, member, paramName);
                             }
                         } else if (kind == TypeDescKind.UNION) {
                             List<TypeSymbol> symbolList = ((UnionTypeSymbol) typeSymbol).memberTypeDescriptors();


### PR DESCRIPTION
## Purpose
> $subject

Fixes [#1480](https://github.com/ballerina-platform/ballerina-standard-library/issues/1480)

## Examples
Following code sample should give a compile time.
```ballerina
import ballerina/http;

service / on new http:Listener(8080) {
    resource function get getResource(@http:Header int[] length) {
        // ... 
    }
    
}
```

Output
```bash
invalid type of header param 'length': expected 'string' or 'string[]'
```

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [X] Added tests