### PR TITLE
Remove unnecessary warning logs

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/websocket/DefaultWebSocketConnection.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/websocket/DefaultWebSocketConnection.java
@@ -273,8 +273,6 @@ public class DefaultWebSocketConnection implements WebSocketConnection {
         if (ctx.pipeline().get(IDLE_STATE_HANDLER) == null && readTimeOut > 0) {
             ctx.pipeline().addBefore(MESSAGE_QUEUE_HANDLER, IDLE_STATE_HANDLER,
                     new IdleStateHandler(readTimeOut, 0, 0, TimeUnit.SECONDS));
-        } else {
-            LOG.warn("Idle state handler already added to the sync client");
         }
     }
 


### PR DESCRIPTION
## Purpose
Earlier this was added since we didn't have idle state handlers added before reading the messages. 
After that with this issue(https://github.com/ballerina-platform/ballerina-standard-library/issues/1478) being fixed, this log becomes no longer valid and unnecessary. 

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests