### PR TITLE
Enable HTTP Trace and Access Log

### DIFF
--- a/ballerina/http_log_manager.bal
+++ b/ballerina/http_log_manager.bal
@@ -16,11 +16,25 @@
 
 import ballerina/jballerina.java;
 
-function init() {
-    setModule();
-    initializeHttpLogs();
+public type TraceLogConfiguration record {|
+    boolean consoleEnabled = false;
+    string path = "";
+    string host = "";
+    int port = 0;
+|};
+
+public type AccessLogConfiguration record {|
+    boolean consoleEnabled = false;
+    string path = "";
+|};
+
+isolated function initializeHttpLogs() {
+    TraceLogConfiguration & readonly traceLogConfig = {};
+    AccessLogConfiguration & readonly accessLogConfig = {};
+    handle httpLogManager = newHttpLogManager(traceLogConfig, accessLogConfig);
 }
 
-function setModule() = @java:Method {
-    'class: "io.ballerina.stdlib.http.api.nativeimpl.ModuleUtils"
+isolated function newHttpLogManager(TraceLogConfiguration traceLogConfig, AccessLogConfiguration accessLogConfig)
+returns handle = @java:Constructor {
+    'class: "io.ballerina.stdlib.http.api.logging.HttpLogManager"
 } external;

--- a/ballerina/http_log_manager.bal
+++ b/ballerina/http_log_manager.bal
@@ -16,6 +16,12 @@
 
 import ballerina/jballerina.java;
 
+# Represents HTTP trace log configuration.
+#
+# + consoleEnabled - Boolean value to enable or disable console trace logs
+# + path - File path to store trace logs
+# + host - Socket hostname to publish the trace logs
+# + port - Socket port to publish the trace logs
 public type TraceLogConfiguration record {|
     boolean consoleEnabled = false;
     string path = "";
@@ -23,6 +29,10 @@ public type TraceLogConfiguration record {|
     int port = 0;
 |};
 
+# Represents HTTP access log configuration.
+#
+# + consoleEnabled - Boolean value to enable or disable console access logs
+# + path - File path to store access logs
 public type AccessLogConfiguration record {|
     boolean consoleEnabled = false;
     string path = "";

--- a/ballerina/http_log_manager.bal
+++ b/ballerina/http_log_manager.bal
@@ -43,11 +43,7 @@ public type AccessLogConfiguration record {|
 configurable TraceLogConfiguration & readonly traceLogConfig = {};
 configurable AccessLogConfiguration & readonly accessLogConfig = {};
 
-isolated function initializeHttpLogs() {
-    _ = initializeHttpLogManager(traceLogConfig, accessLogConfig);
-}
-
-isolated function initializeHttpLogManager(TraceLogConfiguration traceLogConfig, AccessLogConfiguration accessLogConfig)
+isolated function initializeHttpLogs(TraceLogConfiguration traceLogConfig, AccessLogConfiguration accessLogConfig)
 returns handle = @java:Constructor {
     'class: "io.ballerina.stdlib.http.api.logging.HttpLogManager"
 } external;

--- a/ballerina/http_log_manager.bal
+++ b/ballerina/http_log_manager.bal
@@ -38,9 +38,10 @@ public type AccessLogConfiguration record {|
     string path = "";
 |};
 
+configurable TraceLogConfiguration & readonly traceLogConfig = {};
+configurable AccessLogConfiguration & readonly accessLogConfig = {};
+
 isolated function initializeHttpLogs() {
-    TraceLogConfiguration & readonly traceLogConfig = {};
-    AccessLogConfiguration & readonly accessLogConfig = {};
     handle httpLogManager = newHttpLogManager(traceLogConfig, accessLogConfig);
 }
 

--- a/ballerina/http_log_manager.bal
+++ b/ballerina/http_log_manager.bal
@@ -16,28 +16,26 @@
 
 import ballerina/jballerina.java;
 
-// TODO: Make the fields optional once configurable records support union members
 # Represents HTTP trace log configuration.
 #
 # + console - Boolean value to enable or disable console trace logs
-# + path - File path to store trace logs
-# + host - Socket hostname to publish the trace logs
-# + port - Socket port to publish the trace logs
+# + path - Optional file path to store trace logs
+# + host - Optional socket hostname to publish the trace logs
+# + port - Optional socket port to publish the trace logs
 public type TraceLogConfiguration record {|
     boolean console = false;
-    string path = "";
-    string host = "";
-    int port = 0;
+    string path?;
+    string host?;
+    int port?;
 |};
 
-// TODO: Make the fields optional once configurable records support union members
 # Represents HTTP access log configuration.
 #
 # + console - Boolean value to enable or disable console access logs
-# + path - File path to store access logs
+# + path - Optional file path to store access logs
 public type AccessLogConfiguration record {|
     boolean console = false;
-    string path = "";
+    string path?;
 |};
 
 configurable TraceLogConfiguration & readonly traceLogConfig = {};

--- a/ballerina/http_log_manager.bal
+++ b/ballerina/http_log_manager.bal
@@ -16,25 +16,27 @@
 
 import ballerina/jballerina.java;
 
+// TODO: Make the fields optional once configurable records support union members
 # Represents HTTP trace log configuration.
 #
-# + consoleEnabled - Boolean value to enable or disable console trace logs
+# + console - Boolean value to enable or disable console trace logs
 # + path - File path to store trace logs
 # + host - Socket hostname to publish the trace logs
 # + port - Socket port to publish the trace logs
 public type TraceLogConfiguration record {|
-    boolean consoleEnabled = false;
+    boolean console = false;
     string path = "";
     string host = "";
     int port = 0;
 |};
 
+// TODO: Make the fields optional once configurable records support union members
 # Represents HTTP access log configuration.
 #
-# + consoleEnabled - Boolean value to enable or disable console access logs
+# + console - Boolean value to enable or disable console access logs
 # + path - File path to store access logs
 public type AccessLogConfiguration record {|
-    boolean consoleEnabled = false;
+    boolean console = false;
     string path = "";
 |};
 
@@ -42,10 +44,10 @@ configurable TraceLogConfiguration & readonly traceLogConfig = {};
 configurable AccessLogConfiguration & readonly accessLogConfig = {};
 
 isolated function initializeHttpLogs() {
-    handle httpLogManager = newHttpLogManager(traceLogConfig, accessLogConfig);
+    _ = initializeHttpLogManager(traceLogConfig, accessLogConfig);
 }
 
-isolated function newHttpLogManager(TraceLogConfiguration traceLogConfig, AccessLogConfiguration accessLogConfig)
+isolated function initializeHttpLogManager(TraceLogConfiguration traceLogConfig, AccessLogConfiguration accessLogConfig)
 returns handle = @java:Constructor {
     'class: "io.ballerina.stdlib.http.api.logging.HttpLogManager"
 } external;

--- a/ballerina/init.bal
+++ b/ballerina/init.bal
@@ -18,7 +18,7 @@ import ballerina/jballerina.java;
 
 function init() {
     setModule();
-    initializeHttpLogs();
+    _ = initializeHttpLogs(traceLogConfig, accessLogConfig);
 }
 
 function setModule() = @java:Method {

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## Added
+- [Enable HTTP trace and access log support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1073)
+
+## [1.1.0-beta.2] - 2021-07-07
+
 ### Fixed
 - [Fix the limitation of not supporting different API resources with same end URL Template](https://github.com/ballerina-platform/ballerina-standard-library/issues/1095)
 - [Fix dispatching failure when same path param identifiers exist in a different order](https://github.com/ballerina-platform/ballerina-standard-library/issues/342)

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,7 @@ mimepullVersion=1.9.11
 testngVersion=7.4.0
 ballerinaGradlePluginVersion=0.10.0
 mockitoVersion=3.7.7
+gsonVersion=2.7
 
 stdlibIoVersion=0.6.0-beta.3-20210708-142400-de75ca2
 stdlibRegexVersion=0.7.0-beta.3-20210708-161600-c58ceb5

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation group: 'org.slf4j', name: 'slf4j-jdk14', version: "${slf4jVersion}"
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: "${commonsLang3Version}"
     implementation group: 'org.testng', name: 'testng', version: "${testngVersion}"
+    implementation group: 'com.google.code.gson', name: 'gson', version: "${gsonVersion}"
 
     // Transport related dependencies
     implementation group: 'io.netty', name: 'netty-codec-http2', version:"${nettyVersion}"

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -292,9 +292,17 @@ public class HttpConstants {
     public static final String RETRY_COUNT_FIELD = "count";
     public static final String RETRY_INTERVAL_FIELD = "intervalInMillis";
 
-    //Logging related runtime parameter names
-    public static final String HTTP_ACCESS_LOG_ENABLED = "http.accesslog.enabled";
+    // Logging related runtime parameter names
+    public static final String HTTP_TRACE_LOG = "http.tracelog";
     public static final String HTTP_TRACE_LOG_ENABLED = "http.tracelog.enabled";
+    public static final String HTTP_ACCESS_LOG = "http.accesslog";
+    public static final String HTTP_ACCESS_LOG_ENABLED = "http.accesslog.enabled";
+
+    // TraceLog and AccessLog configs
+    public static final BString HTTP_LOG_CONSOLE = StringUtils.fromString("consoleEnabled");
+    public static final BString HTTP_LOG_FILE_PATH = StringUtils.fromString("path");
+    public static final BString HTTP_TRACE_LOG_HOST = StringUtils.fromString("host");
+    public static final BString HTTP_TRACE_LOG_PORT = StringUtils.fromString("port");
 
     // ResponseCacheControl struct field names
     public static final BString RES_CACHE_CONTROL_MUST_REVALIDATE_FIELD = StringUtils.fromString("mustRevalidate");

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -299,7 +299,7 @@ public class HttpConstants {
     public static final String HTTP_ACCESS_LOG_ENABLED = "http.accesslog.enabled";
 
     // TraceLog and AccessLog configs
-    public static final BString HTTP_LOG_CONSOLE = StringUtils.fromString("consoleEnabled");
+    public static final BString HTTP_LOG_CONSOLE = StringUtils.fromString("console");
     public static final BString HTTP_LOG_FILE_PATH = StringUtils.fromString("path");
     public static final BString HTTP_TRACE_LOG_HOST = StringUtils.fromString("host");
     public static final BString HTTP_TRACE_LOG_PORT = StringUtils.fromString("port");

--- a/native/src/main/java/io/ballerina/stdlib/http/api/logging/HttpLogManager.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/logging/HttpLogManager.java
@@ -19,6 +19,7 @@
 package io.ballerina.stdlib.http.api.logging;
 
 import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BString;
 import io.ballerina.stdlib.http.api.logging.formatters.HttpAccessLogFormatter;
 import io.ballerina.stdlib.http.api.logging.formatters.HttpTraceLogFormatter;
 import io.ballerina.stdlib.http.api.logging.formatters.JsonLogFormatter;
@@ -77,30 +78,30 @@ public class HttpLogManager extends LogManager {
             traceLogsEnabled = true;
         }
 
-        String logFilePath = traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH).getValue();
-        if (!logFilePath.trim().isEmpty()) {
+        BString logFilePath = traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH);
+        if (logFilePath != null && !logFilePath.getValue().trim().isEmpty()) {
             try {
-                FileHandler fileHandler = new FileHandler(logFilePath, true);
+                FileHandler fileHandler = new FileHandler(logFilePath.getValue(), true);
                 fileHandler.setFormatter(new HttpTraceLogFormatter());
                 fileHandler.setLevel(Level.FINEST);
                 httpTraceLogger.addHandler(fileHandler);
                 traceLogsEnabled = true;
             } catch (IOException e) {
-                throw new RuntimeException("failed to setup HTTP trace log file: " + logFilePath, e);
+                throw new RuntimeException("failed to setup HTTP trace log file: " + logFilePath.getValue(), e);
             }
         }
 
-        String host = traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST).getValue();
-        int port = traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT).intValue();
-        if (!host.trim().isEmpty() && port != 0) {
+        BString host = traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST);
+        Long port = traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT);
+        if ((host != null && !host.getValue().trim().isEmpty()) && (port != null && port != 0)) {
             try {
-                SocketHandler socketHandler = new SocketHandler(host, port);
+                SocketHandler socketHandler = new SocketHandler(host.getValue(), port.intValue());
                 socketHandler.setFormatter(new JsonLogFormatter());
                 socketHandler.setLevel(Level.FINEST);
                 httpTraceLogger.addHandler(socketHandler);
                 traceLogsEnabled = true;
             } catch (IOException e) {
-                throw new RuntimeException("failed to connect to " + host + ":" + port, e);
+                throw new RuntimeException("failed to connect to " + host.getValue() + ":" + port.intValue(), e);
             }
         }
 
@@ -132,17 +133,17 @@ public class HttpLogManager extends LogManager {
             accessLogsEnabled = true;
         }
 
-        String filePath = accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH).getValue();
-        if (!filePath.trim().isEmpty()) {
+        BString filePath = accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH);
+        if (filePath != null && !filePath.getValue().trim().isEmpty()) {
             try {
-                FileHandler fileHandler = new FileHandler(filePath, true);
+                FileHandler fileHandler = new FileHandler(filePath.getValue(), true);
                 fileHandler.setFormatter(new HttpAccessLogFormatter());
                 fileHandler.setLevel(Level.INFO);
                 httpAccessLogger.addHandler(fileHandler);
                 httpAccessLogger.setLevel(Level.INFO);
                 accessLogsEnabled = true;
             } catch (IOException e) {
-                throw new RuntimeException("failed to setup HTTP access log file: " + filePath, e);
+                throw new RuntimeException("failed to setup HTTP access log file: " + filePath.getValue(), e);
             }
         }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/logging/HttpLogManager.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/logging/HttpLogManager.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.api.logging;
+
+import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.stdlib.http.api.logging.formatters.HttpAccessLogFormatter;
+import io.ballerina.stdlib.http.api.logging.formatters.HttpTraceLogFormatter;
+import io.ballerina.stdlib.http.api.logging.formatters.JsonLogFormatter;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+import java.util.logging.SocketHandler;
+
+import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_ACCESS_LOG;
+import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_ACCESS_LOG_ENABLED;
+import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_LOG_CONSOLE;
+import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_LOG_FILE_PATH;
+import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_TRACE_LOG;
+import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_TRACE_LOG_ENABLED;
+import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_TRACE_LOG_HOST;
+import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_TRACE_LOG_PORT;
+
+/**
+ * Java util logging manager for ballerina which overrides the readConfiguration method to replace placeholders
+ * having system or environment variables.
+ *
+ * @since 0.8.0
+ */
+public class HttpLogManager extends LogManager {
+
+    protected Logger httpTraceLogger;
+    protected Logger httpAccessLogger;
+
+    public HttpLogManager(BMap traceLogConfig, BMap accessLogConfig) {
+        super();
+        this.setHttpTraceLogHandler(traceLogConfig);
+        this.setHttpAccessLogHandler(accessLogConfig);
+    }
+
+    /**
+     * Initializes the HTTP trace logger.
+     */
+    public void setHttpTraceLogHandler(BMap traceLogConfig) {
+        if (httpTraceLogger == null) {
+            // keep a reference to prevent this logger from being garbage collected
+            httpTraceLogger = Logger.getLogger(HTTP_TRACE_LOG);
+        }
+        PrintStream stdErr = System.err;
+        boolean traceLogsEnabled = false;
+
+        Boolean consoleLogEnabled = traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE);
+        if (consoleLogEnabled) {
+            ConsoleHandler consoleHandler = new ConsoleHandler();
+            consoleHandler.setFormatter(new HttpTraceLogFormatter());
+            consoleHandler.setLevel(Level.FINEST);
+            httpTraceLogger.addHandler(consoleHandler);
+            traceLogsEnabled = true;
+        }
+
+        String logFilePath = traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH).getValue();
+        if (!logFilePath.trim().isEmpty()) {
+            try {
+                FileHandler fileHandler = new FileHandler(logFilePath, true);
+                fileHandler.setFormatter(new HttpTraceLogFormatter());
+                fileHandler.setLevel(Level.FINEST);
+                httpTraceLogger.addHandler(fileHandler);
+                traceLogsEnabled = true;
+            } catch (IOException e) {
+                throw new RuntimeException("failed to setup HTTP trace log file: " + logFilePath, e);
+            }
+        }
+
+        String host = traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST).getValue();
+        int port = traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT).intValue();
+        if (!host.trim().isEmpty() && port != 0) {
+            try {
+                SocketHandler socketHandler = new SocketHandler(host, port);
+                socketHandler.setFormatter(new JsonLogFormatter());
+                socketHandler.setLevel(Level.FINEST);
+                httpTraceLogger.addHandler(socketHandler);
+                traceLogsEnabled = true;
+            } catch (IOException e) {
+                throw new RuntimeException("failed to connect to " + host + ":" + port, e);
+            }
+        }
+
+        if (traceLogsEnabled) {
+            httpTraceLogger.setLevel(Level.FINEST);
+            System.setProperty(HTTP_TRACE_LOG_ENABLED, "true");
+            stdErr.println("ballerina: HTTP trace log enabled");
+        }
+    }
+
+    /**
+     * Initializes the HTTP access logger.
+     */
+    public void setHttpAccessLogHandler(BMap accessLogConfig) {
+        if (httpAccessLogger == null) {
+            // keep a reference to prevent this logger from being garbage collected
+            httpAccessLogger = Logger.getLogger(HTTP_ACCESS_LOG);
+        }
+        PrintStream stdErr = System.err;
+        boolean accessLogsEnabled = false;
+
+        Boolean consoleLogEnabled = accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE);
+        if (consoleLogEnabled) {
+            ConsoleHandler consoleHandler = new ConsoleHandler();
+            consoleHandler.setFormatter(new HttpAccessLogFormatter());
+            consoleHandler.setLevel(Level.INFO);
+            httpAccessLogger.addHandler(consoleHandler);
+            httpAccessLogger.setLevel(Level.INFO);
+            accessLogsEnabled = true;
+        }
+
+        String filePath = accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH).getValue();
+        if (!filePath.trim().isEmpty()) {
+            try {
+                FileHandler fileHandler = new FileHandler(filePath, true);
+                fileHandler.setFormatter(new HttpAccessLogFormatter());
+                fileHandler.setLevel(Level.INFO);
+                httpAccessLogger.addHandler(fileHandler);
+                httpAccessLogger.setLevel(Level.INFO);
+                accessLogsEnabled = true;
+            } catch (IOException e) {
+                throw new RuntimeException("failed to setup HTTP access log file: " + filePath, e);
+            }
+        }
+
+        if (accessLogsEnabled) {
+            System.setProperty(HTTP_ACCESS_LOG_ENABLED, "true");
+            stdErr.println("ballerina: HTTP access log enabled");
+        }
+    }
+
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/api/logging/HttpLogManager.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/logging/HttpLogManager.java
@@ -53,7 +53,6 @@ public class HttpLogManager extends LogManager {
     protected Logger httpAccessLogger;
 
     public HttpLogManager(BMap traceLogConfig, BMap accessLogConfig) {
-        super();
         this.setHttpTraceLogHandler(traceLogConfig);
         this.setHttpAccessLogHandler(accessLogConfig);
     }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/logging/formatters/HttpAccessLogFormatter.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/logging/formatters/HttpAccessLogFormatter.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.stdlib.http.api.logging.formatters;
+
+import io.ballerina.stdlib.http.api.logging.HttpLogManager;
+
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+
+/**
+ * A custom log formatter for formatting the HTTP access logs.
+ *
+ * @since 0.965
+ */
+public class HttpAccessLogFormatter extends Formatter {
+
+    private static final String format = HttpLogManager.getLogManager().getProperty(
+            HttpAccessLogFormatter.class.getCanonicalName() + ".format");
+
+    @Override
+    public String format(LogRecord record) {
+        return String.format(format, record.getMessage());
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/api/logging/formatters/HttpTraceLogFormatter.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/logging/formatters/HttpTraceLogFormatter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.api.logging.formatters;
+
+import io.ballerina.stdlib.http.api.logging.HttpLogManager;
+import io.ballerina.stdlib.http.api.logging.util.LogLevelMapper;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Date;
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+
+/**
+ * A custom log formatter for formatting HTTP trace log files.
+ *
+ * @since 0.93
+ */
+public class HttpTraceLogFormatter extends Formatter {
+
+    private static String format = HttpLogManager.getLogManager().getProperty(
+            HttpTraceLogFormatter.class.getCanonicalName() + ".format");
+
+    @Override
+    public String format(LogRecord record) {
+        String source = record.getLoggerName();
+        String ex = "";
+
+        if (record.getThrown() != null) {
+            StringWriter stringWriter = new StringWriter();
+            stringWriter.append('\n');
+            record.getThrown().printStackTrace(new PrintWriter(stringWriter));
+            ex = stringWriter.toString();
+        }
+
+        return String.format(format,
+                new Date(record.getMillis()),
+                LogLevelMapper.getBallerinaLogLevel(record.getLevel()),
+                source,
+                record.getMessage(),
+                ex);
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/api/logging/formatters/JsonLogFormatter.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/logging/formatters/JsonLogFormatter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.api.logging.formatters;
+
+import com.google.gson.Gson;
+
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+
+/**
+ * JSON log formatter for formatting HTTP trace log files.
+ *
+ * @since 0.970.0
+ */
+public class JsonLogFormatter extends Formatter {
+
+    @Override
+    public String format(LogRecord record) {
+        return new Gson().toJson(record) + System.getProperty("line.separator");
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/api/logging/util/LogLevel.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/logging/util/LogLevel.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.api.logging.util;
+
+/**
+ * This class defines constants for log levels.
+ *
+ * @since 0.95.0
+ */
+public enum LogLevel {
+
+    OFF(Integer.MAX_VALUE), ERROR(1000), WARN(900), INFO(800), DEBUG(700), TRACE(600), ALL(Integer.MIN_VALUE);
+
+    private int levelValue;
+
+    LogLevel(int levelValue) {
+        this.levelValue = levelValue;
+    }
+
+    public int value() {
+        return levelValue;
+    }
+
+    public static LogLevel toLogLevel(String logLevel) {
+        LogLevel level;
+        try {
+            level = LogLevel.valueOf(logLevel);
+        } catch (IllegalArgumentException e) {
+            throw new RuntimeException("invalid log level: " + logLevel);
+        }
+        return level;
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/api/logging/util/LogLevelMapper.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/logging/util/LogLevelMapper.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.stdlib.http.api.logging.util;
+
+import java.util.logging.Level;
+
+/**
+ * A mapper class to map log levels from JDK logging to Ballerina log levels.
+ *
+ * @since 0.89
+ */
+public class LogLevelMapper {
+
+    public static String getBallerinaLogLevel(Level level) {
+        switch (level.getName()) {
+            case "SEVERE":
+                return "ERROR";
+            case "WARNING":
+                return "WARN";
+            case "INFO":
+                return "INFO";
+            case "CONFIG":
+                return "INFO";
+            case "FINE":
+                return "DEBUG";
+            case "FINER":
+                return "DEBUG";
+            case "FINEST":
+                return "TRACE";
+            default:
+                return "<UNDEFINED>";
+        }
+    }
+
+    public static Level getLoggerLevel(LogLevel level) {
+        switch (level) {
+            case OFF:
+                return Level.OFF;
+            case ERROR:
+                return Level.SEVERE;
+            case WARN:
+                return Level.WARNING;
+            case INFO:
+                return Level.INFO;
+            case DEBUG:
+                return Level.FINER;
+            case TRACE:
+                return Level.FINEST;
+            case ALL:
+                return Level.ALL;
+        }
+        return Level.INFO;
+    }
+}

--- a/native/src/main/java/module-info.java
+++ b/native/src/main/java/module-info.java
@@ -29,6 +29,8 @@ module io.ballerina.stdlib.http {
     requires java.xml.bind;
     requires java.management;
     requires org.slf4j;
+    requires java.logging;
+    requires gson;
     exports io.ballerina.stdlib.http.api;
     exports io.ballerina.stdlib.http.transport.contract.websocket;
     exports io.ballerina.stdlib.http.transport.contract;

--- a/native/src/main/resources/logging.properties
+++ b/native/src/main/resources/logging.properties
@@ -1,0 +1,19 @@
+####################### HANDLERS #######################
+# Log formatter for HTTP trace logs
+org.ballerinalang.net.http.logging.formatters.HttpTraceLogFormatter.format=[%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS,%1$tL] %2$-5s {%3$s} - %4$s %5$s %n
+
+# Log formatter for HTTP access logs
+org.ballerinalang.net.http.logging.formatters.HttpAccessLogFormatter.format=%1$s %n
+
+####################### LOGGERS #######################
+# Root logger
+handlers=java.util.logging.ConsoleHandler
+.level=OFF
+
+# HTTP tracing logger - This is turned off by default, to turn on, set level to 'FINE' or lower
+http.tracelog.level=OFF
+http.tracelog.useParentHandlers=false
+
+# HTTP access logger
+http.accesslog.level=OFF
+http.accesslog.useParentHandlers=false

--- a/native/src/main/resources/logging.properties
+++ b/native/src/main/resources/logging.properties
@@ -1,9 +1,9 @@
 ####################### HANDLERS #######################
 # Log formatter for HTTP trace logs
-org.ballerinalang.net.http.logging.formatters.HttpTraceLogFormatter.format=[%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS,%1$tL] %2$-5s {%3$s} - %4$s %5$s %n
+io.ballerina.stdlib.http.api.logging.formatters.HttpTraceLogFormatter.format=[%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS,%1$tL] %2$-5s {%3$s} - %4$s %5$s %n
 
 # Log formatter for HTTP access logs
-org.ballerinalang.net.http.logging.formatters.HttpAccessLogFormatter.format=%1$s %n
+io.ballerina.stdlib.http.api.logging.formatters.HttpAccessLogFormatter.format=%1$s %n
 
 ####################### LOGGERS #######################
 # Root logger

--- a/native/src/test/java/io/ballerina/stdlib/http/api/logging/HttpLogManagerTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/api/logging/HttpLogManagerTest.java
@@ -55,7 +55,6 @@ public class HttpLogManagerTest {
         tempLogTestFile = File.createTempFile("logTestFile", ".txt");
     }
 
-
     @Test
     public void testHttpLogManagerWithTraceLogConsole() {
         BMap traceLogConfig = mock(BMap.class);

--- a/native/src/test/java/io/ballerina/stdlib/http/api/logging/HttpLogManagerTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/api/logging/HttpLogManagerTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.api.logging;
+
+import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BString;
+import io.ballerina.stdlib.http.api.logging.formatters.HttpAccessLogFormatter;
+import io.ballerina.stdlib.http.api.logging.formatters.HttpTraceLogFormatter;
+import io.ballerina.stdlib.http.api.logging.formatters.JsonLogFormatter;
+import io.ballerina.stdlib.http.transport.util.TestUtil;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+import java.util.logging.ConsoleHandler;
+import java.util.logging.FileHandler;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.SocketHandler;
+
+import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_LOG_CONSOLE;
+import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_LOG_FILE_PATH;
+import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_TRACE_LOG_HOST;
+import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_TRACE_LOG_PORT;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * A unit test class for Http module HttpLogManager class functions.
+ */
+public class HttpLogManagerTest {
+
+    @Test
+    public void testHttpLogManagerWithTraceLogConsole() {
+        BMap traceLogConfig = mock(BMap.class);
+        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(true);
+        BString traceFilePath = mock(BString.class);
+        BString host = mock(BString.class);
+        BString accessFilePath = mock(BString.class);
+        long port = 0;
+        when(traceFilePath.getValue()).thenReturn("");
+        when(accessFilePath.getValue()).thenReturn("");
+        when(host.getValue()).thenReturn("testHost");
+        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+
+        BMap accessLogConfig = mock(BMap.class);
+        when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
+
+        HttpLogManager httpLogManager = new HttpLogManager(traceLogConfig, accessLogConfig);
+        Handler[] handlers = httpLogManager.httpTraceLogger.getHandlers();
+        Assert.assertTrue(handlers.length > 0);
+        Handler handler = handlers[handlers.length - 1];
+        Assert.assertTrue(handler instanceof ConsoleHandler);
+        Assert.assertTrue(handler.getFormatter() instanceof HttpTraceLogFormatter);
+        Assert.assertEquals(Level.FINEST, handler.getLevel());
+    }
+
+    @Test
+    public void testHttpLogManagerWithTraceLogFile() {
+        BMap traceLogConfig = mock(BMap.class);
+        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        BString traceFilePath = mock(BString.class);
+        BString host = mock(BString.class);
+        BString accessFilePath = mock(BString.class);
+        String path = "/simple-test-config/logTestFile.txt";
+        long port = 80;
+        when(traceFilePath.getValue()).thenReturn(TestUtil.getAbsolutePath(path));
+        when(accessFilePath.getValue()).thenReturn("");
+        when(host.getValue()).thenReturn("");
+        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+
+        BMap accessLogConfig = mock(BMap.class);
+        when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
+
+        HttpLogManager httpLogManager = new HttpLogManager(traceLogConfig, accessLogConfig);
+        Handler[] handlers = httpLogManager.httpTraceLogger.getHandlers();
+        Assert.assertTrue(handlers.length > 0);
+        Handler handler = handlers[handlers.length - 1];
+        Assert.assertTrue(handler instanceof FileHandler);
+        Assert.assertTrue(handler.getFormatter() instanceof HttpTraceLogFormatter);
+        Assert.assertEquals(Level.FINEST, handler.getLevel());
+    }
+
+    @Test
+    public void testHttpLogManagerWithTraceLogSocket() {
+        BMap traceLogConfig = mock(BMap.class);
+        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        BString traceFilePath = mock(BString.class);
+        BString host = mock(BString.class);
+        BString accessFilePath = mock(BString.class);
+        long port = 80;
+        when(traceFilePath.getValue()).thenReturn("");
+        when(accessFilePath.getValue()).thenReturn("");
+        when(host.getValue()).thenReturn("echo.websocket.org");
+        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+
+        BMap accessLogConfig = mock(BMap.class);
+        when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
+
+        HttpLogManager httpLogManager = new HttpLogManager(traceLogConfig, accessLogConfig);
+        Handler[] handlers = httpLogManager.httpTraceLogger.getHandlers();
+        Assert.assertTrue(handlers.length > 0);
+        Handler handler = handlers[handlers.length - 1];
+        Assert.assertTrue(handler instanceof SocketHandler);
+        Assert.assertTrue(handler.getFormatter() instanceof JsonLogFormatter);
+        Assert.assertEquals(Level.FINEST, handler.getLevel());
+    }
+
+    @Test
+    public void testHttpLogManagerWithAccessLogConsole() {
+        BMap traceLogConfig = mock(BMap.class);
+        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        BString traceFilePath = mock(BString.class);
+        BString host = mock(BString.class);
+        BString accessFilePath = mock(BString.class);
+        long port = 0;
+        when(traceFilePath.getValue()).thenReturn("");
+        when(accessFilePath.getValue()).thenReturn("");
+        when(host.getValue()).thenReturn("");
+        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+
+        BMap accessLogConfig = mock(BMap.class);
+        when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(true);
+        when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
+
+        HttpLogManager httpLogManager = new HttpLogManager(traceLogConfig, accessLogConfig);
+        Assert.assertEquals(httpLogManager.httpAccessLogger.getLevel(), Level.INFO);
+        Handler[] handlers = httpLogManager.httpAccessLogger.getHandlers();
+        Assert.assertTrue(handlers.length > 0);
+        Handler handler = handlers[handlers.length - 1];
+        Assert.assertTrue(handler instanceof ConsoleHandler);
+        Assert.assertTrue(handler.getFormatter() instanceof HttpAccessLogFormatter);
+        Assert.assertEquals(Level.INFO, handler.getLevel());
+    }
+
+    @Test
+    public void testHttpLogManagerWithAccessLogFile() {
+        BMap traceLogConfig = mock(BMap.class);
+        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        BString traceFilePath = mock(BString.class);
+        BString host = mock(BString.class);
+        BString accessFilePath = mock(BString.class);
+        String path = "/simple-test-config/logTestFile.txt";
+        long port = 0;
+        when(traceFilePath.getValue()).thenReturn("");
+        when(accessFilePath.getValue()).thenReturn(TestUtil.getAbsolutePath(path));
+        when(host.getValue()).thenReturn("");
+        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+
+        BMap accessLogConfig = mock(BMap.class);
+        when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
+
+        HttpLogManager httpLogManager = new HttpLogManager(traceLogConfig, accessLogConfig);
+        Assert.assertEquals(httpLogManager.httpAccessLogger.getLevel(), Level.INFO);
+        Handler[] handlers = httpLogManager.httpAccessLogger.getHandlers();
+        Assert.assertTrue(handlers.length > 0);
+        Handler handler = handlers[handlers.length - 1];
+        Assert.assertTrue(handler instanceof FileHandler);
+        Assert.assertTrue(handler.getFormatter() instanceof HttpAccessLogFormatter);
+        Assert.assertEquals(Level.INFO, handler.getLevel());
+    }
+
+    @Test (expectedExceptions = RuntimeException.class,
+            expectedExceptionsMessageRegExp = "failed to setup HTTP trace log file: /test/logTestFile.txt")
+    public void testHttpLogManagerWithInvalidTraceLogFilePath() {
+        BMap traceLogConfig = mock(BMap.class);
+        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        BString traceFilePath = mock(BString.class);
+        BString host = mock(BString.class);
+        BString accessFilePath = mock(BString.class);
+        String path = "/test/logTestFile.txt";
+        long port = 0;
+        when(traceFilePath.getValue()).thenReturn(path);
+        when(accessFilePath.getValue()).thenReturn("");
+        when(host.getValue()).thenReturn("");
+        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+
+        BMap accessLogConfig = mock(BMap.class);
+        when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
+
+        HttpLogManager httpLogManager = new HttpLogManager(traceLogConfig, accessLogConfig);
+    }
+
+    @Test (expectedExceptions = RuntimeException.class,
+            expectedExceptionsMessageRegExp = "failed to connect to testHost:8080")
+    public void testHttpLogManagerWithNonExistingSocket() {
+        BMap traceLogConfig = mock(BMap.class);
+        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        BString traceFilePath = mock(BString.class);
+        BString host = mock(BString.class);
+        BString accessFilePath = mock(BString.class);
+        long port = 8080;
+        when(traceFilePath.getValue()).thenReturn("");
+        when(accessFilePath.getValue()).thenReturn("");
+        when(host.getValue()).thenReturn("testHost");
+        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+
+        BMap accessLogConfig = mock(BMap.class);
+        when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
+
+        HttpLogManager httpLogManager = new HttpLogManager(traceLogConfig, accessLogConfig);
+    }
+
+    @Test (expectedExceptions = RuntimeException.class,
+            expectedExceptionsMessageRegExp = "failed to setup HTTP access log file: /test/logTestFile.txt")
+    public void testHttpLogManagerWithInvalidAccessLogPath() {
+        BMap traceLogConfig = mock(BMap.class);
+        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        BString traceFilePath = mock(BString.class);
+        BString host = mock(BString.class);
+        BString accessFilePath = mock(BString.class);
+        String path = "/test/logTestFile.txt";
+        long port = 0;
+        when(traceFilePath.getValue()).thenReturn("");
+        when(accessFilePath.getValue()).thenReturn(path);
+        when(host.getValue()).thenReturn("");
+        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+
+        BMap accessLogConfig = mock(BMap.class);
+        when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
+
+        HttpLogManager httpLogManager = new HttpLogManager(traceLogConfig, accessLogConfig);
+    }
+
+}

--- a/native/src/test/java/io/ballerina/stdlib/http/api/logging/HttpLogManagerTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/api/logging/HttpLogManagerTest.java
@@ -23,10 +23,13 @@ import io.ballerina.runtime.api.values.BString;
 import io.ballerina.stdlib.http.api.logging.formatters.HttpAccessLogFormatter;
 import io.ballerina.stdlib.http.api.logging.formatters.HttpTraceLogFormatter;
 import io.ballerina.stdlib.http.api.logging.formatters.JsonLogFormatter;
-import io.ballerina.stdlib.http.transport.util.TestUtil;
 import org.junit.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.FileHandler;
 import java.util.logging.Handler;
@@ -44,6 +47,14 @@ import static org.mockito.Mockito.when;
  * A unit test class for Http module HttpLogManager class functions.
  */
 public class HttpLogManagerTest {
+
+    File tempLogTestFile;
+
+    @BeforeClass
+    public void setup() throws IOException {
+        tempLogTestFile = File.createTempFile("logTestFile", ".txt");
+    }
+
 
     @Test
     public void testHttpLogManagerWithTraceLogConsole() {
@@ -80,9 +91,9 @@ public class HttpLogManagerTest {
         BString traceFilePath = mock(BString.class);
         BString host = mock(BString.class);
         BString accessFilePath = mock(BString.class);
-        String path = "/simple-test-config/logTestFile.txt";
+        String path = tempLogTestFile.getPath();
         long port = 80;
-        when(traceFilePath.getValue()).thenReturn(TestUtil.getAbsolutePath(path));
+        when(traceFilePath.getValue()).thenReturn(path);
         when(accessFilePath.getValue()).thenReturn("");
         when(host.getValue()).thenReturn("");
         when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
@@ -166,10 +177,10 @@ public class HttpLogManagerTest {
         BString traceFilePath = mock(BString.class);
         BString host = mock(BString.class);
         BString accessFilePath = mock(BString.class);
-        String path = "/simple-test-config/logTestFile.txt";
+        String path = tempLogTestFile.getPath();
         long port = 0;
         when(traceFilePath.getValue()).thenReturn("");
-        when(accessFilePath.getValue()).thenReturn(TestUtil.getAbsolutePath(path));
+        when(accessFilePath.getValue()).thenReturn(path);
         when(host.getValue()).thenReturn("");
         when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
         when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
@@ -258,6 +269,11 @@ public class HttpLogManagerTest {
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
         HttpLogManager httpLogManager = new HttpLogManager(traceLogConfig, accessLogConfig);
+    }
+
+    @AfterClass
+    public void cleanUp() throws IOException {
+        tempLogTestFile.deleteOnExit();
     }
 
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/api/logging/util/LogUtilTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/api/logging/util/LogUtilTest.java
@@ -63,4 +63,45 @@ public class LogUtilTest {
         Assert.assertEquals(LogLevelMapper.getLoggerLevel(LogLevel.ALL), Level.ALL);
     }
 
+    @Test
+    public void testLogLevelGetValue() {
+        LogLevel logLevel = LogLevel.ALL;
+        Assert.assertEquals(logLevel.value(), Integer.MIN_VALUE);
+        logLevel = LogLevel.TRACE;
+        Assert.assertEquals(logLevel.value(), 600);
+        logLevel = LogLevel.DEBUG;
+        Assert.assertEquals(logLevel.value(), 700);
+        logLevel = LogLevel.INFO;
+        Assert.assertEquals(logLevel.value(), 800);
+        logLevel = LogLevel.WARN;
+        Assert.assertEquals(logLevel.value(), 900);
+        logLevel = LogLevel.ERROR;
+        Assert.assertEquals(logLevel.value(), 1000);
+        logLevel = LogLevel.OFF;
+        Assert.assertEquals(logLevel.value(), Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void testToLogLevel() {
+        LogLevel logLevel = LogLevel.toLogLevel("ALL");
+        Assert.assertEquals(logLevel.value(), Integer.MIN_VALUE);
+        logLevel = LogLevel.toLogLevel("TRACE");
+        Assert.assertEquals(logLevel.value(), 600);
+        logLevel = LogLevel.toLogLevel("DEBUG");
+        Assert.assertEquals(logLevel.value(), 700);
+        logLevel = LogLevel.toLogLevel("INFO");
+        Assert.assertEquals(logLevel.value(), 800);
+        logLevel = LogLevel.toLogLevel("WARN");
+        Assert.assertEquals(logLevel.value(), 900);
+        logLevel = LogLevel.toLogLevel("ERROR");
+        Assert.assertEquals(logLevel.value(), 1000);
+        logLevel = LogLevel.toLogLevel("OFF");
+        Assert.assertEquals(logLevel.value(), Integer.MAX_VALUE);
+    }
+
+    @Test (expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "invalid log level: TEST")
+    public void testToLogLevelWithInvalidLogLevel() {
+        LogLevel level = LogLevel.toLogLevel("TEST");
+    }
+
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/api/logging/util/LogUtilTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/api/logging/util/LogUtilTest.java
@@ -22,9 +22,13 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.logging.Level;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * A unit test class for Http module LogLevelMapper class functions.
+ */
 public class LogUtilTest {
 
     @Test

--- a/native/src/test/java/io/ballerina/stdlib/http/api/logging/util/LogUtilTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/api/logging/util/LogUtilTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.api.logging.util;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.logging.Level;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LogUtilTest {
+
+    @Test
+    public void testLogLevelMapperGetBLogLevel() {
+        Level level = mock(Level.class);
+        when(level.getName()).thenReturn("SEVERE");
+        Assert.assertEquals(LogLevelMapper.getBallerinaLogLevel(level), "ERROR");
+        when(level.getName()).thenReturn("WARNING");
+        Assert.assertEquals(LogLevelMapper.getBallerinaLogLevel(level), "WARN");
+        when(level.getName()).thenReturn("INFO");
+        Assert.assertEquals(LogLevelMapper.getBallerinaLogLevel(level), "INFO");
+        when(level.getName()).thenReturn("CONFIG");
+        Assert.assertEquals(LogLevelMapper.getBallerinaLogLevel(level), "INFO");
+        when(level.getName()).thenReturn("FINE");
+        Assert.assertEquals(LogLevelMapper.getBallerinaLogLevel(level), "DEBUG");
+        when(level.getName()).thenReturn("FINER");
+        Assert.assertEquals(LogLevelMapper.getBallerinaLogLevel(level), "DEBUG");
+        when(level.getName()).thenReturn("FINEST");
+        Assert.assertEquals(LogLevelMapper.getBallerinaLogLevel(level), "TRACE");
+        when(level.getName()).thenReturn("TEST");
+        Assert.assertEquals(LogLevelMapper.getBallerinaLogLevel(level), "<UNDEFINED>");
+    }
+
+    @Test
+    public void testLogLevelMapperGetLoggerLevel() {
+        Assert.assertEquals(LogLevelMapper.getLoggerLevel(LogLevel.OFF), Level.OFF);
+        Assert.assertEquals(LogLevelMapper.getLoggerLevel(LogLevel.ERROR), Level.SEVERE);
+        Assert.assertEquals(LogLevelMapper.getLoggerLevel(LogLevel.WARN), Level.WARNING);
+        Assert.assertEquals(LogLevelMapper.getLoggerLevel(LogLevel.INFO), Level.INFO);
+        Assert.assertEquals(LogLevelMapper.getLoggerLevel(LogLevel.DEBUG), Level.FINER);
+        Assert.assertEquals(LogLevelMapper.getLoggerLevel(LogLevel.TRACE), Level.FINEST);
+        Assert.assertEquals(LogLevelMapper.getLoggerLevel(LogLevel.ALL), Level.ALL);
+    }
+
+}

--- a/native/src/test/resources/testng.xml
+++ b/native/src/test/resources/testng.xml
@@ -213,6 +213,7 @@
             <class name="io.ballerina.stdlib.http.api.ExceptionTest"/>
             <class name="io.ballerina.stdlib.http.api.HttpServiceTest"/>
             <class name="io.ballerina.stdlib.http.api.logging.HttpLogManagerTest"/>
+            <class name="io.ballerina.stdlib.http.api.logging.util.LogUtilTest"/>
         </classes>
     </test>
 </suite>

--- a/native/src/test/resources/testng.xml
+++ b/native/src/test/resources/testng.xml
@@ -212,6 +212,7 @@
         <classes>
             <class name="io.ballerina.stdlib.http.api.ExceptionTest"/>
             <class name="io.ballerina.stdlib.http.api.HttpServiceTest"/>
+            <class name="io.ballerina.stdlib.http.api.logging.HttpLogManagerTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose

Move HTTP trace and access log implementation from runtime and enable trace and access log support inside HTTP module

Fixes [`ballerina-platform/ballerina-standard-library/issues/1073`](https://github.com/ballerina-platform/ballerina-standard-library/issues/1073)

## Examples

The HTTP access logs and trace logs are **disabled as default**. To enable, the configurations can be set by the following `config.toml` file:
```toml
[ballerina.http.traceLogConfig]
# Enable printing trace logs in console
console = true              # Default is false
# Specify the file path to save the trace logs  
path = "testTraceLog.txt"   # Optional
# Specify the hostname and port of a socket service to publish the trace logs
host = "localhost"          # Optional
port = 8080                 # Optional

[ballerina.http.accessLogConfig]
# Enable printing access logs in console
console = true              # Default is false
# Specify the file path to save the access logs  
path = "testAccessLog.txt"  # Optional
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests