### PR TITLE
Enable traceLogConsole using CLI parameter

### DIFF
--- a/ballerina/http_log_manager.bal
+++ b/ballerina/http_log_manager.bal
@@ -16,13 +16,16 @@
 
 import ballerina/jballerina.java;
 
+// TODO: Remove this once the command line argument support is given for configurable record
+configurable boolean traceLogConsole = false;
+
 # Represents HTTP trace log configuration.
 #
 # + console - Boolean value to enable or disable console trace logs
 # + path - Optional file path to store trace logs
 # + host - Optional socket hostname to publish the trace logs
 # + port - Optional socket port to publish the trace logs
-public type TraceLogConfiguration record {|
+public type TraceLogConfigurationAdvanced record {|
     boolean console = false;
     string path?;
     string host?;
@@ -38,10 +41,10 @@ public type AccessLogConfiguration record {|
     string path?;
 |};
 
-configurable TraceLogConfiguration & readonly traceLogConfig = {};
+configurable TraceLogConfigurationAdvanced & readonly traceLogConfigAdvanced = {};
 configurable AccessLogConfiguration & readonly accessLogConfig = {};
 
-isolated function initializeHttpLogs(TraceLogConfiguration traceLogConfig, AccessLogConfiguration accessLogConfig)
+isolated function initializeHttpLogs(boolean traceLogConsole, TraceLogConfigurationAdvanced traceLogConfigAdvanced, AccessLogConfiguration accessLogConfig)
 returns handle = @java:Constructor {
     'class: "io.ballerina.stdlib.http.api.logging.HttpLogManager"
 } external;

--- a/ballerina/http_log_manager.bal
+++ b/ballerina/http_log_manager.bal
@@ -41,8 +41,8 @@ public type AccessLogConfiguration record {|
     string path?;
 |};
 
-configurable TraceLogAdvancedConfiguration & readonly traceLogAdvancedConfig = {};
-configurable AccessLogConfiguration & readonly accessLogConfig = {};
+configurable TraceLogAdvancedConfiguration traceLogAdvancedConfig = {};
+configurable AccessLogConfiguration accessLogConfig = {};
 
 isolated function initializeHttpLogs(boolean traceLogConsole, TraceLogAdvancedConfiguration traceLogAdvancedConfig,
 AccessLogConfiguration accessLogConfig) returns handle = @java:Constructor {

--- a/ballerina/http_log_manager.bal
+++ b/ballerina/http_log_manager.bal
@@ -25,7 +25,7 @@ configurable boolean traceLogConsole = false;
 # + path - Optional file path to store trace logs
 # + host - Optional socket hostname to publish the trace logs
 # + port - Optional socket port to publish the trace logs
-public type TraceLogConfigurationAdvanced record {|
+public type TraceLogAdvancedConfiguration record {|
     boolean console = false;
     string path?;
     string host?;
@@ -41,10 +41,10 @@ public type AccessLogConfiguration record {|
     string path?;
 |};
 
-configurable TraceLogConfigurationAdvanced & readonly traceLogConfigAdvanced = {};
+configurable TraceLogAdvancedConfiguration & readonly traceLogAdvancedConfig = {};
 configurable AccessLogConfiguration & readonly accessLogConfig = {};
 
-isolated function initializeHttpLogs(boolean traceLogConsole, TraceLogConfigurationAdvanced traceLogConfigAdvanced, AccessLogConfiguration accessLogConfig)
-returns handle = @java:Constructor {
+isolated function initializeHttpLogs(boolean traceLogConsole, TraceLogAdvancedConfiguration traceLogAdvancedConfig,
+AccessLogConfiguration accessLogConfig) returns handle = @java:Constructor {
     'class: "io.ballerina.stdlib.http.api.logging.HttpLogManager"
 } external;

--- a/ballerina/init.bal
+++ b/ballerina/init.bal
@@ -18,7 +18,7 @@ import ballerina/jballerina.java;
 
 function init() {
     setModule();
-    _ = initializeHttpLogs(traceLogConfig, accessLogConfig);
+    _ = initializeHttpLogs(traceLogConsole, traceLogConfigAdvanced, accessLogConfig);
 }
 
 function setModule() = @java:Method {

--- a/ballerina/init.bal
+++ b/ballerina/init.bal
@@ -18,7 +18,7 @@ import ballerina/jballerina.java;
 
 function init() {
     setModule();
-    _ = initializeHttpLogs(traceLogConsole, traceLogConfigAdvanced, accessLogConfig);
+    _ = initializeHttpLogs(traceLogConsole, traceLogAdvancedConfig, accessLogConfig);
 }
 
 function setModule() = @java:Method {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/logging/HttpLogManager.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/logging/HttpLogManager.java
@@ -53,15 +53,15 @@ public class HttpLogManager extends LogManager {
     protected Logger httpTraceLogger;
     protected Logger httpAccessLogger;
 
-    public HttpLogManager(BMap traceLogConfig, BMap accessLogConfig) {
-        this.setHttpTraceLogHandler(traceLogConfig);
+    public HttpLogManager(boolean traceLogConsole, BMap traceLogConfigAdvanced, BMap accessLogConfig) {
+        this.setHttpTraceLogHandler(traceLogConsole, traceLogConfigAdvanced);
         this.setHttpAccessLogHandler(accessLogConfig);
     }
 
     /**
      * Initializes the HTTP trace logger.
      */
-    public void setHttpTraceLogHandler(BMap traceLogConfig) {
+    public void setHttpTraceLogHandler(boolean traceLogConsole, BMap traceLogConfigAdvanced) {
         if (httpTraceLogger == null) {
             // keep a reference to prevent this logger from being garbage collected
             httpTraceLogger = Logger.getLogger(HTTP_TRACE_LOG);
@@ -69,8 +69,8 @@ public class HttpLogManager extends LogManager {
         PrintStream stdErr = System.err;
         boolean traceLogsEnabled = false;
 
-        Boolean consoleLogEnabled = traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE);
-        if (consoleLogEnabled) {
+        Boolean consoleLogEnabled = traceLogConfigAdvanced.getBooleanValue(HTTP_LOG_CONSOLE);
+        if (traceLogConsole || consoleLogEnabled) {
             ConsoleHandler consoleHandler = new ConsoleHandler();
             consoleHandler.setFormatter(new HttpTraceLogFormatter());
             consoleHandler.setLevel(Level.FINEST);
@@ -78,7 +78,7 @@ public class HttpLogManager extends LogManager {
             traceLogsEnabled = true;
         }
 
-        BString logFilePath = traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH);
+        BString logFilePath = traceLogConfigAdvanced.getStringValue(HTTP_LOG_FILE_PATH);
         if (logFilePath != null && !logFilePath.getValue().trim().isEmpty()) {
             try {
                 FileHandler fileHandler = new FileHandler(logFilePath.getValue(), true);
@@ -91,8 +91,8 @@ public class HttpLogManager extends LogManager {
             }
         }
 
-        BString host = traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST);
-        Long port = traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT);
+        BString host = traceLogConfigAdvanced.getStringValue(HTTP_TRACE_LOG_HOST);
+        Long port = traceLogConfigAdvanced.getIntValue(HTTP_TRACE_LOG_PORT);
         if ((host != null && !host.getValue().trim().isEmpty()) && (port != null && port != 0)) {
             try {
                 SocketHandler socketHandler = new SocketHandler(host.getValue(), port.intValue());

--- a/native/src/main/java/io/ballerina/stdlib/http/api/logging/HttpLogManager.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/logging/HttpLogManager.java
@@ -53,15 +53,15 @@ public class HttpLogManager extends LogManager {
     protected Logger httpTraceLogger;
     protected Logger httpAccessLogger;
 
-    public HttpLogManager(boolean traceLogConsole, BMap traceLogConfigAdvanced, BMap accessLogConfig) {
-        this.setHttpTraceLogHandler(traceLogConsole, traceLogConfigAdvanced);
+    public HttpLogManager(boolean traceLogConsole, BMap traceLogAdvancedConfig, BMap accessLogConfig) {
+        this.setHttpTraceLogHandler(traceLogConsole, traceLogAdvancedConfig);
         this.setHttpAccessLogHandler(accessLogConfig);
     }
 
     /**
      * Initializes the HTTP trace logger.
      */
-    public void setHttpTraceLogHandler(boolean traceLogConsole, BMap traceLogConfigAdvanced) {
+    public void setHttpTraceLogHandler(boolean traceLogConsole, BMap traceLogAdvancedConfig) {
         if (httpTraceLogger == null) {
             // keep a reference to prevent this logger from being garbage collected
             httpTraceLogger = Logger.getLogger(HTTP_TRACE_LOG);
@@ -69,7 +69,7 @@ public class HttpLogManager extends LogManager {
         PrintStream stdErr = System.err;
         boolean traceLogsEnabled = false;
 
-        Boolean consoleLogEnabled = traceLogConfigAdvanced.getBooleanValue(HTTP_LOG_CONSOLE);
+        Boolean consoleLogEnabled = traceLogAdvancedConfig.getBooleanValue(HTTP_LOG_CONSOLE);
         if (traceLogConsole || consoleLogEnabled) {
             ConsoleHandler consoleHandler = new ConsoleHandler();
             consoleHandler.setFormatter(new HttpTraceLogFormatter());
@@ -78,7 +78,7 @@ public class HttpLogManager extends LogManager {
             traceLogsEnabled = true;
         }
 
-        BString logFilePath = traceLogConfigAdvanced.getStringValue(HTTP_LOG_FILE_PATH);
+        BString logFilePath = traceLogAdvancedConfig.getStringValue(HTTP_LOG_FILE_PATH);
         if (logFilePath != null && !logFilePath.getValue().trim().isEmpty()) {
             try {
                 FileHandler fileHandler = new FileHandler(logFilePath.getValue(), true);
@@ -91,8 +91,8 @@ public class HttpLogManager extends LogManager {
             }
         }
 
-        BString host = traceLogConfigAdvanced.getStringValue(HTTP_TRACE_LOG_HOST);
-        Long port = traceLogConfigAdvanced.getIntValue(HTTP_TRACE_LOG_PORT);
+        BString host = traceLogAdvancedConfig.getStringValue(HTTP_TRACE_LOG_HOST);
+        Long port = traceLogAdvancedConfig.getIntValue(HTTP_TRACE_LOG_PORT);
         if ((host != null && !host.getValue().trim().isEmpty()) && (port != null && port != 0)) {
             try {
                 SocketHandler socketHandler = new SocketHandler(host.getValue(), port.intValue());

--- a/native/src/test/java/io/ballerina/stdlib/http/api/logging/HttpLogManagerTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/api/logging/HttpLogManagerTest.java
@@ -59,8 +59,8 @@ public class HttpLogManagerTest {
 
     @Test
     public void testHttpLogManagerWithTraceLogConsole1() {
-        BMap traceLogConfig = mock(BMap.class);
-        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(true);
+        BMap traceLogAdvancedConfig = mock(BMap.class);
+        when(traceLogAdvancedConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(true);
         BString traceFilePath = mock(BString.class);
         BString host = mock(BString.class);
         BString accessFilePath = mock(BString.class);
@@ -68,15 +68,15 @@ public class HttpLogManagerTest {
         when(traceFilePath.getValue()).thenReturn("");
         when(accessFilePath.getValue()).thenReturn("");
         when(host.getValue()).thenReturn("testHost");
-        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
-        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
-        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogAdvancedConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
 
         BMap accessLogConfig = mock(BMap.class);
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogAdvancedConfig, accessLogConfig);
         Handler[] handlers = httpLogManager.httpTraceLogger.getHandlers();
         Assert.assertTrue(handlers.length > 0);
         Handler handler = handlers[handlers.length - 1];
@@ -87,8 +87,8 @@ public class HttpLogManagerTest {
 
     @Test
     public void testHttpLogManagerWithTraceLogConsole2() {
-        BMap traceLogConfig = mock(BMap.class);
-        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        BMap traceLogAdvancedConfig = mock(BMap.class);
+        when(traceLogAdvancedConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         BString traceFilePath = mock(BString.class);
         BString host = mock(BString.class);
         BString accessFilePath = mock(BString.class);
@@ -96,15 +96,15 @@ public class HttpLogManagerTest {
         when(traceFilePath.getValue()).thenReturn("");
         when(accessFilePath.getValue()).thenReturn("");
         when(host.getValue()).thenReturn("testHost");
-        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
-        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
-        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogAdvancedConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
 
         BMap accessLogConfig = mock(BMap.class);
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(true, traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(true, traceLogAdvancedConfig, accessLogConfig);
         Handler[] handlers = httpLogManager.httpTraceLogger.getHandlers();
         Assert.assertTrue(handlers.length > 0);
         Handler handler = handlers[handlers.length - 1];
@@ -115,8 +115,8 @@ public class HttpLogManagerTest {
 
     @Test
     public void testHttpLogManagerWithTraceLogConsole3() {
-        BMap traceLogConfig = mock(BMap.class);
-        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(true);
+        BMap traceLogAdvancedConfig = mock(BMap.class);
+        when(traceLogAdvancedConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(true);
         BString traceFilePath = mock(BString.class);
         BString host = mock(BString.class);
         BString accessFilePath = mock(BString.class);
@@ -124,15 +124,15 @@ public class HttpLogManagerTest {
         when(traceFilePath.getValue()).thenReturn("");
         when(accessFilePath.getValue()).thenReturn("");
         when(host.getValue()).thenReturn("testHost");
-        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
-        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
-        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogAdvancedConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
 
         BMap accessLogConfig = mock(BMap.class);
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(true, traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(true, traceLogAdvancedConfig, accessLogConfig);
         Handler[] handlers = httpLogManager.httpTraceLogger.getHandlers();
         Assert.assertTrue(handlers.length > 0);
         Handler handler = handlers[handlers.length - 1];
@@ -143,8 +143,8 @@ public class HttpLogManagerTest {
 
     @Test
     public void testHttpLogManagerWithTraceLogFile() {
-        BMap traceLogConfig = mock(BMap.class);
-        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        BMap traceLogAdvancedConfig = mock(BMap.class);
+        when(traceLogAdvancedConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         BString traceFilePath = mock(BString.class);
         BString host = mock(BString.class);
         BString accessFilePath = mock(BString.class);
@@ -153,15 +153,15 @@ public class HttpLogManagerTest {
         when(traceFilePath.getValue()).thenReturn(path);
         when(accessFilePath.getValue()).thenReturn("");
         when(host.getValue()).thenReturn("");
-        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
-        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
-        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogAdvancedConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
 
         BMap accessLogConfig = mock(BMap.class);
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogAdvancedConfig, accessLogConfig);
         Handler[] handlers = httpLogManager.httpTraceLogger.getHandlers();
         Assert.assertTrue(handlers.length > 0);
         Handler handler = handlers[handlers.length - 1];
@@ -172,8 +172,8 @@ public class HttpLogManagerTest {
 
     @Test
     public void testHttpLogManagerWithTraceLogSocket() throws IOException {
-        BMap traceLogConfig = mock(BMap.class);
-        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        BMap traceLogAdvancedConfig = mock(BMap.class);
+        when(traceLogAdvancedConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         BString traceFilePath = mock(BString.class);
         BString host = mock(BString.class);
         BString accessFilePath = mock(BString.class);
@@ -182,15 +182,15 @@ public class HttpLogManagerTest {
         when(traceFilePath.getValue()).thenReturn("");
         when(accessFilePath.getValue()).thenReturn("");
         when(host.getValue()).thenReturn("localhost");
-        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
-        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
-        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogAdvancedConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
 
         BMap accessLogConfig = mock(BMap.class);
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogAdvancedConfig, accessLogConfig);
         Handler[] handlers = httpLogManager.httpTraceLogger.getHandlers();
         Assert.assertTrue(handlers.length > 0);
         Handler handler = handlers[handlers.length - 1];
@@ -202,8 +202,8 @@ public class HttpLogManagerTest {
 
     @Test
     public void testHttpLogManagerWithAccessLogConsole() {
-        BMap traceLogConfig = mock(BMap.class);
-        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        BMap traceLogAdvancedConfig = mock(BMap.class);
+        when(traceLogAdvancedConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         BString traceFilePath = mock(BString.class);
         BString host = mock(BString.class);
         BString accessFilePath = mock(BString.class);
@@ -211,15 +211,15 @@ public class HttpLogManagerTest {
         when(traceFilePath.getValue()).thenReturn("");
         when(accessFilePath.getValue()).thenReturn("");
         when(host.getValue()).thenReturn("");
-        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
-        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
-        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogAdvancedConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
 
         BMap accessLogConfig = mock(BMap.class);
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(true);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogAdvancedConfig, accessLogConfig);
         Assert.assertEquals(httpLogManager.httpAccessLogger.getLevel(), Level.INFO);
         Handler[] handlers = httpLogManager.httpAccessLogger.getHandlers();
         Assert.assertTrue(handlers.length > 0);
@@ -231,8 +231,8 @@ public class HttpLogManagerTest {
 
     @Test
     public void testHttpLogManagerWithAccessLogFile() {
-        BMap traceLogConfig = mock(BMap.class);
-        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        BMap traceLogAdvancedConfig = mock(BMap.class);
+        when(traceLogAdvancedConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         BString traceFilePath = mock(BString.class);
         BString host = mock(BString.class);
         BString accessFilePath = mock(BString.class);
@@ -241,15 +241,15 @@ public class HttpLogManagerTest {
         when(traceFilePath.getValue()).thenReturn("");
         when(accessFilePath.getValue()).thenReturn(path);
         when(host.getValue()).thenReturn("");
-        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
-        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
-        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogAdvancedConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
 
         BMap accessLogConfig = mock(BMap.class);
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogAdvancedConfig, accessLogConfig);
         Assert.assertEquals(httpLogManager.httpAccessLogger.getLevel(), Level.INFO);
         Handler[] handlers = httpLogManager.httpAccessLogger.getHandlers();
         Assert.assertTrue(handlers.length > 0);
@@ -262,8 +262,8 @@ public class HttpLogManagerTest {
     @Test (expectedExceptions = RuntimeException.class,
             expectedExceptionsMessageRegExp = "failed to setup HTTP trace log file: /test/logTestFile.txt")
     public void testHttpLogManagerWithInvalidTraceLogFilePath() {
-        BMap traceLogConfig = mock(BMap.class);
-        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        BMap traceLogAdvancedConfig = mock(BMap.class);
+        when(traceLogAdvancedConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         BString traceFilePath = mock(BString.class);
         BString host = mock(BString.class);
         BString accessFilePath = mock(BString.class);
@@ -272,22 +272,22 @@ public class HttpLogManagerTest {
         when(traceFilePath.getValue()).thenReturn(path);
         when(accessFilePath.getValue()).thenReturn("");
         when(host.getValue()).thenReturn("");
-        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
-        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
-        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogAdvancedConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
 
         BMap accessLogConfig = mock(BMap.class);
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogAdvancedConfig, accessLogConfig);
     }
 
     @Test (expectedExceptions = RuntimeException.class,
             expectedExceptionsMessageRegExp = "failed to connect to testHost:8080")
     public void testHttpLogManagerWithNonExistingSocket() {
-        BMap traceLogConfig = mock(BMap.class);
-        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        BMap traceLogAdvancedConfig = mock(BMap.class);
+        when(traceLogAdvancedConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         BString traceFilePath = mock(BString.class);
         BString host = mock(BString.class);
         BString accessFilePath = mock(BString.class);
@@ -295,22 +295,22 @@ public class HttpLogManagerTest {
         when(traceFilePath.getValue()).thenReturn("");
         when(accessFilePath.getValue()).thenReturn("");
         when(host.getValue()).thenReturn("testHost");
-        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
-        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
-        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogAdvancedConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
 
         BMap accessLogConfig = mock(BMap.class);
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogAdvancedConfig, accessLogConfig);
     }
 
     @Test (expectedExceptions = RuntimeException.class,
             expectedExceptionsMessageRegExp = "failed to setup HTTP access log file: /test/logTestFile.txt")
     public void testHttpLogManagerWithInvalidAccessLogPath() {
-        BMap traceLogConfig = mock(BMap.class);
-        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        BMap traceLogAdvancedConfig = mock(BMap.class);
+        when(traceLogAdvancedConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         BString traceFilePath = mock(BString.class);
         BString host = mock(BString.class);
         BString accessFilePath = mock(BString.class);
@@ -319,15 +319,15 @@ public class HttpLogManagerTest {
         when(traceFilePath.getValue()).thenReturn("");
         when(accessFilePath.getValue()).thenReturn(path);
         when(host.getValue()).thenReturn("");
-        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
-        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
-        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogAdvancedConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogAdvancedConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
 
         BMap accessLogConfig = mock(BMap.class);
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogAdvancedConfig, accessLogConfig);
     }
 
     @AfterClass

--- a/native/src/test/java/io/ballerina/stdlib/http/api/logging/HttpLogManagerTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/api/logging/HttpLogManagerTest.java
@@ -76,7 +76,7 @@ public class HttpLogManagerTest {
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogConfig, accessLogConfig);
         Handler[] handlers = httpLogManager.httpTraceLogger.getHandlers();
         Assert.assertTrue(handlers.length > 0);
         Handler handler = handlers[handlers.length - 1];
@@ -105,7 +105,7 @@ public class HttpLogManagerTest {
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogConfig, accessLogConfig);
         Handler[] handlers = httpLogManager.httpTraceLogger.getHandlers();
         Assert.assertTrue(handlers.length > 0);
         Handler handler = handlers[handlers.length - 1];
@@ -134,7 +134,7 @@ public class HttpLogManagerTest {
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogConfig, accessLogConfig);
         Handler[] handlers = httpLogManager.httpTraceLogger.getHandlers();
         Assert.assertTrue(handlers.length > 0);
         Handler handler = handlers[handlers.length - 1];
@@ -163,7 +163,7 @@ public class HttpLogManagerTest {
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(true);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogConfig, accessLogConfig);
         Assert.assertEquals(httpLogManager.httpAccessLogger.getLevel(), Level.INFO);
         Handler[] handlers = httpLogManager.httpAccessLogger.getHandlers();
         Assert.assertTrue(handlers.length > 0);
@@ -193,7 +193,7 @@ public class HttpLogManagerTest {
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogConfig, accessLogConfig);
         Assert.assertEquals(httpLogManager.httpAccessLogger.getLevel(), Level.INFO);
         Handler[] handlers = httpLogManager.httpAccessLogger.getHandlers();
         Assert.assertTrue(handlers.length > 0);
@@ -224,7 +224,7 @@ public class HttpLogManagerTest {
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogConfig, accessLogConfig);
     }
 
     @Test (expectedExceptions = RuntimeException.class,
@@ -247,7 +247,7 @@ public class HttpLogManagerTest {
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogConfig, accessLogConfig);
     }
 
     @Test (expectedExceptions = RuntimeException.class,
@@ -271,7 +271,7 @@ public class HttpLogManagerTest {
         when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
-        HttpLogManager httpLogManager = new HttpLogManager(traceLogConfig, accessLogConfig);
+        HttpLogManager httpLogManager = new HttpLogManager(false, traceLogConfig, accessLogConfig);
     }
 
     @AfterClass

--- a/native/src/test/java/io/ballerina/stdlib/http/api/logging/HttpLogManagerTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/api/logging/HttpLogManagerTest.java
@@ -58,7 +58,7 @@ public class HttpLogManagerTest {
     }
 
     @Test
-    public void testHttpLogManagerWithTraceLogConsole() {
+    public void testHttpLogManagerWithTraceLogConsole1() {
         BMap traceLogConfig = mock(BMap.class);
         when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(true);
         BString traceFilePath = mock(BString.class);
@@ -77,6 +77,62 @@ public class HttpLogManagerTest {
         when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
 
         HttpLogManager httpLogManager = new HttpLogManager(false, traceLogConfig, accessLogConfig);
+        Handler[] handlers = httpLogManager.httpTraceLogger.getHandlers();
+        Assert.assertTrue(handlers.length > 0);
+        Handler handler = handlers[handlers.length - 1];
+        Assert.assertTrue(handler instanceof ConsoleHandler);
+        Assert.assertTrue(handler.getFormatter() instanceof HttpTraceLogFormatter);
+        Assert.assertEquals(Level.FINEST, handler.getLevel());
+    }
+
+    @Test
+    public void testHttpLogManagerWithTraceLogConsole2() {
+        BMap traceLogConfig = mock(BMap.class);
+        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        BString traceFilePath = mock(BString.class);
+        BString host = mock(BString.class);
+        BString accessFilePath = mock(BString.class);
+        long port = 0;
+        when(traceFilePath.getValue()).thenReturn("");
+        when(accessFilePath.getValue()).thenReturn("");
+        when(host.getValue()).thenReturn("testHost");
+        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+
+        BMap accessLogConfig = mock(BMap.class);
+        when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
+
+        HttpLogManager httpLogManager = new HttpLogManager(true, traceLogConfig, accessLogConfig);
+        Handler[] handlers = httpLogManager.httpTraceLogger.getHandlers();
+        Assert.assertTrue(handlers.length > 0);
+        Handler handler = handlers[handlers.length - 1];
+        Assert.assertTrue(handler instanceof ConsoleHandler);
+        Assert.assertTrue(handler.getFormatter() instanceof HttpTraceLogFormatter);
+        Assert.assertEquals(Level.FINEST, handler.getLevel());
+    }
+
+    @Test
+    public void testHttpLogManagerWithTraceLogConsole3() {
+        BMap traceLogConfig = mock(BMap.class);
+        when(traceLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(true);
+        BString traceFilePath = mock(BString.class);
+        BString host = mock(BString.class);
+        BString accessFilePath = mock(BString.class);
+        long port = 0;
+        when(traceFilePath.getValue()).thenReturn("");
+        when(accessFilePath.getValue()).thenReturn("");
+        when(host.getValue()).thenReturn("testHost");
+        when(traceLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(traceFilePath);
+        when(traceLogConfig.getStringValue(HTTP_TRACE_LOG_HOST)).thenReturn(host);
+        when(traceLogConfig.getIntValue(HTTP_TRACE_LOG_PORT)).thenReturn(port);
+
+        BMap accessLogConfig = mock(BMap.class);
+        when(accessLogConfig.getBooleanValue(HTTP_LOG_CONSOLE)).thenReturn(false);
+        when(accessLogConfig.getStringValue(HTTP_LOG_FILE_PATH)).thenReturn(accessFilePath);
+
+        HttpLogManager httpLogManager = new HttpLogManager(true, traceLogConfig, accessLogConfig);
         Handler[] handlers = httpLogManager.httpTraceLogger.getHandlers();
         Assert.assertTrue(handlers.length > 0);
         Handler handler = handlers[handlers.length - 1];


### PR DESCRIPTION
## Purpose

Fixes [`ballerina-platform/ballerina-standard-library/issues/1689`](https://github.com/ballerina-platform/ballerina-standard-library/issues/1689)

## Example

Printing trace logs in console can be enabled using the command-line parameter `-Cballerina.http.traceLogConsole=true`  in addition to the following TOML syntax :

```toml
[ballerina.http.traceLogAdvancedConfig]
# Enable printing trace logs in console
console = true              # Default is false
# Specify the file path to save the trace logs  
path = "testTraceLog.txt"   # Optional
# Specify the hostname and port of a socket service to publish the trace logs
host = "localhost"          # Optional
port = 8080                 # Optional
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests