### PR TITLE
Refactor Retry client logic for validating response status

### DIFF
--- a/http-ballerina/http_client_endpoint.bal
+++ b/http-ballerina/http_client_endpoint.bal
@@ -588,13 +588,12 @@ isolated function createCircuitBreakerClient(string uri, ClientConfiguration con
 isolated function createRetryClient(string url, ClientConfiguration configuration, CookieStore? cookieStore) returns HttpClient|ClientError {
     var retryConfig = configuration.retryConfig;
     if (retryConfig is RetryConfig) {
-        boolean[] statusCodes = populateErrorCodeIndex(retryConfig.statusCodes);
         RetryInferredConfig retryInferredConfig = {
             count: retryConfig.count,
             interval: retryConfig.interval,
             backOffFactor: retryConfig.backOffFactor,
             maxWaitInterval: retryConfig.maxWaitInterval,
-            statusCodes: statusCodes
+            statusCodes: retryConfig.statusCodes
         };
         var httpCookieClient = createCookieClient(url, configuration, cookieStore);
         if (httpCookieClient is HttpClient) {

--- a/http-ballerina/http_commons.bal
+++ b/http-ballerina/http_commons.bal
@@ -204,16 +204,6 @@ isolated function extractHttpOperation (string httpVerb) returns HttpOperation {
     return inferredConnectorAction;
 }
 
-// Populate boolean index array by looking at the configured Http status codes to get better performance
-// at runtime.
-isolated function populateErrorCodeIndex (int[] errorCode) returns boolean[] {
-    boolean[] result = [];
-    foreach var i in errorCode {
-        result[i] = true;
-    }
-    return result;
-}
-
 isolated function getError() returns UnsupportedActionError {
     return error UnsupportedActionError("Unsupported connector action received.");
 }

--- a/http-ballerina/resiliency_http_retry_client.bal
+++ b/http-ballerina/resiliency_http_retry_client.bal
@@ -28,7 +28,7 @@ type RetryInferredConfig record {|
     decimal interval = 0;
     float backOffFactor = 0.0;
     decimal maxWaitInterval = 0;
-    boolean[] statusCodes = [];
+    int[] statusCodes = [];
 |};
 
 # Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client
@@ -270,7 +270,7 @@ isolated function performRetryAction(@untainted string path, Request request, Ht
     int currentRetryCount = 0;
     int retryCount = retryClient.retryInferredConfig.count;
     decimal interval = retryClient.retryInferredConfig.interval;
-    boolean[] statusCodeIndex = retryClient.retryInferredConfig.statusCodes;
+    int[] statusCodes = retryClient.retryInferredConfig.statusCodes;
     //initializeBackOffFactorAndMaxWaitInterval(retryClient);
     float inputBackOffFactor = retryClient.retryInferredConfig.backOffFactor;
     float backOffFactor = inputBackOffFactor <= 0.0 ? 1.0 : inputBackOffFactor;
@@ -290,8 +290,7 @@ isolated function performRetryAction(@untainted string path, Request request, Ht
         var backendResponse = invokeEndpoint(path, inRequest, requestAction, httpClient, verb = verb);
         if (backendResponse is Response) {
             int responseStatusCode = backendResponse.statusCode;
-            if (statusCodeIndex.length() > responseStatusCode && (statusCodeIndex[responseStatusCode])
-                                                              && currentRetryCount < (retryCount)) {
+            if ((statusCodes.indexOf(responseStatusCode) is int) && currentRetryCount < (retryCount)) {
                 [interval, currentRetryCount] =
                                 calculateEffectiveIntervalAndRetryCount(retryClient, currentRetryCount, interval,
                                 backOffFactor, maxWaitInterval);
@@ -302,8 +301,7 @@ isolated function performRetryAction(@untainted string path, Request request, Ht
             var response = httpClient->getResponse(backendResponse);
             if (response is Response) {
                 int responseStatusCode = response.statusCode;
-                if (statusCodeIndex.length() > responseStatusCode && (statusCodeIndex[responseStatusCode])
-                                                                  && currentRetryCount < (retryCount)) {
+                if ((statusCodes.indexOf(responseStatusCode) is int) && currentRetryCount < (retryCount)) {
                     [interval, currentRetryCount] =
                                     calculateEffectiveIntervalAndRetryCount(retryClient, currentRetryCount, interval,
                                     backOffFactor, maxWaitInterval);


### PR DESCRIPTION
## Purpose

This removes the `populateErrorCodeIndex ()` function and replaces the boolean array to integer array statusCodes in `RetryInferredConfig` record

Fixes [`ballerina-platform/ballerina-standard-library/issues/1601`](https://github.com/ballerina-platform/ballerina-standard-library/issues/1601)

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests