### PR TITLE
Introduce @http:CacheConfig annotation to the resource

### DIFF
--- a/ballerina-tests/tests/http_cache_config_annotation_test.bal
+++ b/ballerina-tests/tests/http_cache_config_annotation_test.bal
@@ -1,0 +1,221 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+import ballerina/lang.runtime as runtime;
+import ballerina/http;
+import ballerina/log;
+
+http:Client cacheClientEP = check new("http://localhost:" + cacheAnnotationTestPort1.toString(), { cache: { enabled: false }});
+
+http:Client cacheBackendEP = check new("http://localhost:" + cacheAnnotationTestPort2.toString(), { cache: { isShared: true } });
+
+int numberOfProxyHitsNew = 0;
+
+service / on new http:Listener(cacheAnnotationTestPort1) {
+
+    resource function get noCache(http:Caller caller, http:Request req) {
+        http:Response|error response = cacheBackendEP->forward("/nocacheBE", req);
+        if (response is http:Response) {
+            checkpanic caller->respond(response);
+        } else {
+            log:printError(response.message());
+            http:Response res = new;
+            res.statusCode = 500;
+            res.setPayload(response.message());
+            checkpanic caller->respond(res);
+        }
+    }
+
+    resource function get maxAge(http:Caller caller, http:Request req) {
+        http:Response|error response = cacheBackendEP->forward("/maxAgeBE", req);
+        if (response is http:Response) {
+            checkpanic caller->respond(response);
+        } else {
+            http:Response res = new;
+            res.statusCode = 500;
+            res.setPayload(response.message());
+            checkpanic caller->respond(res);
+        }
+    }
+
+    resource function get mustRevalidate(http:Caller caller, http:Request req) {
+        numberOfProxyHitsNew += 1;
+        http:Response|error response = cacheBackendEP->forward("/mustRevalidateBE", req);
+        if (response is http:Response) {
+            response.setHeader("x-proxy-hit-count", numberOfProxyHitsNew.toString());
+            checkpanic caller->respond(response);
+        } else {
+            http:Response res = new;
+            res.statusCode = 500;
+            res.setPayload(response.message());
+            checkpanic caller->respond(res);
+        }
+    }
+}
+
+int noCacheHitCountNew = 0;
+int maxAgeHitCountNew = 0;
+int numberOfHitsNew = 0;
+
+service / on new http:Listener(cacheAnnotationTestPort2) {
+
+    resource function default nocacheBE(http:Request req) returns @http:CacheConfig{noCache : true, setETag : true}
+            http:Response {
+        json nocachePayload = {};
+        http:Response res = new;
+        if (noCacheHitCountNew < 1) {
+            nocachePayload = { "message": "1st response" };
+        } else {
+            nocachePayload = { "message": "2nd response" };
+        }
+        noCacheHitCountNew += 1;
+        res.setHeader("x-service-hit-count", noCacheHitCountNew.toString());
+        res.setPayload(nocachePayload);
+
+        return res;
+    }
+
+    resource function default maxAgeBE(http:Request req) returns @http:CacheConfig{maxAge : 5, setETag : true}
+            http:Response {
+        http:Response res = new;
+        if (maxAgeHitCountNew < 1) {
+            maxAgePayload = { "message": "before cache expiration" };
+        } else {
+            maxAgePayload = { "message": "after cache expiration" };
+        }
+        maxAgeHitCountNew += 1;
+        res.setPayload(maxAgePayload);
+
+        return res;
+    }
+
+    resource function get mustRevalidateBE(http:Caller caller, http:Request req) returns
+            @http:CacheConfig{mustRevalidate : true, maxAge : 5, setETag : true} http:Response {
+        http:Response res = new;
+        json payload = {"message" : "Hello, World!"};
+        numberOfHitsNew += 1;
+        res.setPayload(payload);
+        res.setHeader("x-service-hit-count", numberOfHitsNew.toString());
+
+        return res;
+    }
+}
+
+@test:Config {}
+function testNoCacheCacheControlWithAnnotation() {
+    http:Response|error response = cacheClientEP->get("/noCache");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(checkpanic response.getHeader(serviceHitCount), "1");
+        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertJsonPayload(response.getJsonPayload(), {message:"1st response"});
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+
+    response = cacheClientEP->get("/noCache");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(checkpanic response.getHeader(serviceHitCount), "2");
+        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertJsonPayload(response.getJsonPayload(), {message:"2nd response"});
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+
+    response = cacheClientEP->get("/noCache");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(checkpanic response.getHeader(serviceHitCount), "3");
+        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertJsonPayload(response.getJsonPayload(), {message:"2nd response"});
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}
+
+@test:Config {}
+function testMaxAgeCacheControlWithAnnotation() {
+    http:Response|error response = cacheClientEP->get("/maxAge");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertJsonPayload(response.getJsonPayload(), { "message": "before cache expiration" });
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+
+    response = cacheClientEP->get("/maxAge");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertJsonPayload(response.getJsonPayload(), { "message": "before cache expiration" });
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+
+    // Wait for a while before sending the next request
+    runtime:sleep(5);
+
+    response = cacheClientEP->get("/maxAge");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertJsonPayload(response.getJsonPayload(), {message:"after cache expiration"});
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}
+
+@test:Config {}
+function testMustRevalidateCacheControlWithAnnotation() {
+    http:Response|error response = cacheClientEP->get("/mustRevalidate");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(checkpanic response.getHeader(serviceHitCount), "1");
+        assertHeaderValue(checkpanic response.getHeader(proxyHitCount), "1");
+        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertJsonPayload(response.getJsonPayload(), cachingPayload);
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+
+    response = cacheClientEP->get("/mustRevalidate");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(checkpanic response.getHeader(serviceHitCount), "1");
+        assertHeaderValue(checkpanic response.getHeader(proxyHitCount), "2");
+        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertJsonPayload(response.getJsonPayload(), cachingPayload);
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+
+    // Wait for a while before sending the next request
+    runtime:sleep(5);
+
+    response = cacheClientEP->get("/mustRevalidate");
+    if (response is http:Response) {
+        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(checkpanic response.getHeader(serviceHitCount), "2");
+        assertHeaderValue(checkpanic response.getHeader(proxyHitCount), "3");
+        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertJsonPayload(response.getJsonPayload(), cachingPayload);
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}

--- a/ballerina-tests/tests/http_cache_config_annotation_test.bal
+++ b/ballerina-tests/tests/http_cache_config_annotation_test.bal
@@ -42,7 +42,7 @@ service / on new http:Listener(cacheAnnotationTestPort1) {
 
     resource function get noCache(http:Request req) returns http:Response|http:InternalServerError {
         http:Response|error response = cacheBackendEP->forward("/nocacheBE", req);
-        if (response is http:Response) {
+        if response is http:Response {
             return response;
         } else {
             http:InternalServerError errorRes = {body : response.message()};
@@ -52,7 +52,7 @@ service / on new http:Listener(cacheAnnotationTestPort1) {
 
     resource function get maxAge(http:Request req) returns http:Response|http:InternalServerError {
         http:Response|error response = cacheBackendEP->forward("/maxAgeBE", req);
-        if (response is http:Response) {
+        if response is http:Response {
             return response;
         } else {
             http:InternalServerError errorRes = {body : response.message()};
@@ -63,7 +63,7 @@ service / on new http:Listener(cacheAnnotationTestPort1) {
     resource function get mustRevalidate(http:Request req) returns http:Response|http:InternalServerError {
         numberOfProxyHitsNew += 1;
         http:Response|error response = cacheBackendEP->forward("/mustRevalidateBE", req);
-        if (response is http:Response) {
+        if response is http:Response {
             response.setHeader(serviceHitCount, numberOfHitsNew.toString());
             response.setHeader(proxyHitCount, numberOfProxyHitsNew.toString());
             return response;
@@ -75,7 +75,7 @@ service / on new http:Listener(cacheAnnotationTestPort1) {
 
     resource function get statusResponse(http:Request req) returns http:Response|http:InternalServerError {
         http:Response|error response = cacheBackendEP->forward("/statusResponseBE", req);
-        if (response is http:Response) {
+        if response is http:Response {
             return response;
         } else {
             http:InternalServerError errorRes = {body : response.message()};
@@ -89,7 +89,7 @@ service / on new http:Listener(cacheAnnotationTestPort2) {
     resource function default nocacheBE(http:Request req) returns @http:CacheConfig{noCache : true, maxAge : -1,
     mustRevalidate : false} json {
         noCacheHitCountNew += 1;
-        if (noCacheHitCountNew == 1) {
+        if noCacheHitCountNew == 1 {
             return nocachePayload1;
         } else {
             return nocachePayload2;
@@ -98,7 +98,7 @@ service / on new http:Listener(cacheAnnotationTestPort2) {
 
     resource function default maxAgeBE(http:Request req) returns @http:CacheConfig{maxAge : 5, mustRevalidate : false} xml {
         maxAgeHitCountNew += 1;
-        if (maxAgeHitCountNew == 1) {
+        if maxAgeHitCountNew == 1 {
             return maxAgePayload1;
         } else {
             return maxAgePayload2;
@@ -107,7 +107,7 @@ service / on new http:Listener(cacheAnnotationTestPort2) {
 
     resource function get mustRevalidateBE(http:Request req) returns @http:CacheConfig{maxAge : 5} string|byte[] {
         numberOfHitsNew += 1;
-        if (numberOfHitsNew < 2) {
+        if numberOfHitsNew < 2 {
             return mustRevalidatePayload1;
         } else {
             return mustRevalidatePayload2;
@@ -117,7 +117,7 @@ service / on new http:Listener(cacheAnnotationTestPort2) {
     resource function get statusResponseBE(http:Request req) returns @http:CacheConfig{noCache : true, maxAge : -1,
     mustRevalidate : false} http:Ok|http:InternalServerError {
         statusHits += 1;
-        if (statusHits < 3) {
+        if statusHits < 3 {
             return ok;
         } else {
             return err;
@@ -126,41 +126,41 @@ service / on new http:Listener(cacheAnnotationTestPort2) {
 }
 
 @test:Config {}
-function testNoCacheCacheControlWithAnnotation() {
+function testNoCacheCacheControlWithAnnotation() returns error? {
     http:Response|error response = cacheClientEP->get("/noCache");
-    if (response is http:Response) {
+    if response is http:Response {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertEquals(noCacheHitCountNew, 1);
         test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "no-cache,public");
-        assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(nocachePayload1.toString().toBytes()));
-        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "no-cache,public");
+        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(nocachePayload1.toString().toBytes()));
+        assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
         assertJsonPayload(response.getJsonPayload(), nocachePayload1);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }
 
     response = cacheClientEP->get("/noCache");
-    if (response is http:Response) {
+    if response is http:Response {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertEquals(noCacheHitCountNew, 2);
         test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "no-cache,public");
-        assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(nocachePayload2.toString().toBytes()));
-        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "no-cache,public");
+        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(nocachePayload2.toString().toBytes()));
+        assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
         assertJsonPayload(response.getJsonPayload(), nocachePayload2);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }
 
     response = cacheClientEP->get("/noCache");
-    if (response is http:Response) {
+    if response is http:Response {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertEquals(noCacheHitCountNew, 3);
         test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "no-cache,public");
-        assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(nocachePayload2.toString().toBytes()));
-        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "no-cache,public");
+        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(nocachePayload2.toString().toBytes()));
+        assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
         assertJsonPayload(response.getJsonPayload(), nocachePayload2);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
@@ -168,28 +168,28 @@ function testNoCacheCacheControlWithAnnotation() {
 }
 
 @test:Config {}
-function testMaxAgeCacheControlWithAnnotation() {
+function testMaxAgeCacheControlWithAnnotation() returns error? {
     http:Response|error response = cacheClientEP->get("/maxAge");
-    if (response is http:Response) {
+    if response is http:Response {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertEquals(maxAgeHitCountNew, 1);
         test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "public,max-age=5");
-        assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(maxAgePayload1.toString().toBytes()));
-        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_XML);
+        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "public,max-age=5");
+        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(maxAgePayload1.toString().toBytes()));
+        assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_XML);
         assertXmlPayload(response.getXmlPayload(), maxAgePayload1);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }
 
     response = cacheClientEP->get("/maxAge");
-    if (response is http:Response) {
+    if response is http:Response {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertEquals(maxAgeHitCountNew, 1);
         test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "public,max-age=5");
-        assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(maxAgePayload1.toString().toBytes()));
-        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_XML);
+        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "public,max-age=5");
+        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(maxAgePayload1.toString().toBytes()));
+        assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_XML);
         assertXmlPayload(response.getXmlPayload(), maxAgePayload1);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
@@ -199,13 +199,13 @@ function testMaxAgeCacheControlWithAnnotation() {
     runtime:sleep(5);
 
     response = cacheClientEP->get("/maxAge");
-    if (response is http:Response) {
+    if response is http:Response {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertEquals(maxAgeHitCountNew, 2);
         test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "public,max-age=5");
-        assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(maxAgePayload2.toString().toBytes()));
-        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_XML);
+        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "public,max-age=5");
+        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(maxAgePayload2.toString().toBytes()));
+        assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_XML);
         assertXmlPayload(response.getXmlPayload(), maxAgePayload2);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
@@ -213,30 +213,30 @@ function testMaxAgeCacheControlWithAnnotation() {
 }
 
 @test:Config {}
-function testMustRevalidateCacheControlWithAnnotation() {
+function testMustRevalidateCacheControlWithAnnotation() returns error? {
     http:Response|error response = cacheClientEP->get("/mustRevalidate");
-    if (response is http:Response) {
+    if response is http:Response {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "must-revalidate,public,max-age=5");
-        assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
-        assertHeaderValue(checkpanic response.getHeader(serviceHitCount), "1");
-        assertHeaderValue(checkpanic response.getHeader(proxyHitCount), "1");
-        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "must-revalidate,public,max-age=5");
+        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
+        assertHeaderValue(check response.getHeader(serviceHitCount), "1");
+        assertHeaderValue(check response.getHeader(proxyHitCount), "1");
+        assertHeaderValue(check response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
         assertTextPayload(response.getTextPayload(), mustRevalidatePayload1);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }
 
     response = cacheClientEP->get("/mustRevalidate");
-    if (response is http:Response) {
+    if response is http:Response {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "must-revalidate,public,max-age=5");
-        assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
-        assertHeaderValue(checkpanic response.getHeader(serviceHitCount), "1");
-        assertHeaderValue(checkpanic response.getHeader(proxyHitCount), "2");
-        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "must-revalidate,public,max-age=5");
+        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
+        assertHeaderValue(check response.getHeader(serviceHitCount), "1");
+        assertHeaderValue(check response.getHeader(proxyHitCount), "2");
+        assertHeaderValue(check response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
         assertTextPayload(response.getTextPayload(), mustRevalidatePayload1);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
@@ -246,14 +246,14 @@ function testMustRevalidateCacheControlWithAnnotation() {
     runtime:sleep(5);
 
     response = cacheClientEP->get("/mustRevalidate");
-    if (response is http:Response) {
+    if response is http:Response {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "must-revalidate,public,max-age=5");
-        assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload2));
-        assertHeaderValue(checkpanic response.getHeader(serviceHitCount), "2");
-        assertHeaderValue(checkpanic response.getHeader(proxyHitCount), "3");
-        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_BINARY);
+        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "must-revalidate,public,max-age=5");
+        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload2));
+        assertHeaderValue(check response.getHeader(serviceHitCount), "2");
+        assertHeaderValue(check response.getHeader(proxyHitCount), "3");
+        assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_BINARY);
         assertBinaryPayload(response.getBinaryPayload(), mustRevalidatePayload2);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
@@ -261,41 +261,41 @@ function testMustRevalidateCacheControlWithAnnotation() {
 }
 
 @test:Config {}
-function testReturnStatusCodeResponsesWithAnnotation() {
+function testReturnStatusCodeResponsesWithAnnotation() returns error? {
     http:Response|error response = cacheClientEP->get("/statusResponse");
-    if (response is http:Response) {
+    if response is http:Response {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertEquals(statusHits, 1);
         test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "no-cache,public");
-        assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
-        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "no-cache,public");
+        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
+        assertHeaderValue(check response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
         assertTextPayload(response.getTextPayload(), mustRevalidatePayload1);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }
 
     response = cacheClientEP->get("/statusResponse");
-    if (response is http:Response) {
+    if response is http:Response {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertEquals(statusHits, 2);
         test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "no-cache,public");
-        assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
-        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "no-cache,public");
+        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
+        assertHeaderValue(check response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
         assertTextPayload(response.getTextPayload(), mustRevalidatePayload1);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }
 
     response = cacheClientEP->get("/statusResponse");
-    if (response is http:Response) {
+    if response is http:Response {
         test:assertEquals(response.statusCode, 500, msg = "Found unexpected output");
         test:assertEquals(statusHits, 3);
         test:assertFalse(response.hasHeader(ETAG));
         test:assertFalse(response.hasHeader(CACHE_CONTROL));
         test:assertFalse(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+        assertHeaderValue(check response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
         assertTextPayload(response.getTextPayload(), errorBody);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());

--- a/ballerina-tests/tests/http_cache_config_annotation_test.bal
+++ b/ballerina-tests/tests/http_cache_config_annotation_test.bal
@@ -96,7 +96,7 @@ service / on new http:Listener(cacheAnnotationTestPort1) {
 
 service / on new http:Listener(cacheAnnotationTestPort2) {
 
-    resource function default nocacheBE(http:Request req) returns @http:CacheConfig{} json {
+    resource function default nocacheBE(http:Request req) returns @http:CacheConfig json {
         noCacheHitCountNew += 1;
         if (noCacheHitCountNew == 1) {
             return nocachePayload1;
@@ -124,7 +124,7 @@ service / on new http:Listener(cacheAnnotationTestPort2) {
         }
     }
 
-    resource function get statusResponseBE(http:Request req) returns @http:CacheConfig{} http:Ok|http:InternalServerError {
+    resource function get statusResponseBE(http:Request req) returns @http:CacheConfig http:Ok|http:InternalServerError {
         statusHits += 1;
         if (statusHits < 3) {
             return ok;
@@ -140,6 +140,8 @@ function testNoCacheCacheControlWithAnnotation() {
     if (response is http:Response) {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertEquals(noCacheHitCountNew, 1);
+        test:assertTrue(response.hasHeader(LAST_MODIFIED));
+        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "no-cache,public");
         assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(nocachePayload1.toString().toBytes()));
         assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
         assertJsonPayload(response.getJsonPayload(), nocachePayload1);
@@ -151,6 +153,8 @@ function testNoCacheCacheControlWithAnnotation() {
     if (response is http:Response) {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertEquals(noCacheHitCountNew, 2);
+        test:assertTrue(response.hasHeader(LAST_MODIFIED));
+        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "no-cache,public");
         assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(nocachePayload2.toString().toBytes()));
         assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
         assertJsonPayload(response.getJsonPayload(), nocachePayload2);
@@ -162,6 +166,8 @@ function testNoCacheCacheControlWithAnnotation() {
     if (response is http:Response) {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertEquals(noCacheHitCountNew, 3);
+        test:assertTrue(response.hasHeader(LAST_MODIFIED));
+        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "no-cache,public");
         assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(nocachePayload2.toString().toBytes()));
         assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
         assertJsonPayload(response.getJsonPayload(), nocachePayload2);
@@ -176,6 +182,8 @@ function testMaxAgeCacheControlWithAnnotation() {
     if (response is http:Response) {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertEquals(maxAgeHitCountNew, 1);
+        test:assertTrue(response.hasHeader(LAST_MODIFIED));
+        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "public,max-age=5");
         assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(maxAgePayload1.toString().toBytes()));
         assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_XML);
         assertXmlPayload(response.getXmlPayload(), maxAgePayload1);
@@ -187,6 +195,8 @@ function testMaxAgeCacheControlWithAnnotation() {
     if (response is http:Response) {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertEquals(maxAgeHitCountNew, 1);
+        test:assertTrue(response.hasHeader(LAST_MODIFIED));
+        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "public,max-age=5");
         assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(maxAgePayload1.toString().toBytes()));
         assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_XML);
         assertXmlPayload(response.getXmlPayload(), maxAgePayload1);
@@ -201,6 +211,8 @@ function testMaxAgeCacheControlWithAnnotation() {
     if (response is http:Response) {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertEquals(maxAgeHitCountNew, 2);
+        test:assertTrue(response.hasHeader(LAST_MODIFIED));
+        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "public,max-age=5");
         assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(maxAgePayload2.toString().toBytes()));
         assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), APPLICATION_XML);
         assertXmlPayload(response.getXmlPayload(), maxAgePayload2);
@@ -214,6 +226,8 @@ function testMustRevalidateCacheControlWithAnnotation() {
     http:Response|error response = cacheClientEP->get("/mustRevalidate");
     if (response is http:Response) {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        test:assertTrue(response.hasHeader(LAST_MODIFIED));
+        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "must-revalidate,public,max-age=5");
         assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
         assertHeaderValue(checkpanic response.getHeader(serviceHitCount), "1");
         assertHeaderValue(checkpanic response.getHeader(proxyHitCount), "1");
@@ -226,6 +240,8 @@ function testMustRevalidateCacheControlWithAnnotation() {
     response = cacheClientEP->get("/mustRevalidate");
     if (response is http:Response) {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        test:assertTrue(response.hasHeader(LAST_MODIFIED));
+        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "must-revalidate,public,max-age=5");
         assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
         assertHeaderValue(checkpanic response.getHeader(serviceHitCount), "1");
         assertHeaderValue(checkpanic response.getHeader(proxyHitCount), "2");
@@ -241,6 +257,8 @@ function testMustRevalidateCacheControlWithAnnotation() {
     response = cacheClientEP->get("/mustRevalidate");
     if (response is http:Response) {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+        test:assertTrue(response.hasHeader(LAST_MODIFIED));
+        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "must-revalidate,public,max-age=5");
         assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload2));
         assertHeaderValue(checkpanic response.getHeader(serviceHitCount), "2");
         assertHeaderValue(checkpanic response.getHeader(proxyHitCount), "3");
@@ -257,6 +275,8 @@ function testReturnStatusCodeResponsesWithAnnotation() {
     if (response is http:Response) {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertEquals(statusHits, 1);
+        test:assertTrue(response.hasHeader(LAST_MODIFIED));
+        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "no-cache,public");
         assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
         assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
         assertTextPayload(response.getTextPayload(), mustRevalidatePayload1);
@@ -268,6 +288,8 @@ function testReturnStatusCodeResponsesWithAnnotation() {
     if (response is http:Response) {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         test:assertEquals(statusHits, 2);
+        test:assertTrue(response.hasHeader(LAST_MODIFIED));
+        assertHeaderValue(checkpanic response.getHeader(CACHE_CONTROL), "no-cache,public");
         assertHeaderValue(checkpanic response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
         assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
         assertTextPayload(response.getTextPayload(), mustRevalidatePayload1);
@@ -281,6 +303,7 @@ function testReturnStatusCodeResponsesWithAnnotation() {
         test:assertEquals(statusHits, 3);
         test:assertFalse(response.hasHeader(ETAG));
         test:assertFalse(response.hasHeader(CACHE_CONTROL));
+        test:assertFalse(response.hasHeader(LAST_MODIFIED));
         assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
         assertTextPayload(response.getTextPayload(), errorBody);
     } else {

--- a/ballerina-tests/tests/http_cache_config_annotation_test.bal
+++ b/ballerina-tests/tests/http_cache_config_annotation_test.bal
@@ -127,177 +127,129 @@ service / on new http:Listener(cacheAnnotationTestPort2) {
 
 @test:Config {}
 function testNoCacheCacheControlWithAnnotation() returns error? {
-    http:Response|error response = cacheClientEP->get("/noCache");
-    if response is http:Response {
-        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
-        test:assertEquals(noCacheHitCountNew, 1);
-        test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "no-cache,public");
-        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(nocachePayload1.toString().toBytes()));
-        assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
-        assertJsonPayload(response.getJsonPayload(), nocachePayload1);
-    } else {
-        test:assertFail(msg = "Found unexpected output type: " + response.message());
-    }
+    http:Response response = check cacheClientEP->get("/noCache");
+    test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+    test:assertEquals(noCacheHitCountNew, 1);
+    test:assertTrue(response.hasHeader(LAST_MODIFIED));
+    assertHeaderValue(check response.getHeader(CACHE_CONTROL), "no-cache,public");
+    assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(nocachePayload1.toString().toBytes()));
+    assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+    assertJsonPayload(response.getJsonPayload(), nocachePayload1);
 
-    response = cacheClientEP->get("/noCache");
-    if response is http:Response {
-        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
-        test:assertEquals(noCacheHitCountNew, 2);
-        test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "no-cache,public");
-        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(nocachePayload2.toString().toBytes()));
-        assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
-        assertJsonPayload(response.getJsonPayload(), nocachePayload2);
-    } else {
-        test:assertFail(msg = "Found unexpected output type: " + response.message());
-    }
+    response = check cacheClientEP->get("/noCache");
+    test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+    test:assertEquals(noCacheHitCountNew, 2);
+    test:assertTrue(response.hasHeader(LAST_MODIFIED));
+    assertHeaderValue(check response.getHeader(CACHE_CONTROL), "no-cache,public");
+    assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(nocachePayload2.toString().toBytes()));
+    assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+    assertJsonPayload(response.getJsonPayload(), nocachePayload2);
 
-    response = cacheClientEP->get("/noCache");
-    if response is http:Response {
-        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
-        test:assertEquals(noCacheHitCountNew, 3);
-        test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "no-cache,public");
-        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(nocachePayload2.toString().toBytes()));
-        assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
-        assertJsonPayload(response.getJsonPayload(), nocachePayload2);
-    } else {
-        test:assertFail(msg = "Found unexpected output type: " + response.message());
-    }
+    response = check cacheClientEP->get("/noCache");
+    test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+    test:assertEquals(noCacheHitCountNew, 3);
+    test:assertTrue(response.hasHeader(LAST_MODIFIED));
+    assertHeaderValue(check response.getHeader(CACHE_CONTROL), "no-cache,public");
+    assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(nocachePayload2.toString().toBytes()));
+    assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+    assertJsonPayload(response.getJsonPayload(), nocachePayload2);
 }
 
 @test:Config {}
 function testMaxAgeCacheControlWithAnnotation() returns error? {
-    http:Response|error response = cacheClientEP->get("/maxAge");
-    if response is http:Response {
-        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
-        test:assertEquals(maxAgeHitCountNew, 1);
-        test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "public,max-age=5");
-        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(maxAgePayload1.toString().toBytes()));
-        assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_XML);
-        assertXmlPayload(response.getXmlPayload(), maxAgePayload1);
-    } else {
-        test:assertFail(msg = "Found unexpected output type: " + response.message());
-    }
+    http:Response response = check cacheClientEP->get("/maxAge");
+    test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+    test:assertEquals(maxAgeHitCountNew, 1);
+    test:assertTrue(response.hasHeader(LAST_MODIFIED));
+    assertHeaderValue(check response.getHeader(CACHE_CONTROL), "public,max-age=5");
+    assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(maxAgePayload1.toString().toBytes()));
+    assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_XML);
+    assertXmlPayload(response.getXmlPayload(), maxAgePayload1);
 
-    response = cacheClientEP->get("/maxAge");
-    if response is http:Response {
-        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
-        test:assertEquals(maxAgeHitCountNew, 1);
-        test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "public,max-age=5");
-        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(maxAgePayload1.toString().toBytes()));
-        assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_XML);
-        assertXmlPayload(response.getXmlPayload(), maxAgePayload1);
-    } else {
-        test:assertFail(msg = "Found unexpected output type: " + response.message());
-    }
+    response = check cacheClientEP->get("/maxAge");
+    test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+    test:assertEquals(maxAgeHitCountNew, 1);
+    test:assertTrue(response.hasHeader(LAST_MODIFIED));
+    assertHeaderValue(check response.getHeader(CACHE_CONTROL), "public,max-age=5");
+    assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(maxAgePayload1.toString().toBytes()));
+    assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_XML);
+    assertXmlPayload(response.getXmlPayload(), maxAgePayload1);
 
     // Wait for a while before sending the next request
     runtime:sleep(5);
 
-    response = cacheClientEP->get("/maxAge");
-    if response is http:Response {
-        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
-        test:assertEquals(maxAgeHitCountNew, 2);
-        test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "public,max-age=5");
-        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(maxAgePayload2.toString().toBytes()));
-        assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_XML);
-        assertXmlPayload(response.getXmlPayload(), maxAgePayload2);
-    } else {
-        test:assertFail(msg = "Found unexpected output type: " + response.message());
-    }
+    response = check cacheClientEP->get("/maxAge");
+    test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+    test:assertEquals(maxAgeHitCountNew, 2);
+    test:assertTrue(response.hasHeader(LAST_MODIFIED));
+    assertHeaderValue(check response.getHeader(CACHE_CONTROL), "public,max-age=5");
+    assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(maxAgePayload2.toString().toBytes()));
+    assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_XML);
+    assertXmlPayload(response.getXmlPayload(), maxAgePayload2);
 }
 
 @test:Config {}
 function testMustRevalidateCacheControlWithAnnotation() returns error? {
-    http:Response|error response = cacheClientEP->get("/mustRevalidate");
-    if response is http:Response {
-        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
-        test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "must-revalidate,public,max-age=5");
-        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
-        assertHeaderValue(check response.getHeader(serviceHitCount), "1");
-        assertHeaderValue(check response.getHeader(proxyHitCount), "1");
-        assertHeaderValue(check response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
-        assertTextPayload(response.getTextPayload(), mustRevalidatePayload1);
-    } else {
-        test:assertFail(msg = "Found unexpected output type: " + response.message());
-    }
+    http:Response response = check cacheClientEP->get("/mustRevalidate");
+    test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+    test:assertTrue(response.hasHeader(LAST_MODIFIED));
+    assertHeaderValue(check response.getHeader(CACHE_CONTROL), "must-revalidate,public,max-age=5");
+    assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
+    assertHeaderValue(check response.getHeader(serviceHitCount), "1");
+    assertHeaderValue(check response.getHeader(proxyHitCount), "1");
+    assertHeaderValue(check response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+    assertTextPayload(response.getTextPayload(), mustRevalidatePayload1);
 
-    response = cacheClientEP->get("/mustRevalidate");
-    if response is http:Response {
-        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
-        test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "must-revalidate,public,max-age=5");
-        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
-        assertHeaderValue(check response.getHeader(serviceHitCount), "1");
-        assertHeaderValue(check response.getHeader(proxyHitCount), "2");
-        assertHeaderValue(check response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
-        assertTextPayload(response.getTextPayload(), mustRevalidatePayload1);
-    } else {
-        test:assertFail(msg = "Found unexpected output type: " + response.message());
-    }
+    response = check cacheClientEP->get("/mustRevalidate");
+    test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+    test:assertTrue(response.hasHeader(LAST_MODIFIED));
+    assertHeaderValue(check response.getHeader(CACHE_CONTROL), "must-revalidate,public,max-age=5");
+    assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
+    assertHeaderValue(check response.getHeader(serviceHitCount), "1");
+    assertHeaderValue(check response.getHeader(proxyHitCount), "2");
+    assertHeaderValue(check response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+    assertTextPayload(response.getTextPayload(), mustRevalidatePayload1);
 
     // Wait for a while before sending the next request
     runtime:sleep(5);
 
-    response = cacheClientEP->get("/mustRevalidate");
-    if response is http:Response {
-        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
-        test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "must-revalidate,public,max-age=5");
-        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload2));
-        assertHeaderValue(check response.getHeader(serviceHitCount), "2");
-        assertHeaderValue(check response.getHeader(proxyHitCount), "3");
-        assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_BINARY);
-        assertBinaryPayload(response.getBinaryPayload(), mustRevalidatePayload2);
-    } else {
-        test:assertFail(msg = "Found unexpected output type: " + response.message());
-    }
+    response = check cacheClientEP->get("/mustRevalidate");
+    test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+    test:assertTrue(response.hasHeader(LAST_MODIFIED));
+    assertHeaderValue(check response.getHeader(CACHE_CONTROL), "must-revalidate,public,max-age=5");
+    assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload2));
+    assertHeaderValue(check response.getHeader(serviceHitCount), "2");
+    assertHeaderValue(check response.getHeader(proxyHitCount), "3");
+    assertHeaderValue(check response.getHeader(CONTENT_TYPE), APPLICATION_BINARY);
+    assertBinaryPayload(response.getBinaryPayload(), mustRevalidatePayload2);
 }
 
 @test:Config {}
 function testReturnStatusCodeResponsesWithAnnotation() returns error? {
-    http:Response|error response = cacheClientEP->get("/statusResponse");
-    if response is http:Response {
-        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
-        test:assertEquals(statusHits, 1);
-        test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "no-cache,public");
-        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
-        assertHeaderValue(check response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
-        assertTextPayload(response.getTextPayload(), mustRevalidatePayload1);
-    } else {
-        test:assertFail(msg = "Found unexpected output type: " + response.message());
-    }
+    http:Response response = check cacheClientEP->get("/statusResponse");
+    test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+    test:assertEquals(statusHits, 1);
+    test:assertTrue(response.hasHeader(LAST_MODIFIED));
+    assertHeaderValue(check response.getHeader(CACHE_CONTROL), "no-cache,public");
+    assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
+    assertHeaderValue(check response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+    assertTextPayload(response.getTextPayload(), mustRevalidatePayload1);
 
-    response = cacheClientEP->get("/statusResponse");
-    if response is http:Response {
-        test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
-        test:assertEquals(statusHits, 2);
-        test:assertTrue(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(check response.getHeader(CACHE_CONTROL), "no-cache,public");
-        assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
-        assertHeaderValue(check response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
-        assertTextPayload(response.getTextPayload(), mustRevalidatePayload1);
-    } else {
-        test:assertFail(msg = "Found unexpected output type: " + response.message());
-    }
+    response = check cacheClientEP->get("/statusResponse");
+    test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
+    test:assertEquals(statusHits, 2);
+    test:assertTrue(response.hasHeader(LAST_MODIFIED));
+    assertHeaderValue(check response.getHeader(CACHE_CONTROL), "no-cache,public");
+    assertHeaderValue(check response.getHeader(ETAG), crypto:crc32b(mustRevalidatePayload1.toBytes()));
+    assertHeaderValue(check response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+    assertTextPayload(response.getTextPayload(), mustRevalidatePayload1);
 
-    response = cacheClientEP->get("/statusResponse");
-    if response is http:Response {
-        test:assertEquals(response.statusCode, 500, msg = "Found unexpected output");
-        test:assertEquals(statusHits, 3);
-        test:assertFalse(response.hasHeader(ETAG));
-        test:assertFalse(response.hasHeader(CACHE_CONTROL));
-        test:assertFalse(response.hasHeader(LAST_MODIFIED));
-        assertHeaderValue(check response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
-        assertTextPayload(response.getTextPayload(), errorBody);
-    } else {
-        test:assertFail(msg = "Found unexpected output type: " + response.message());
-    }
+    response = check cacheClientEP->get("/statusResponse");
+    test:assertEquals(response.statusCode, 500, msg = "Found unexpected output");
+    test:assertEquals(statusHits, 3);
+    test:assertFalse(response.hasHeader(ETAG));
+    test:assertFalse(response.hasHeader(CACHE_CONTROL));
+    test:assertFalse(response.hasHeader(LAST_MODIFIED));
+    assertHeaderValue(check response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+    assertTextPayload(response.getTextPayload(), errorBody);
 }

--- a/ballerina-tests/tests/test_commons.bal
+++ b/ballerina-tests/tests/test_commons.bal
@@ -21,6 +21,7 @@ import ballerina/test;
 const string CONTENT_TYPE = "content-type";
 const string ETAG = "etag";
 const string CACHE_CONTROL = "cache-control";
+const string LAST_MODIFIED = "last-modified";
 const string CONTENT_ENCODING = "content-encoding";
 const string ACCEPT_ENCODING = "accept-encoding";
 const string CONTENT_LENGTH = "content-length";

--- a/ballerina-tests/tests/test_commons.bal
+++ b/ballerina-tests/tests/test_commons.bal
@@ -19,6 +19,7 @@ import ballerina/mime;
 import ballerina/test;
 
 const string CONTENT_TYPE = "content-type";
+const string ETAG = "etag";
 const string CONTENT_ENCODING = "content-encoding";
 const string ACCEPT_ENCODING = "accept-encoding";
 const string CONTENT_LENGTH = "content-length";
@@ -54,6 +55,7 @@ const string TEXT_PLAIN = "text/plain";
 const string APPLICATION_XML = "application/xml";
 const string APPLICATION_JSON = "application/json";
 const string APPLICATION_FORM = "application/x-www-form-urlencoded";
+const string APPLICATION_BINARY = "application/octet-stream";
 
 const string errorMessage = "Found an unexpected output:";
 
@@ -85,6 +87,22 @@ isolated function assertJsonPayload(json|error payload, json expectValue) {
 isolated function assertJsonPayloadtoJsonString(json|error payload, json expectValue) {
     if payload is json {
         test:assertEquals(payload.toJsonString(), expectValue.toJsonString(), msg = "Found unexpected output");
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + payload.message());
+    }
+}
+
+isolated function assertXmlPayload(xml|error payload, xml expectValue) {
+    if payload is xml {
+        test:assertEquals(payload, expectValue, msg = "Found unexpected output");
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + payload.message());
+    }
+}
+
+isolated function assertBinaryPayload(byte[]|error payload, byte[] expectValue) {
+    if payload is byte[] {
+        test:assertEquals(payload, expectValue, msg = "Found unexpected output");
     } else {
         test:assertFail(msg = "Found unexpected output type: " + payload.message());
     }

--- a/ballerina-tests/tests/test_commons.bal
+++ b/ballerina-tests/tests/test_commons.bal
@@ -20,6 +20,7 @@ import ballerina/test;
 
 const string CONTENT_TYPE = "content-type";
 const string ETAG = "etag";
+const string CACHE_CONTROL = "cache-control";
 const string CONTENT_ENCODING = "content-encoding";
 const string ACCEPT_ENCODING = "accept-encoding";
 const string CONTENT_LENGTH = "content-length";

--- a/ballerina-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/tests/test_service_ports.bal
@@ -122,6 +122,8 @@ const int inResponseCachedPayloadTestPort = 9573;
 const int inResponseCachedPayloadTestBEPort = 9574;
 const int httpEnumActionsTestPort = 9575;
 const int payloadRetrievalAfterRespondingTestPort = 9576;
+const int cacheAnnotationTestPort1 = 9577;
+const int cacheAnnotationTestPort2 = 9578;
 
 //HTTP2
 const int serverPushTestPort1 = 9601;

--- a/ballerina/caching_response_cache_control.bal
+++ b/ballerina/caching_response_cache_control.bal
@@ -41,6 +41,19 @@ public class ResponseCacheControl {
     public string[] noCacheFields = [];
     public string[] privateFields = [];
 
+    public isolated function populateFields(HttpCacheConfig cacheConfig) {
+        self.mustRevalidate = cacheConfig.mustRevalidate;
+        self.noCache = cacheConfig.noCache;
+        self.noStore = cacheConfig.noStore;
+        self.noTransform = cacheConfig.noTransform;
+        self.isPrivate = cacheConfig.isPrivate;
+        self.proxyRevalidate = cacheConfig.proxyRevalidate;
+        self.maxAge = cacheConfig.maxAge;
+        self.sMaxAge = cacheConfig.sMaxAge;
+        self.noCacheFields = cacheConfig.noCacheFields;
+        self.privateFields = cacheConfig.privateFields;
+    }
+
     # Builds the cache control directives string from the current `http:ResponseCacheControl` configurations.
     #
     # + return - The cache control directives string to be used in the `cache-control` header

--- a/ballerina/http_annotation.bal
+++ b/ballerina/http_annotation.bal
@@ -106,7 +106,7 @@ public annotation HttpHeader Header on parameter;
 # + noTransform - Sets the `no-transform` directive
 # + isPrivate - Sets the `private` and `public` directives
 # + proxyRevalidate - Sets the `proxy-revalidate` directive
-# + maxAge - Sets the `max-age` directive. Default value is 600 seconds
+# + maxAge - Sets the `max-age` directive. Default value is 3600 seconds
 # + sMaxAge - Sets the `s-maxage` directive
 # + noCacheFields - Optional fields for the `no-cache` directive. Before sending a listed field in a response, it
 #                   must be validated with the origin server
@@ -121,7 +121,7 @@ public type HttpCacheConfig record {|
     boolean noTransform = false;
     boolean isPrivate = false;
     boolean proxyRevalidate = false;
-    decimal maxAge = 600;
+    decimal maxAge = 3600;
     decimal sMaxAge = -1;
     string[] noCacheFields = [];
     string[] privateFields = [];
@@ -130,6 +130,6 @@ public type HttpCacheConfig record {|
 |};
 
 # The annotation which is used to define the response cache configuration. This annotation only supports `anydata` and
-# Success(2XX) `StatusCodeResponses` return types. Default annotation adds `must-revalidate,public,max-age=600` as
+# Success(2XX) `StatusCodeResponses` return types. Default annotation adds `must-revalidate,public,max-age=3600` as
 # `cache-control` header in addition to `etag` and `last-modified` headers.
 public annotation HttpCacheConfig CacheConfig on return;

--- a/ballerina/http_annotation.bal
+++ b/ballerina/http_annotation.bal
@@ -97,7 +97,8 @@ public type HttpHeader record {|
 # The annotation which is used to define the Header resource signature parameter.
 public annotation HttpHeader Header on parameter;
 
-# Defines the HTTP response cache configuration.
+# Defines the HTTP response cache configuration. By default the `no-cache` directive is setted to the `cache-control`
+# header. In addition to that `etag` and `last-modified` headers are also added for cache validation.
 #
 # + mustRevalidate - Sets the `must-revalidate` directive
 # + noCache - Sets the `no-cache` directive
@@ -115,7 +116,7 @@ public annotation HttpHeader Header on parameter;
 # + setLastModified - Sets the current time as the `last-modified` header
 public type HttpCacheConfig record {|
     boolean mustRevalidate = false;
-    boolean noCache = false;
+    boolean noCache = true;
     boolean noStore = false;
     boolean noTransform = false;
     boolean isPrivate = false;
@@ -124,9 +125,10 @@ public type HttpCacheConfig record {|
     decimal sMaxAge = -1;
     string[] noCacheFields = [];
     string[] privateFields = [];
-    boolean setETag = false;
-    boolean setLastModified = false;
+    boolean setETag = true;
+    boolean setLastModified = true;
 |};
 
-# The annotation which is used to define the response cache configuration.
+# The annotation which is used to define the response cache configuration. This annotation only supports `anydata` and
+# `SuccessStatusCodeResponse` return types.
 public annotation HttpCacheConfig CacheConfig on return;

--- a/ballerina/http_annotation.bal
+++ b/ballerina/http_annotation.bal
@@ -106,7 +106,7 @@ public annotation HttpHeader Header on parameter;
 # + noTransform - Sets the `no-transform` directive
 # + isPrivate - Sets the `private` and `public` directives
 # + proxyRevalidate - Sets the `proxy-revalidate` directive
-# + maxAge - Sets the `max-age` directive
+# + maxAge - Sets the `max-age` directive. Default value is 600 seconds
 # + sMaxAge - Sets the `s-maxage` directive
 # + noCacheFields - Optional fields for the `no-cache` directive. Before sending a listed field in a response, it
 #                   must be validated with the origin server
@@ -115,13 +115,13 @@ public annotation HttpHeader Header on parameter;
 # + setETag - Sets the `etag` header for the given payload
 # + setLastModified - Sets the current time as the `last-modified` header
 public type HttpCacheConfig record {|
-    boolean mustRevalidate = false;
-    boolean noCache = true;
+    boolean mustRevalidate = true;
+    boolean noCache = false;
     boolean noStore = false;
     boolean noTransform = false;
     boolean isPrivate = false;
     boolean proxyRevalidate = false;
-    decimal maxAge = -1;
+    decimal maxAge = 600;
     decimal sMaxAge = -1;
     string[] noCacheFields = [];
     string[] privateFields = [];
@@ -130,5 +130,6 @@ public type HttpCacheConfig record {|
 |};
 
 # The annotation which is used to define the response cache configuration. This annotation only supports `anydata` and
-# `SuccessStatusCodeResponse` return types.
+# Success(2XX) `StatusCodeResponses` return types. Default annotation adds `must-revalidate,public,max-age=600` as
+# `cache-control` header in addition to `etag` and `last-modified` headers.
 public annotation HttpCacheConfig CacheConfig on return;

--- a/ballerina/http_annotation.bal
+++ b/ballerina/http_annotation.bal
@@ -96,3 +96,37 @@ public type HttpHeader record {|
 
 # The annotation which is used to define the Header resource signature parameter.
 public annotation HttpHeader Header on parameter;
+
+# Defines the HTTP response cache configuration.
+#
+# + mustRevalidate - Sets the `must-revalidate` directive
+# + noCache - Sets the `no-cache` directive
+# + noStore - Sets the `no-store` directive
+# + noTransform - Sets the `no-transform` directive
+# + isPrivate - Sets the `private` and `public` directives
+# + proxyRevalidate - Sets the `proxy-revalidate` directive
+# + maxAge - Sets the `max-age` directive
+# + sMaxAge - Sets the `s-maxage` directive
+# + noCacheFields - Optional fields for the `no-cache` directive. Before sending a listed field in a response, it
+#                   must be validated with the origin server
+# + privateFields - Optional fields for the `private` directive. A cache can omit the fields specified and store
+#                   the rest of the response
+# + setETag - Sets the `etag` header for the given payload
+# + setLastModified - Sets the current time as the `last-modified` header
+public type HttpCacheConfig record {|
+    boolean mustRevalidate = false;
+    boolean noCache = false;
+    boolean noStore = false;
+    boolean noTransform = false;
+    boolean isPrivate = false;
+    boolean proxyRevalidate = false;
+    decimal maxAge = -1;
+    decimal sMaxAge = -1;
+    string[] noCacheFields = [];
+    string[] privateFields = [];
+    boolean setETag = false;
+    boolean setLastModified = false;
+|};
+
+# The annotation which is used to define the response cache configuration.
+public annotation HttpCacheConfig CacheConfig on return;

--- a/ballerina/http_connection.bal
+++ b/ballerina/http_connection.bal
@@ -118,16 +118,16 @@ public client class Caller {
         Response response = new;
         boolean setETag = cacheConfig is () ? false: cacheConfig.setETag;
         boolean cacheCompatibleType = false;
-        if (message is ()) {
-            if (self.present) {
+        if message is () {
+            if self.present {
                 InternalServerError errResponse = {};
                 response = createStatusCodeResponse(errResponse);
             } else {
                 Accepted AcceptedResponse = {};
                 response = createStatusCodeResponse(AcceptedResponse);
             }
-        } else if (message is error) {
-            if (message is ApplicationResponseError) {
+        } else if message is error {
+            if message is ApplicationResponseError {
                 InternalServerError err = {
                     headers: message.detail().headers,
                     body: message.detail().body
@@ -138,14 +138,14 @@ public client class Caller {
                 response.statusCode = STATUS_INTERNAL_SERVER_ERROR;
                 response.setTextPayload(message.message());
             }
-        } else if (message is StatusCodeResponse) {
-            if (message is SuccessStatusCodeResponse) {
+        } else if message is StatusCodeResponse {
+            if message is SuccessStatusCodeResponse {
                 response = createStatusCodeResponse(message, returnMediaType, setETag);
                 cacheCompatibleType = true;
             } else {
                 response = createStatusCodeResponse(message, returnMediaType);
             }
-        } else if (message is Response) {
+        } else if message is Response {
             response = message;
             // Update content-type header with mediaType annotation value only if the response does not already 
             // have a similar header
@@ -154,7 +154,7 @@ public client class Caller {
             }
         } else {
             setPayload(message, response, setETag);
-            if (returnMediaType is string) {
+            if returnMediaType is string {
                 response.setHeader(CONTENT_TYPE, returnMediaType);
             }
             cacheCompatibleType = true;
@@ -218,21 +218,21 @@ isolated function createStatusCodeResponse(StatusCodeResponse message, string? r
 }
 
 isolated function setPayload(anydata payload, Response response, boolean setETag = false) {
-    if (payload is ()) {
+    if payload is () {
         return;
-    } else if (payload is xml) {
+    } else if payload is xml {
         response.setXmlPayload(payload);
-        if (setETag) {
+        if setETag {
             response.setETag(payload);
         }
-    } else if (payload is string) {
+    } else if payload is string {
         response.setTextPayload(payload);
-        if (setETag) {
+        if setETag {
             response.setETag(payload);
         }
-    } else if (payload is byte[]) {
+    } else if payload is byte[] {
         response.setBinaryPayload(payload);
-        if (setETag) {
+        if setETag {
             response.setETag(payload);
         }
     } else {
@@ -242,11 +242,11 @@ isolated function setPayload(anydata payload, Response response, boolean setETag
 
 isolated function castToJsonAndSetPayload(Response response, anydata payload, string errMsg, boolean setETag = false) {
     var result = trap val:toJson(payload);
-    if (result is error) {
+    if result is error {
         panic error InitializingOutboundResponseError(errMsg + result.message(), result);
     } else {
         response.setJsonPayload(result);
-        if (setETag) {
+        if setETag {
             response.setETag(result);
         }
     }

--- a/ballerina/http_connection.bal
+++ b/ballerina/http_connection.bal
@@ -117,7 +117,7 @@ public client class Caller {
         HttpCacheConfig? cacheConfig) returns ListenerError? {
         Response response = new;
         boolean setETag = cacheConfig is () ? false: cacheConfig.setETag;
-        boolean enableCache = false;
+        boolean cacheCompatibleType = false;
         if (message is ()) {
             if (self.present) {
                 InternalServerError errResponse = {};
@@ -141,7 +141,7 @@ public client class Caller {
         } else if (message is StatusCodeResponse) {
             if (message is SuccessStatusCodeResponse) {
                 response = createStatusCodeResponse(message, returnMediaType, setETag);
-                enableCache = true;
+                cacheCompatibleType = true;
             } else {
                 response = createStatusCodeResponse(message, returnMediaType);
             }
@@ -157,9 +157,9 @@ public client class Caller {
             if (returnMediaType is string) {
                 response.setHeader(CONTENT_TYPE, returnMediaType);
             }
-            enableCache = true;
+            cacheCompatibleType = true;
         }
-        if (enableCache && (cacheConfig is HttpCacheConfig)) {
+        if (cacheCompatibleType && (cacheConfig is HttpCacheConfig)) {
             ResponseCacheControl responseCacheControl = new;
             responseCacheControl.populateFields(cacheConfig);
             response.cacheControl = responseCacheControl;

--- a/ballerina/http_response.bal
+++ b/ballerina/http_response.bal
@@ -342,7 +342,7 @@ public class Response {
     #
     # + payload - The payload for which the ETag should be set
     public isolated function setETag(json|xml|string|byte[] payload) {
-        string etag = crypto:crc32b(payload.toString().toBytes());
+        string etag = payload is byte[] ? crypto:crc32b(payload) : crypto:crc32b(payload.toString().toBytes());
         self.setHeader(ETAG, etag);
     }
 

--- a/ballerina/http_status_code_types.bal
+++ b/ballerina/http_status_code_types.bal
@@ -24,7 +24,7 @@ public type StatusCodeResponse Continue|SwitchingProtocols|Ok|Created|Accepted|N
     InternalServerError|NotImplemented|BadGateway|ServiceUnavailable|GatewayTimeout|HttpVersionNotSupported;
 
 # Defines the possible success status code response record types.
-public type SuccessStatusCodeResponse Ok|Created|Accepted|NonAuthoritativeInformation|NoContent|ResetContent|
+type SuccessStatusCodeResponse Ok|Created|Accepted|NonAuthoritativeInformation|NoContent|ResetContent|
     PartialContent;
 
 # The `Status` object creates the distinction for the different response status code types.

--- a/ballerina/http_status_code_types.bal
+++ b/ballerina/http_status_code_types.bal
@@ -23,6 +23,10 @@ public type StatusCodeResponse Continue|SwitchingProtocols|Ok|Created|Accepted|N
     UriTooLong|UnsupportedMediaType|RangeNotSatisfiable|ExpectationFailed|UpgradeRequired|RequestHeaderFieldsTooLarge|
     InternalServerError|NotImplemented|BadGateway|ServiceUnavailable|GatewayTimeout|HttpVersionNotSupported;
 
+# Defines the possible success status code response record types.
+public type SuccessStatusCodeResponse Ok|Created|Accepted|NonAuthoritativeInformation|NoContent|ResetContent|
+    PartialContent;
+
 # The `Status` object creates the distinction for the different response status code types.
 #
 # + code - The response status code

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Added
 - [Enable HTTP trace and access log support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1073)
 - [Add HATEOS link support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1637)
+- [Introduce http:CacheConfig annotation to the resource signature](https://github.com/ballerina-platform/ballerina-standard-library/issues/1533)
 
 ## [1.1.0-beta.2] - 2021-07-07
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/BallerinaHTTPConnectorListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/BallerinaHTTPConnectorListener.java
@@ -113,7 +113,7 @@ public class BallerinaHTTPConnectorListener implements HttpConnectorListener {
             inboundMessage.setProperty(HttpConstants.OBSERVABILITY_CONTEXT_PROPERTY, observerContext);
         }
         Callback callback = new HttpCallableUnitCallback(inboundMessage, httpServicesRegistry.getRuntime(),
-                                                         httpResource.getReturnMediaType());
+                                httpResource.getReturnMediaType(), httpResource.getResponseCacheConfig());
         BObject service = httpResource.getParentService().getBalService();
         httpServicesRegistry.getRuntime().invokeMethodAsync(service, httpResource.getName(), null,
                                                             ModuleUtils.getOnMessageMetaData(), callback,

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
@@ -20,6 +20,7 @@ import io.ballerina.runtime.api.Runtime;
 import io.ballerina.runtime.api.async.Callback;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BError;
+import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.observability.ObserveUtils;
 import io.ballerina.runtime.observability.ObserverContext;
@@ -37,14 +38,17 @@ public class HttpCallableUnitCallback implements Callback {
     private final BObject caller;
     private final Runtime runtime;
     private final String returnMediaType;
+    private final BMap cacheConfig;
     private HttpCarbonMessage requestMessage;
     private static final String ILLEGAL_FUNCTION_INVOKED = "illegal return: response has already been sent";
 
-    HttpCallableUnitCallback(HttpCarbonMessage requestMessage, Runtime runtime, String returnMediaType) {
+    HttpCallableUnitCallback(HttpCarbonMessage requestMessage, Runtime runtime, String returnMediaType,
+                             BMap cacheConfig) {
         this.requestMessage = requestMessage;
         this.caller = (BObject) requestMessage.getProperty(HttpConstants.CALLER);
         this.runtime = runtime;
         this.returnMediaType = returnMediaType;
+        this.cacheConfig = cacheConfig;
     }
 
     @Override
@@ -55,11 +59,13 @@ public class HttpCallableUnitCallback implements Callback {
         }
         printStacktraceIfError(result);
 
-        Object[] paramFeed = new Object[4];
+        Object[] paramFeed = new Object[6];
         paramFeed[0] = result;
         paramFeed[1] = true;
         paramFeed[2] = returnMediaType != null ? StringUtils.fromString(returnMediaType) : null;
         paramFeed[3] = true;
+        paramFeed[4] = cacheConfig;
+        paramFeed[5] = true;
 
         Callback returnCallback = new Callback() {
             @Override

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -147,6 +147,7 @@ public class HttpConstants {
     public static final String DIRTY_RESPONSE = "dirtyResponse";
     public static final BString ANN_FIELD_MEDIA_TYPE = StringUtils.fromString("mediaType");
     public static final BString ANN_FIELD_NAME = StringUtils.fromString("name");
+    public static final String ANN_NAME_CACHE_CONFIG = "CacheConfig";
 
     public static final String VALUE_ATTRIBUTE = "value";
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpResource.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpResource.java
@@ -73,6 +73,7 @@ public class HttpResource {
     private String wildcardToken;
     private int pathParamCount;
     private String returnMediaType;
+    private BMap cacheConfig;
 
     protected HttpResource(MethodType resource, HttpService parentService) {
         this.balResource = resource;
@@ -82,6 +83,7 @@ public class HttpResource {
             this.populateResourcePath();
             this.populateMethod();
             this.populateReturnMediaType();
+            this.populateResponseCacheConfig();
         }
     }
 
@@ -295,6 +297,26 @@ public class HttpResource {
 
     String getReturnMediaType() {
         return returnMediaType;
+    }
+
+    private void populateResponseCacheConfig() {
+        BMap annotations = (BMap) getBalResource().getAnnotation(StringUtils.fromString(RETURN_ANNOT_PREFIX));
+        if (annotations == null) {
+            return;
+        }
+        Object[] annotationsKeys = annotations.getKeys();
+        for (Object objKey : annotationsKeys) {
+            BString key = ((BString) objKey);
+            if (!ParamHandler.CACHE_CONFIG_ANNOTATION.equals(key.getValue())) {
+                continue;
+            }
+            this.cacheConfig = annotations.getMapValue(key);
+            return;
+        }
+    }
+
+    BMap getResponseCacheConfig() {
+        return cacheConfig;
     }
 
     // Followings added due to WebSub requirement

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static io.ballerina.stdlib.http.api.HttpConstants.ANN_NAME_CACHE_CONFIG;
 import static io.ballerina.stdlib.http.api.HttpConstants.ANN_NAME_CALLER_INFO;
 import static io.ballerina.stdlib.http.api.HttpConstants.ANN_NAME_HEADER;
 import static io.ballerina.stdlib.http.api.HttpConstants.ANN_NAME_PAYLOAD;
@@ -77,6 +78,8 @@ public class ParamHandler {
             ModuleUtils.getHttpPackageIdentifier() + COLON + ANN_NAME_CALLER_INFO;
     public static final String PAYLOAD_ANNOTATION = ModuleUtils.getHttpPackageIdentifier() + COLON + ANN_NAME_PAYLOAD;
     public static final String HEADER_ANNOTATION = ModuleUtils.getHttpPackageIdentifier() + COLON + ANN_NAME_HEADER;
+    public static final String CACHE_CONFIG_ANNOTATION = ModuleUtils.getHttpPackageIdentifier() + COLON
+            + ANN_NAME_CACHE_CONFIG;
 
     public ParamHandler(ResourceMethodType resource, int pathParamCount) {
         this.resource = resource;


### PR DESCRIPTION
## Purpose

> Fixes [`ballerina-standard-library/issues/1533`](https://github.com/ballerina-platform/ballerina-standard-library/issues/1533)

This annotation can be used to enable response caching from the resource signature. This allows to set the `cache-control`, `etag` and `last-modified` headers in the response. 

The default behavior (`@http:CacheConfig`) is to have `must-revalidate,public,max-age=3600` directives in `cache-control` header. In addition to that `etag` and `last-modified` headers will be added. 

```ballerina
@http:CacheConfig {           // Default Configuration
    mustRevalidate : true,    // Sets the must-revalidate directive
    noCache : false,          // Sets the no-cache directive
    noStore : false,          // Sets the no-store directive 
    noTransform : false,      // Sets the no-transform directive
    isPrivate : false,        // Sets the private and public directive
    proxyRevalidate : false,  // Sets the proxy-revalidate directive
    maxAge : 600,             // Sets the max-age directive. Default value is 3600 seconds
    sMaxAge : -1,             // Sets the s-maxage directive
    noCacheFields : [],       // Optional fields for no-cache directive
    privateFields : [],       // Optional fields for private directive
    setETag : true,           // Sets the etag header
    setLastModified : true    // Sets the last-modified header
}
```
This annotation can **only** support return types of `anydata` and `SucessStatusCodeResponse`. (For other return values cache configuration will not be added through this annotation)

## Example

```ballerina
// Sets the cache-control header as "public,must-revalidate,max-age=5". Also sets the etag header.
// last-modified header will not be set
resource function get cachingBackEnd(http:Request req) returns @http:CacheConfig{maxAge : 5, 
    setLastModified : false} string {

    return "Hello, World!!"
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests