### PR TITLE
Introduce anydata as an outbound req/resp data types

### DIFF
--- a/ballerina-tests/tests/http_client_actions_test.bal
+++ b/ballerina-tests/tests/http_client_actions_test.bal
@@ -105,7 +105,6 @@ service /httpClientActionBE on httpClientActionListenerEP1 {
         checkpanic caller->respond(checkpanic request.getTextPayload());
     }
 
-    // withWhitespacedExpression
     resource function 'default [string id](http:Caller caller, http:Request request) {
         error? res = caller->respond(id);
     }
@@ -197,8 +196,8 @@ service /httpClientActionTestService on httpClientActionListenerEP2 {
                 value = value + result.message();
             }
         }
-
-        http:Response|error jsonResponse = clientEP2->post("/httpClientActionBE/directPayload", { name: "apple", color: "red" });
+        json j = { name: "apple", color: "red" };
+        http:Response|error jsonResponse = clientEP2->post("/httpClientActionBE/directPayload", j);
         if (jsonResponse is http:Response) {
             var result = jsonResponse.getJsonPayload();
             if (result is json) {
@@ -226,46 +225,46 @@ service /httpClientActionTestService on httpClientActionListenerEP2 {
         checkpanic caller->respond(value);
     }
 
-    resource function get handleStringJson(http:Caller caller, http:Request request) {
-      http:Request req = new;
-      string payload = "a" + "\n" + "b" + "\n";
-      req.setJsonPayload(payload);
-      string backendPayload = checkpanic clientEP2->post("/httpClientActionBE/_bulk", req, targetType = string);
-      checkpanic caller->respond(backendPayload);
+    resource function get handleStringJson(http:Caller caller) returns error? {
+        http:Request req = new;
+        string payload = "a" + "\n" + "b" + "\n";
+        req.setJsonPayload(payload);
+        string backendPayload = check clientEP2->post("/httpClientActionBE/_bulk", req);
+        check caller->respond(backendPayload);
     }
 
-    resource function get handleTextAndJsonContent(http:Caller caller, http:Request request) {
+    resource function get handleTextAndJsonContent(http:Caller caller) returns error? {
         http:Request req = new;
         string payload = "a" + "\n" + "b" + "\n";
         req.setTextPayload(payload, contentType = "application/json");
-        string backendPayload = checkpanic clientEP2->post("/httpClientActionBE/_bulk", req, targetType = string);
-        checkpanic caller->respond(backendPayload);
+        string backendPayload = check clientEP2->post("/httpClientActionBE/_bulk", req);
+        check caller->respond(backendPayload);
     }
 
-    resource function get handleTextAndXmlContent(http:Caller caller, http:Request request) {
+    resource function get handleTextAndXmlContent(http:Caller caller) returns error? {
         http:Request req = new;
         string payload = "a" + "\n" + "b" + "\n";
         req.setTextPayload(payload, contentType = "text/xml");
-        string backendPayload = checkpanic clientEP2->post("/httpClientActionBE/_bulk", req, targetType = string);
-        checkpanic caller->respond(backendPayload);
+        string backendPayload = check clientEP2->post("/httpClientActionBE/_bulk", req);
+        check caller->respond(backendPayload);
     }
 
-    resource function get handleTextAndJsonAlternateContent(http:Caller caller, http:Request request) {
+    resource function get handleTextAndJsonAlternateContent(http:Caller caller) returns error? {
         http:Request req = new;
         string payload = "a" + "\n" + "b" + "\n";
         req.setTextPayload(payload, contentType = "application/json");
         req.setJsonPayload(payload);
-        string backendPayload = checkpanic clientEP2->post("/httpClientActionBE/_bulk", req, targetType = string);
-        checkpanic caller->respond(backendPayload);
+        string backendPayload = check clientEP2->post("/httpClientActionBE/_bulk", req);
+        check caller->respond(backendPayload);
     }
 
-    resource function get handleStringJsonAlternate(http:Caller caller, http:Request request) {
-      http:Request req = new;
-      string payload = "a" + "\n" + "b" + "\n";
-      req.setJsonPayload(payload);
-      req.setTextPayload(payload, contentType = "application/json");
-      string backendPayload = checkpanic clientEP2->post("/httpClientActionBE/_bulk", req, targetType = string);
-      checkpanic caller->respond(backendPayload);
+    resource function get handleStringJsonAlternate(http:Caller caller) returns error? {
+        http:Request req = new;
+        string payload = "a" + "\n" + "b" + "\n";
+        req.setJsonPayload(payload);
+        req.setTextPayload(payload, contentType = "application/json");
+        string backendPayload = check clientEP2->post("/httpClientActionBE/_bulk", req);
+        check caller->respond(backendPayload);
     }
 
     // TODO: Enable after the I/O revamp

--- a/ballerina-tests/tests/http_outbound_headers_test.bal
+++ b/ballerina-tests/tests/http_outbound_headers_test.bal
@@ -299,7 +299,7 @@ public function testDeleteWithOverrideMediaType() {
 
 @test:Config {}
 public function testInlineReq() {
-    var resp = outReqHeadClient->post("/mytest/inline", 
+    var resp = outReqHeadClient->post("/mytest/inline",
         { 
             name: "foo", 
             age: 30, 

--- a/ballerina-tests/tests/http_outbound_message_type_test.bal
+++ b/ballerina-tests/tests/http_outbound_message_type_test.bal
@@ -22,92 +22,248 @@ listener http:Listener outRequestTypeTestEP = new(outRequestTypeTest);
 http:Client outRequestClient = check new("http://localhost:" + outRequestTypeTest.toString());
 
 type CustomerTable table<map<json>>;
+type CustomerIntTable table<map<int>>;
 
 @test:Config {}
-public function testSendingNil() {
-    http:Response|error resp = outRequestClient->post("/mytest/nil", ());
-    if (resp is http:Response) {
-        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        test:assertEquals(checkpanic resp.getHeader(CONTENT_TYPE), TEXT_PLAIN);
-        assertTextPayload(resp.getTextPayload(), "0");
-    } else {
-        test:assertFail(msg = "Found unexpected output: " +  resp.message());
-    }
+public function testSendingNil() returns error? {
+    http:Response resp = check outRequestClient->post("/mytest/nil", ());
+    test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
+    test:assertEquals(check resp.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+    assertTextPayload(resp.getTextPayload(), "0");
 }
 
 @test:Config {}
-public function testSendingInt() {
+public function testSendingInt() returns error? {
     int val = 139;
-    http:Response|error resp = outRequestClient->post("/mytest/json", val);
-    if (resp is http:Response) {
-        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
-        assertJsonPayload(resp.getJsonPayload(), 139);
-    } else {
-        test:assertFail(msg = "Found unexpected output: " +  resp.message());
-    }
+    http:Response resp = check outRequestClient->post("/mytest/json", val);
+    test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
+    assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+    assertJsonPayload(resp.getJsonPayload(), 139);
 }
 
 @test:Config {}
-public function testSendingFloat() {
+public function testSendingIntArr() returns error? {
+    int[] val = [139,5345];
+    json payload = check outRequestClient->post("/mytest/json", val);
+    test:assertEquals(payload, [139, 5345], msg = "Found unexpected output");
+}
+
+@test:Config {}
+public function testSendingIntMap() returns error? {
+    map<int> val = {a: 139, b: 5345};
+    json payload = check outRequestClient->post("/mytest/json", val);
+    test:assertEquals(payload, {a: 139,b: 5345}, msg = "Found unexpected output");
+}
+
+@test:Config {}
+public function testSendingIntMapTable() returns error? {
+    table<map<int>> customerTab = table [
+        {id: 13 , fname: 1, lname: 2},
+        {id: 23 , fname: 3 , lname: 4}
+    ];
+    json payload = check outRequestClient->post("/mytest/json", customerTab);
+    test:assertEquals(payload, [{id: 13 , fname: 1, lname: 2}, {id: 23 , fname: 3 , lname: 4}],
+        msg = "Found unexpected output");
+}
+
+@test:Config {}
+public function testSendingFloat() returns error? {
     float val = 1.39;
-    http:Response|error resp = outRequestClient->post("/mytest/json", val);
-    if (resp is http:Response) {
-        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
-        assertJsonPayloadtoJsonString(resp.getJsonPayload(), 1.39);
-    } else {
-        test:assertFail(msg = "Found unexpected output: " +  resp.message());
-    }
+    http:Response resp = check outRequestClient->post("/mytest/json", val);
+    test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
+    assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+    assertJsonPayloadtoJsonString(resp.getJsonPayload(), 1.39);
 }
 
 @test:Config {}
-public function testSendingDecimal() {
+public function testSendingFloatArr() returns error? {
+    float[] val = [13.9,53.45];
+    json payload = check outRequestClient->post("/mytest/json", val);
+    assertJsonPayloadtoJsonString(payload, [13.9,53.45]);
+}
+
+@test:Config {}
+public function testSendingFloatMap() returns error? {
+    map<float> val = {a: 13.9, b: 53.45};
+    json payload = check outRequestClient->post("/mytest/json", val);
+    assertJsonPayloadtoJsonString(payload, {a: 13.9,b: 53.45});
+}
+
+@test:Config {}
+public function testSendingFloatMapTable() returns error? {
+    table<map<float>> customerTab = table [
+        {id: 13 , fname: 1.0, lname: 2.23},
+        {id: 23 , fname: 34.234 , lname: 4.42314}
+    ];
+    json payload = check outRequestClient->post("/mytest/json", customerTab);
+    assertJsonPayloadtoJsonString(payload, [{id: 13.0 , fname: 1.0, lname: 2.23},
+        {id: 23.0 , fname: 34.234 , lname: 4.42314}]);
+}
+
+@test:Config {}
+public function testSendingDecimal() returns error? {
     decimal val = 1.3;
-    http:Response|error resp = outRequestClient->post("/mytest/json", val);
-    if (resp is http:Response) {
-        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
-        assertJsonPayloadtoJsonString(resp.getJsonPayload(), 1.3);
-    } else {
-        test:assertFail(msg = "Found unexpected output: " +  resp.message());
-    }
+    http:Response resp = check outRequestClient->post("/mytest/json", val);
+    test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
+    assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+    assertJsonPayloadtoJsonString(resp.getJsonPayload(), 1.3);
 }
 
 @test:Config {}
-public function testSendingBoolean() {
+public function testSendingDecimalArr() returns error? {
+    decimal[] val = [13.9,53.45];
+    json payload = check outRequestClient->post("/mytest/json", val);
+    assertJsonPayloadtoJsonString(payload, [13.9,53.45]);
+}
+
+@test:Config {}
+public function testSendingDecimalMap() returns error? {
+    map<decimal> val = {a: 13.9, b: 53.45};
+    json payload = check outRequestClient->post("/mytest/json", val);
+    assertJsonPayloadtoJsonString(payload, {a: 13.9,b: 53.45});
+}
+
+@test:Config {}
+public function testSendingDecimalMapTable() returns error? {
+    table<map<decimal>> customerTab = table [
+        {id: 13 , fname: 1.0, lname: 2.23},
+        {id: 23 , fname: 34.234 , lname: 4.42314}
+    ];
+    json payload = check outRequestClient->post("/mytest/json", customerTab);
+    assertJsonPayloadtoJsonString(payload, [{id: 13 , fname: 1.0, lname: 2.23},
+        {id: 23 , fname: 34.234 , lname: 4.42314}]);
+}
+
+@test:Config {}
+public function testSendingBoolean() returns error? {
     boolean val = true;
+    http:Response resp = check outRequestClient->post("/mytest/json", val);
+    test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
+    assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+    assertJsonPayload(resp.getJsonPayload(), true);
+}
+
+@test:Config {}
+public function testSendingBooleanArr() returns error? {
+    boolean[] val = [true, false];
+    json payload = check outRequestClient->post("/mytest/json", val);
+    assertJsonPayloadtoJsonString(payload, [true,false]);
+}
+
+@test:Config {}
+public function testSendingBooleanMap() returns error? {
+    map<boolean> val = {a: true, b: false};
+    json payload = check outRequestClient->post("/mytest/json", val);
+    assertJsonPayloadtoJsonString(payload, {a: true,b: false});
+}
+
+@test:Config {}
+public function testSendingBooleanMapTable() returns error? {
+    table<map<boolean>> customerTab = table [
+        {id: true, fname: false, lname: true},
+        {id: false, fname: true, lname: false}
+    ];
+    json payload = check outRequestClient->post("/mytest/json", customerTab);
+    assertJsonPayloadtoJsonString(payload, [{id: true, fname: false, lname: true},
+        {id: false, fname: true, lname: false}]);
+}
+
+@test:Config {}
+public function testSendingString() returns error? {
+    string val = "ballerina";
+    http:Response resp = check outRequestClient->post("/mytest/string", val);
+    test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
+    assertHeaderValue(check resp.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+    test:assertEquals(check resp.getTextPayload(), "ballerina");
+}
+
+@test:Config {}
+public function testSendingStringArr() returns error? {
+    string[] val = ["ballerina1","ballerina2"];
+    json payload = check outRequestClient->post("/mytest/json", val);
+    test:assertEquals(payload, ["ballerina1", "ballerina2"], msg = "Found unexpected output");
+}
+
+@test:Config {}
+public function testSendingStringMap() returns error? {
+    map<string> val = {a: "ballerina1", b: "ballerina2"};
+    json payload = check outRequestClient->post("/mytest/json", val);
+    test:assertEquals(payload, {a: "ballerina1",b: "ballerina2"}, msg = "Found unexpected output");
+}
+
+@test:Config {}
+public function testSendingStringMapTable() returns error? {
+    table<map<string>> customerTab = table [
+        {id: "ballerina1" , fname: "ballerina2", lname: "ballerina3"},
+        {id: "ballerina3" , fname: "ballerina2" , lname: "ballerina1"}
+    ];
+    json payload = check outRequestClient->post("/mytest/json", customerTab);
+    test:assertEquals(payload, [{id: "ballerina1" , fname: "ballerina2", lname: "ballerina3"},
+        {id: "ballerina3" , fname: "ballerina2" , lname: "ballerina1"}],
+        msg = "Found unexpected output");
+}
+
+@test:Config {}
+public function testSendingXml() returns error? {
+    xml val = xml `<name>Ballerina</name>`;
+    http:Response resp = check outRequestClient->post("/mytest/xml", val);
+    test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
+    assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_XML);
+    test:assertEquals(check resp.getXmlPayload(), val);
+}
+
+@test:Config {}
+public function testSendingXmlArr() returns error? {
+    xml val = xml `<name>Ballerina</name>`;
+    xml[] arr = [val, val];
+    json payload = check outRequestClient->post("/mytest/json", arr);
+    assertJsonPayloadtoJsonString(payload, ["<name>Ballerina</name>","<name>Ballerina</name>"]);
+}
+
+@test:Config {}
+public function testSendingXmlMap() returns error? {
+    xml val = xml `<name>Ballerina</name>`;
+    map<xml> xmlMap = {a: val, b: val};
+    json payload = check outRequestClient->post("/mytest/json", xmlMap);
+    assertJsonPayloadtoJsonString(payload, {a: "<name>Ballerina</name>",b: "<name>Ballerina</name>"});
+}
+
+@test:Config {}
+public function testSendingXmlMapTable() returns error? {
+    xml val1 = xml `<name>Ballerina1</name>`;
+    xml val2 = xml `<name>Ballerina2</name>`;
+    xml val3 = xml `<name>Ballerina3</name>`;
+    table<map<xml>> customerTab = table [
+        {id: val1, fname: val2, lname: val3},
+        {id: val3, fname: val1, lname: val2}
+    ];
+    json payload = check outRequestClient->post("/mytest/json", customerTab);
+    assertJsonPayloadtoJsonString(payload,
+        [{id: "<name>Ballerina1</name>", fname: "<name>Ballerina2</name>", lname: "<name>Ballerina3</name>"},
+        {id: "<name>Ballerina3</name>", fname: "<name>Ballerina1</name>", lname: "<name>Ballerina2</name>"}]);
+}
+
+@test:Config {}
+public function testSendingMap() returns error? {
+    map<json> val = {sam: 50, john: {no:56}};
     http:Response|error resp = outRequestClient->post("/mytest/json", val);
     if (resp is http:Response) {
         test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
-        assertJsonPayload(resp.getJsonPayload(), true);
+        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertJsonPayload(resp.getJsonPayload(), {sam: 50, john: {no:56}});
     } else {
         test:assertFail(msg = "Found unexpected output: " +  resp.message());
     }
 }
 
 @test:Config {}
-public function testSendingMap() {
-    map<int> val = {sam: 50, jhon: 60};
-    http:Response|error resp = outRequestClient->post("/mytest/json", val);
-    if (resp is http:Response) {
-        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
-        assertJsonPayload(resp.getJsonPayload(), {sam: 50, jhon: 60});
-    } else {
-        test:assertFail(msg = "Found unexpected output: " +  resp.message());
-    }
-}
-
-@test:Config {}
-public function testSendingMapArray() {
-    map<json> jj = {sam: {hello:"world"}, jhon: {no:56}};
+public function testSendingMapArray() returns error? {
+    map<json> jj = {sam: {hello:"world"}, john: {no:56}};
     map<json>[] val = [jj,jj];
     http:Response|error resp = outRequestClient->post("/mytest/json", val);
     if (resp is http:Response) {
         test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
         assertJsonPayload(resp.getJsonPayload(), val);
     } else {
         test:assertFail(msg = "Found unexpected output: " +  resp.message());
@@ -115,7 +271,7 @@ public function testSendingMapArray() {
 }
 
 @test:Config {}
-public function testSendingTable() {
+public function testSendingTable() returns error? {
     CustomerTable customerTab = table [
         {id: 13 , fname: "Dan", lname: "Bing"},
         {id: 23 , fname: "Hay" , lname: "Kelsey"}
@@ -123,7 +279,7 @@ public function testSendingTable() {
     http:Response|error resp = outRequestClient->post("/mytest/json", customerTab);
     if (resp is http:Response) {
         test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
         assertJsonPayload(resp.getJsonPayload(), [{id: 13 , fname: "Dan", lname: "Bing"},
             {id: 23 , fname: "Hay" , lname: "Kelsey"}]);
     } else {
@@ -132,7 +288,7 @@ public function testSendingTable() {
 }
 
 @test:Config {}
-public function testSendingTableArray() {
+public function testSendingTableArray() returns error? {
     CustomerTable customerTab = table [
         {id: 13 , fname: "Dan", lname: "Bing"}
     ];
@@ -140,12 +296,23 @@ public function testSendingTableArray() {
     http:Response|error resp = outRequestClient->post("/mytest/json", customerTabArr);
     if (resp is http:Response) {
         test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
         assertJsonPayload(resp.getJsonPayload(), [[{id: 13 , fname: "Dan", lname: "Bing"}],
             [{id: 13 , fname: "Dan", lname: "Bing"}]]);
     } else {
         test:assertFail(msg = "Found unexpected output: " +  resp.message());
     }
+}
+
+@test:Config {}
+public function testSendingTableMap() returns error? {
+    CustomerTable customerTab = table [
+        {id: 13 , fname: "Dan", lname: "Bing"}
+    ];
+    map<CustomerTable> customerTabMap = {a: customerTab, b: customerTab};
+    json payload = check outRequestClient->post("/mytest/json", customerTabMap);
+    assertJsonPayload(payload, {a : [{id: 13 , fname: "Dan", lname: "Bing"}],
+        b: [{id: 13 , fname: "Dan", lname: "Bing"}]});
 }
 
 type OpenCustomer record {
@@ -157,29 +324,39 @@ type OpenCustomer record {
 @test:Config {}
 public function testSendingOpenRecord() returns error? {
     OpenCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
-    http:Response|error resp = outRequestClient->post("/mytest/json", customer);
-    if (resp is http:Response) {
-        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
-        assertJsonPayload(resp.getJsonPayload(), {"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]});
-    } else {
-        test:assertFail(msg = "Found unexpected output: " +  resp.message());
-    }
+    json payload = check outRequestClient->post("/mytest/json", customer);
+    assertJsonPayload(payload, {"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]});
 }
 
 @test:Config {}
 public function testSendingOpenRecordArray() returns error? {
     OpenCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
     OpenCustomer[] custArr = [customer, customer];
-    http:Response|error resp = outRequestClient->post("/mytest/json", custArr);
-    if (resp is http:Response) {
-        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
-        assertJsonPayload(resp.getJsonPayload(), [{"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]},
-            {"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]}]);
-    } else {
-        test:assertFail(msg = "Found unexpected output: " +  resp.message());
-    }
+    json payload = check outRequestClient->post("/mytest/json", custArr);
+    assertJsonPayload(payload, [{"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]},
+        {"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]}]);
+}
+
+@test:Config {}
+public function testSendingOpenRecordMap() returns error? {
+    OpenCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
+    map<OpenCustomer> custMap = {a:customer, b:customer};
+    json payload = check outRequestClient->post("/mytest/json", custMap);
+    assertJsonPayload(payload,
+        {a:{"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]},
+        b:{"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]}});
+}
+
+@test:Config {}
+public function testSendingOpenRecordTable() returns error? {
+    table<OpenCustomer> customerTab = table [
+        { name: "ballerina1", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()},
+        { name: "ballerina2", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()}
+    ];
+    json payload = check outRequestClient->post("/mytest/json", customerTab);
+    assertJsonPayload(payload,
+        [{ name: "ballerina1", aa: "<book>Hello World</book>", bb: [97,98,99]},
+        { name: "ballerina2", aa: "<book>Hello World</book>", bb: [97,98,99]}]);
 }
 
 type ClosedCustomer record {|
@@ -191,34 +368,59 @@ type ClosedCustomer record {|
 @test:Config {}
 public function testSendingClosedRecord() returns error? {
     ClosedCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
-    http:Response|error resp = outRequestClient->post("/mytest/json", customer);
-    if (resp is http:Response) {
-        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
-        assertJsonPayload(resp.getJsonPayload(), {name: "ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]});
-    } else {
-        test:assertFail(msg = "Found unexpected output: " +  resp.message());
-    }
+    json payload = check outRequestClient->post("/mytest/json", customer);
+    assertJsonPayload(payload, {name: "ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]});
 }
 
 @test:Config {}
 public function testSendingClosedRecordArray() returns error? {
     ClosedCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
     ClosedCustomer[] custArr = [customer, customer];
-    http:Response|error resp = outRequestClient->post("/mytest/json", custArr);
-    if (resp is http:Response) {
-        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
-        assertJsonPayload(resp.getJsonPayload(), [{"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]},
-            {"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]}]);
-    } else {
-        test:assertFail(msg = "Found unexpected output: " +  resp.message());
+    json payload = check outRequestClient->post("/mytest/json", custArr);
+    assertJsonPayload(payload, [{"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]},
+        {"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]}]);
+}
+
+@test:Config {}
+public function testSendingClosedRecordMap() returns error? {
+    ClosedCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
+    map<ClosedCustomer> custMap = {a:customer, b:customer};
+    json payload = check outRequestClient->post("/mytest/json", custMap);
+    assertJsonPayload(payload,
+        {a:{"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]},
+        b:{"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]}});
+}
+
+@test:Config {}
+public function testSendingClosedRecordTable() returns error? {
+    table<ClosedCustomer> customerTab = table [
+        { name: "ballerina1", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()},
+        { name: "ballerina2", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()}
+    ];
+    json payload = check outRequestClient->post("/mytest/json", customerTab);
+    assertJsonPayload(payload,
+        [{ name: "ballerina1", aa: "<book>Hello World</book>", bb: [97,98,99]},
+        { name: "ballerina2", aa: "<book>Hello World</book>", bb: [97,98,99]}]);
+}
+
+@test:Config {}
+public function testRequestAnydataNegative() returns error? {
+    anydata[] x = [];
+    x.push(x);
+    json|error payload = outRequestClient->post("/mytest/json", x);
+    if payload is error {
+        if payload is http:InitializingOutboundRequestError {
+            //Change error after https://github.com/ballerina-platform/ballerina-lang/issues/32001 is fixed
+            test:assertEquals(payload.message(), "json conversion error: java.lang.ClassCastException");
+            return;
+        }
     }
+    test:assertFail(msg = "Found unexpected output");
 }
 
 service /mytest on outRequestTypeTestEP {
 
-    resource function post 'json(@http:Payload {} json data) returns json {
+    resource function post 'json(@http:Payload json data) returns json {
         return data;
     }
 
@@ -226,107 +428,158 @@ service /mytest on outRequestTypeTestEP {
         return req.getHeader("Content-Length");
     }
 
-    resource function get nil(http:Caller caller) {
-        checkpanic caller->respond(());
+    resource function get nil(http:Caller caller) returns error? {
+        check caller->respond(());
     }
 
-    resource function get 'int(http:Caller caller) {
+    resource function get 'int(http:Caller caller) returns error? {
         int val = 1395767;
-        checkpanic caller->respond(val);
+        check caller->respond(val);
     }
 
-    resource function get 'float(http:Caller caller) {
+    resource function get 'intArr(http:Caller caller) returns error? {
+        int[] val = [139,5345];
+        check caller->respond(val);
+    }
+
+    resource function get 'intMap(http:Caller caller) returns error? {
+        map<int> val = {a: 139, b: 5345};
+        check caller->respond(val);
+    }
+
+    resource function get 'intTable(http:Caller caller) returns error? {
+        table<map<int>> customerTab = table [
+                {id: 13 , fname: 1, lname: 2},
+                {id: 23 , fname: 3 , lname: 4}
+            ];
+        check caller->respond(customerTab);
+    }
+
+    resource function get 'float(http:Caller caller) returns error? {
         float val = 13.95767;
-        checkpanic caller->respond(val);
+        check caller->respond(val);
     }
 
-    resource function get 'decimal(http:Caller caller) {
+    resource function get 'decimal(http:Caller caller) returns error? {
         decimal val = 6.7;
-        checkpanic caller->respond(val);
+        check caller->respond(val);
     }
 
-    resource function get bool(http:Caller caller) {
+    resource function get bool(http:Caller caller) returns error? {
         boolean val = true;
-        checkpanic caller->respond(val);
+        check caller->respond(val);
     }
 
-    resource function get 'map(http:Caller caller) {
+    resource function post 'string(@http:Payload string data) returns string {
+        return data;
+    }
+
+    resource function post 'xml(@http:Payload xml data) returns xml {
+        return data;
+    }
+
+    resource function get 'map(http:Caller caller) returns error? {
         map<string> val = {line1: "a", line2: "b"};
-        checkpanic caller->respond(val);
+        check caller->respond(val);
     }
 
-    resource function get mapArr(http:Caller caller) {
+    resource function get mapArr(http:Caller caller) returns error? {
         map<string>[] val = [{line1: "a", line2: "b"}, {line3: "c", line4: "d"}];
-        checkpanic caller->respond(val);
+        check caller->respond(val);
     }
 
-    resource function get 'table(http:Caller caller) {
+    resource function get 'table(http:Caller caller) returns error? {
         table<map<string>> val = table [
             {fname: "John", lname: "Wick"},
             {fname: "Robert", lname: "Downey"}
         ];
-        checkpanic caller->respond(val);
+        check caller->respond(val);
     }
 
-    resource function get tableArr(http:Caller caller) {
+    resource function get tableArr(http:Caller caller) returns error? {
         table<map<string>> val1 = table [{fname: "John", lname: "Wick"}];
         table<map<json>> val2 = table [{name: 23, lname: {a:"go"}}];
         table<map<json>>[] val = [val1, val2];
-        checkpanic caller->respond(val);
+        check caller->respond(val);
     }
 
-    resource function get openRecord(http:Caller caller) {
+    resource function get tableMap(http:Caller caller) returns error? {
+        CustomerTable customerTab = table [
+                {id: 13 , fname: "Dan", lname: "Bing"}
+            ];
+        map<CustomerTable> customerTabMap = {a: customerTab, b: customerTab};
+        check caller->respond(customerTabMap);
+    }
+
+    resource function get openRecord(http:Caller caller) returns error? {
         OpenCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
-        checkpanic caller->respond(customer);
+        check caller->respond(customer);
     }
 
-    resource function get openRecordArr(http:Caller caller) {
+    resource function get openRecordArr(http:Caller caller) returns error? {
         OpenCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
         OpenCustomer[] custArr = [customer, customer];
-        checkpanic caller->respond(custArr);
+        check caller->respond(custArr);
     }
 
-    resource function get closedRecord(http:Caller caller) {
+    resource function get closedRecord(http:Caller caller) returns error? {
         ClosedCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
-        checkpanic caller->respond(customer);
+        check caller->respond(customer);
     }
 
-    resource function get closedRecordArr(http:Caller caller) {
+    resource function get closedRecordArr(http:Caller caller) returns error? {
         ClosedCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
         ClosedCustomer[] custArr = [customer, customer];
-        checkpanic caller->respond(custArr);
+        check caller->respond(custArr);
+    }
+
+    resource function get anydataNegative(http:Caller caller) returns error? {
+        anydata[] x = [];
+        x.push(x);
+        check caller->respond(x);
     }
 }
 
 @test:Config {}
-public function testGettingNil() {
-    http:Response|error resp = outRequestClient->get("/mytest/nil");
-    if (resp is http:Response) {
-        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(checkpanic resp.getHeader(CONTENT_LENGTH), "0");
-    } else {
-        test:assertFail(msg = "Found unexpected output: " +  resp.message());
-    }
+public function testGettingNil() returns error? {
+    http:Response resp = check outRequestClient->get("/mytest/nil");
+    test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
+    assertHeaderValue(check resp.getHeader(CONTENT_LENGTH), "0");
 }
 
 @test:Config {}
-public function testGettingInt() {
-    http:Response|error resp = outRequestClient->get("/mytest/int");
-    if (resp is http:Response) {
-        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
-        assertJsonPayload(resp.getJsonPayload(), 1395767);
-    } else {
-        test:assertFail(msg = "Found unexpected output: " +  resp.message());
-    }
+public function testGettingInt() returns error? {
+    http:Response resp = check outRequestClient->get("/mytest/int");
+    test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
+    assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+    assertJsonPayload(resp.getJsonPayload(), 1395767);
 }
 
 @test:Config {}
-public function testGettingFloat() {
+public function testGettingIntArr() returns error? {
+    json payload = check outRequestClient->get("/mytest/intArr");
+    test:assertEquals(payload, [139, 5345], msg = "Found unexpected output");
+}
+
+@test:Config {}
+public function testGettingIntMap() returns error? {
+    json payload = check outRequestClient->get("/mytest/intMap");
+    test:assertEquals(payload, {a: 139,b: 5345}, msg = "Found unexpected output");
+}
+
+@test:Config {}
+public function testGettingIntTable() returns error? {
+    json payload = check outRequestClient->get("/mytest/intTable");
+    test:assertEquals(payload, [{id: 13 , fname: 1, lname: 2}, {id: 23 , fname: 3 , lname: 4}],
+            msg = "Found unexpected output");
+}
+
+@test:Config {}
+public function testGettingFloat() returns error? {
     http:Response|error resp = outRequestClient->get("/mytest/float");
     if (resp is http:Response) {
         test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
         assertJsonPayloadtoJsonString(resp.getJsonPayload(), 13.95767);
     } else {
         test:assertFail(msg = "Found unexpected output: " +  resp.message());
@@ -334,11 +587,11 @@ public function testGettingFloat() {
 }
 
 @test:Config {}
-public function testGettingDecimal() {
+public function testGettingDecimal() returns error? {
     http:Response|error resp = outRequestClient->get("/mytest/decimal");
     if (resp is http:Response) {
         test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
         assertJsonPayloadtoJsonString(resp.getJsonPayload(), 6.7);
     } else {
         test:assertFail(msg = "Found unexpected output: " +  resp.message());
@@ -346,11 +599,11 @@ public function testGettingDecimal() {
 }
 
 @test:Config {}
-public function testGettingBoolean() {
+public function testGettingBoolean() returns error? {
     http:Response|error resp = outRequestClient->get("/mytest/bool");
     if (resp is http:Response) {
         test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
         assertJsonPayload(resp.getJsonPayload(), true);
     } else {
         test:assertFail(msg = "Found unexpected output: " +  resp.message());
@@ -358,11 +611,11 @@ public function testGettingBoolean() {
 }
 
 @test:Config {}
-public function testGettingMap() {
+public function testGettingMap() returns error? {
     http:Response|error resp = outRequestClient->get("/mytest/map");
     if (resp is http:Response) {
         test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
         assertJsonPayload(resp.getJsonPayload(), {line1: "a", line2: "b"});
     } else {
         test:assertFail(msg = "Found unexpected output: " +  resp.message());
@@ -370,11 +623,11 @@ public function testGettingMap() {
 }
 
 @test:Config {}
-public function testGettingMapArray() {
+public function testGettingMapArray() returns error? {
     http:Response|error resp = outRequestClient->get("/mytest/mapArr");
     if (resp is http:Response) {
         test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
         assertJsonPayload(resp.getJsonPayload(), [{line1: "a", line2: "b"}, {line3: "c", line4: "d"}]);
     } else {
         test:assertFail(msg = "Found unexpected output: " +  resp.message());
@@ -382,11 +635,11 @@ public function testGettingMapArray() {
 }
 
 @test:Config {}
-public function testGettingTable() {
+public function testGettingTable() returns error? {
     http:Response|error resp = outRequestClient->get("/mytest/table");
     if (resp is http:Response) {
         test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
         assertJsonPayload(resp.getJsonPayload(), [{fname: "John", lname: "Wick"},
             {fname: "Robert", lname: "Downey"}]);
     } else {
@@ -395,16 +648,23 @@ public function testGettingTable() {
 }
 
 @test:Config {}
-public function testGettingTableArray() {
+public function testGettingTableArray() returns error? {
     http:Response|error resp = outRequestClient->get("/mytest/tableArr");
     if (resp is http:Response) {
         test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
-        assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
         assertJsonPayload(resp.getJsonPayload(), [[{fname: "John", lname: "Wick"}],
             [{name: 23, lname: {a:"go"}}]]);
     } else {
         test:assertFail(msg = "Found unexpected output: " +  resp.message());
     }
+}
+
+@test:Config {}
+public function testGettingTableMap() returns error? {
+    json payload = check outRequestClient->get("/mytest/tableMap");
+    assertJsonPayload(payload, {a : [{id: 13 , fname: "Dan", lname: "Bing"}],
+            b: [{id: 13 , fname: "Dan", lname: "Bing"}]});
 }
 
 @test:Config {}
@@ -455,4 +715,13 @@ public function testGettingClosedRecordArray() returns error? {
     } else {
         test:assertFail(msg = "Found unexpected output: " +  resp.message());
     }
+}
+
+@test:Config {}
+public function testResponseAnydataNegative() returns error? {
+    http:Response resp = check outRequestClient->get("/mytest/anydataNegative");
+    test:assertEquals(resp.statusCode, 500, msg = "Found unexpected output");
+    assertHeaderValue(check resp.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+    //Change error after https://github.com/ballerina-platform/ballerina-lang/issues/32001 is fixed
+    test:assertEquals(check resp.getTextPayload(), "json conversion error: java.lang.ClassCastException");
 }

--- a/ballerina/http_client_endpoint.bal
+++ b/ballerina/http_client_endpoint.bal
@@ -71,7 +71,7 @@ public client isolated class Client {
 
     private isolated function processPost(string path, RequestMessage message, TargetType targetType,
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         Response|ClientError response = self.httpClient->post(path, req);
         if (observabilityEnabled && response is Response) {
@@ -98,7 +98,7 @@ public client isolated class Client {
 
     private isolated function processPut(string path, RequestMessage message, TargetType targetType,
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         Response|ClientError response = self.httpClient->put(path, req);
         if (observabilityEnabled && response is Response) {
@@ -125,7 +125,7 @@ public client isolated class Client {
 
     private isolated function processPatch(string path, RequestMessage message, TargetType targetType,
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         Response|ClientError response = self.httpClient->patch(path, req);
         if (observabilityEnabled && response is Response) {
@@ -152,7 +152,7 @@ public client isolated class Client {
 
     private isolated function processDelete(string path, RequestMessage message, TargetType targetType,
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         Response|ClientError response = self.httpClient->delete(path, req);
         if (observabilityEnabled && response is Response) {
@@ -241,7 +241,7 @@ public client isolated class Client {
     private isolated function processExecute(string httpVerb, string path, RequestMessage message,
             TargetType targetType, string? mediaType, map<string|string[]>? headers)
             returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         Response|ClientError response = self.httpClient->execute(httpVerb, path, req);
         if (observabilityEnabled && response is Response) {
@@ -281,7 +281,7 @@ public client isolated class Client {
     # + message - An HTTP outbound request or any allowed payload
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission fails
     remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         return self.httpClient->submit(httpVerb, path, req);
 
     }

--- a/ballerina/http_commons.bal
+++ b/ballerina/http_commons.bal
@@ -33,7 +33,7 @@ public isolated function parseHeader(string headerValue) returns [string, map<an
     name: "parseHeader"
 } external;
 
-isolated function buildRequest(RequestMessage message) returns Request {
+isolated function buildRequest(RequestMessage message) returns Request|ClientError {
     Request request = new;
     if (message is ()) {
         request.noEntityBody = true;
@@ -56,7 +56,7 @@ isolated function buildRequest(RequestMessage message) returns Request {
     } else {
         var result = trap val:toJson(message);
         if (result is error) {
-            panic error InitializingOutboundRequestError("json conversion error: " + result.message(), result);
+            return error InitializingOutboundRequestError("json conversion error: " + result.message(), result);
         } else {
             request.setJsonPayload(result);
         }
@@ -64,7 +64,7 @@ isolated function buildRequest(RequestMessage message) returns Request {
     return request;
 }
 
-isolated function buildResponse(ResponseMessage message) returns Response {
+isolated function buildResponse(ResponseMessage message) returns Response|ListenerError {
     Response response = new;
     if (message is ()) {
         return response;
@@ -85,7 +85,7 @@ isolated function buildResponse(ResponseMessage message) returns Response {
     } else {
         var result = trap val:toJson(message);
         if (result is error) {
-            panic error InitializingOutboundResponseError("json conversion error: " + result.message(), result);
+            return error InitializingOutboundResponseError("json conversion error: " + result.message(), result);
         } else {
             response.setJsonPayload(result);
         }
@@ -94,7 +94,7 @@ isolated function buildResponse(ResponseMessage message) returns Response {
 }
 
 isolated function populateOptions(Request request, string? mediaType, map<string|string[]>? headers) {
-    // This method is called after setting the payload. Hence default content type header will be overriden.
+    // This method is called after setting the payload. Hence default content type header will be overridden.
     // Update content-type header according to the priority. (Highest to lowest)
     // 1. MediaType arg in client method
     // 2. Headers arg in client method

--- a/ballerina/http_connection.bal
+++ b/ballerina/http_connection.bal
@@ -37,7 +37,7 @@ public client class Caller {
     # + message - The outbound response or any allowed payload
     # + return - An `http:ListenerError` if failed to respond or else `()`
     remote isolated function respond(ResponseMessage message = ()) returns ListenerError? {
-        Response response = buildResponse(message);
+        Response response = check buildResponse(message);
         return nativeRespond(self, response);
     }
 

--- a/ballerina/http_types.bal
+++ b/ballerina/http_types.bal
@@ -17,15 +17,13 @@
 import ballerina/io;
 import ballerina/mime;
 
-# The types of messages that are accepted by HTTP `client` when sending out the outbound request.
-public type RequestMessage Request|string|xml|json|byte[]|int|float|decimal|boolean|map<json>|table<map<json>>|
-                           (map<json>|table<map<json>>)[]|mime:Entity[]|stream<byte[], io:Error?>|()|
-                           record {| anydata...; |}|record {| anydata...; |}[];
+# The types of messages that are accepted by HTTP `client` when sending out the outbound request. The `anydata` type
+# is equivalent to `()|boolean|int|float|decimal|string|xml|anydata[]|map<anydata>|table<map<anydata>>`
+public type RequestMessage anydata|byte[]|Request|mime:Entity[]|stream<byte[], io:Error?>;
 
-# The types of messages that are accepted by HTTP `listener` when sending out the outbound response.
-public type ResponseMessage Response|string|xml|json|byte[]|int|float|decimal|boolean|map<json>|table<map<json>>|
-                            (map<json>|table<map<json>>)[]|mime:Entity[]|stream<byte[], io:Error?>|()|
-                            record {| anydata...; |}|record {| anydata...; |}[];
+# The types of messages that are accepted by HTTP `listener` when sending out the outbound response. The `anydata` type
+# is equivalent to `()|boolean|int|float|decimal|string|xml|anydata[]|map<anydata>|table<map<anydata>>`
+public type ResponseMessage anydata|byte[]|Response|mime:Entity[]|stream<byte[], io:Error?>;
 
 # The HTTP service type.
 public type Service service object {

--- a/ballerina/http_types.bal
+++ b/ballerina/http_types.bal
@@ -19,11 +19,13 @@ import ballerina/mime;
 
 # The types of messages that are accepted by HTTP `client` when sending out the outbound request.
 public type RequestMessage Request|string|xml|json|byte[]|int|float|decimal|boolean|map<json>|table<map<json>>|
-                           (map<json>|table<map<json>>)[]|mime:Entity[]|stream<byte[], io:Error?>|();
+                           (map<json>|table<map<json>>)[]|mime:Entity[]|stream<byte[], io:Error?>|()|
+                           record {| anydata...; |}|record {| anydata...; |}[];
 
 # The types of messages that are accepted by HTTP `listener` when sending out the outbound response.
 public type ResponseMessage Response|string|xml|json|byte[]|int|float|decimal|boolean|map<json>|table<map<json>>|
-                            (map<json>|table<map<json>>)[]|mime:Entity[]|stream<byte[], io:Error?>|();
+                            (map<json>|table<map<json>>)[]|mime:Entity[]|stream<byte[], io:Error?>|()|
+                            record {| anydata...; |}|record {| anydata...; |}[];
 
 # The HTTP service type.
 public type Service service object {

--- a/ballerina/resiliency_failover_client.bal
+++ b/ballerina/resiliency_failover_client.bal
@@ -80,7 +80,7 @@ public client isolated class FailoverClient {
 
     private isolated function processPost(string path, RequestMessage message, TargetType targetType, 
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performFailoverAction(path, req, HTTP_POST);
         if (result is HttpFuture) {
@@ -108,7 +108,7 @@ public client isolated class FailoverClient {
     
     private isolated function processPut(string path, RequestMessage message, TargetType targetType, 
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performFailoverAction(path, req, HTTP_PUT);
         if (result is HttpFuture) {
@@ -136,7 +136,7 @@ public client isolated class FailoverClient {
     
     private isolated function processPatch(string path, RequestMessage message, TargetType targetType, 
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performFailoverAction(path, req, HTTP_PATCH);
         if (result is HttpFuture) {
@@ -164,7 +164,7 @@ public client isolated class FailoverClient {
     
     private isolated function processDelete(string path, RequestMessage message, TargetType targetType, 
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performFailoverAction(path, req, HTTP_DELETE);
         if (result is HttpFuture) {
@@ -257,7 +257,7 @@ public client isolated class FailoverClient {
     private isolated function processExecute(string httpVerb, string path, RequestMessage message,
             TargetType targetType, string? mediaType, map<string|string[]>? headers) 
             returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performExecuteAction(path, req, httpVerb);
         if (result is HttpFuture) {
@@ -300,7 +300,7 @@ public client isolated class FailoverClient {
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission
     #            fails
     remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         var result = self.performExecuteAction(path, req, "SUBMIT", verb = httpVerb);
         if (result is Response) {
             return getInvalidTypeError();

--- a/ballerina/resiliency_load_balance_client.bal
+++ b/ballerina/resiliency_load_balance_client.bal
@@ -72,7 +72,7 @@ public client isolated class LoadBalanceClient {
     
     private isolated function processPost(string path, RequestMessage message, TargetType targetType, 
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performLoadBalanceAction(path, req, HTTP_POST);
         return processResponse(result, targetType);
@@ -96,7 +96,7 @@ public client isolated class LoadBalanceClient {
     
     private isolated function processPut(string path, RequestMessage message, TargetType targetType, 
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performLoadBalanceAction(path, req, HTTP_PUT);
         return processResponse(result, targetType);
@@ -120,7 +120,7 @@ public client isolated class LoadBalanceClient {
     
     private isolated function processPatch(string path, RequestMessage message, TargetType targetType, 
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performLoadBalanceAction(path, req, HTTP_PATCH);
         return processResponse(result, targetType);
@@ -144,7 +144,7 @@ public client isolated class LoadBalanceClient {
     
     private isolated function processDelete(string path, RequestMessage message, TargetType targetType, 
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performLoadBalanceAction(path, req, HTTP_DELETE);
         return processResponse(result, targetType);
@@ -220,7 +220,7 @@ public client isolated class LoadBalanceClient {
     private isolated function processExecute(string httpVerb, string path, RequestMessage message,
             TargetType targetType, string? mediaType, map<string|string[]>? headers) 
             returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performLoadBalanceExecuteAction(path, req, httpVerb);
         return processResponse(result, targetType);

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Enable HTTP trace and access log support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1073)
 - [Add HATEOS link support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1637)
 - [Introduce http:CacheConfig annotation to the resource signature](https://github.com/ballerina-platform/ballerina-standard-library/issues/1533)
+- [Introduce record as a outbound req/resp data types](https://github.com/ballerina-platform/ballerina-standard-library/issues/1719)
 
 ## [1.1.0-beta.2] - 2021-07-07
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Enable HTTP trace and access log support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1073)
 - [Add HATEOS link support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1637)
 - [Introduce http:CacheConfig annotation to the resource signature](https://github.com/ballerina-platform/ballerina-standard-library/issues/1533)
-- [Introduce record as a outbound req/resp data types](https://github.com/ballerina-platform/ballerina-standard-library/issues/1719)
+- [Introduce anydata as a outbound req/resp data types](https://github.com/ballerina-platform/ballerina-standard-library/issues/1719)
 
 ## [1.1.0-beta.2] - 2021-07-07
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Enable HTTP trace and access log support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1073)
 - [Add HATEOS link support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1637)
 - [Introduce http:CacheConfig annotation to the resource signature](https://github.com/ballerina-platform/ballerina-standard-library/issues/1533)
-- [Introduce anydata as a outbound req/resp data types](https://github.com/ballerina-platform/ballerina-standard-library/issues/1719)
+- [Introduce anydata as an outbound req/resp data types](https://github.com/ballerina-platform/ballerina-standard-library/issues/1719)
 
 ## [1.1.0-beta.2] - 2021-07-07
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -259,7 +259,7 @@ public class CompilerPluginTest {
         Package currentPackage = loadPackage("sample_package_11");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
-        Assert.assertEquals(diagnosticResult.diagnosticCount(), 10);
+        Assert.assertEquals(diagnosticResult.diagnosticCount(), 11);
         assertError(diagnosticResult, 0, "incompatible respond method argument type : expected " +
                 "'http:Response' according to the 'http:CallerInfo' annotation", HTTP_114);
         assertError(diagnosticResult, 1, "incompatible respond method argument type : expected " +
@@ -267,18 +267,20 @@ public class CompilerPluginTest {
         assertError(diagnosticResult, 2, "incompatible respond method argument type : expected " +
                 "'json' according to the 'http:CallerInfo' annotation", HTTP_114);
         assertError(diagnosticResult, 3, "incompatible respond method argument type : expected " +
-                "'ByteArr' according to the 'http:CallerInfo' annotation", HTTP_114);
+                "'json' according to the 'http:CallerInfo' annotation", HTTP_114);
         assertError(diagnosticResult, 4, "incompatible respond method argument type : expected " +
-                "'MapJson' according to the 'http:CallerInfo' annotation", HTTP_114);
+                "'ByteArr' according to the 'http:CallerInfo' annotation", HTTP_114);
         assertError(diagnosticResult, 5, "incompatible respond method argument type : expected " +
-                "'PersonTable' according to the 'http:CallerInfo' annotation", HTTP_114);
+                "'MapJson' according to the 'http:CallerInfo' annotation", HTTP_114);
         assertError(diagnosticResult, 6, "incompatible respond method argument type : expected " +
-                "'MapJsonArr' according to the 'http:CallerInfo' annotation", HTTP_114);
+                "'PersonTable' according to the 'http:CallerInfo' annotation", HTTP_114);
         assertError(diagnosticResult, 7, "incompatible respond method argument type : expected " +
-                "'PersonTableArr' according to the 'http:CallerInfo' annotation", HTTP_114);
+                "'MapJsonArr' according to the 'http:CallerInfo' annotation", HTTP_114);
         assertError(diagnosticResult, 8, "incompatible respond method argument type : expected " +
-                "'EntityArr' according to the 'http:CallerInfo' annotation", HTTP_114);
+                "'PersonTableArr' according to the 'http:CallerInfo' annotation", HTTP_114);
         assertError(diagnosticResult, 9, "incompatible respond method argument type : expected " +
+                "'EntityArr' according to the 'http:CallerInfo' annotation", HTTP_114);
+        assertError(diagnosticResult, 10, "incompatible respond method argument type : expected " +
                 "'ByteStream' according to the 'http:CallerInfo' annotation", HTTP_114);
     }
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_11/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_11/service.bal
@@ -26,11 +26,13 @@ type RetEmployee record {|
 type PersonTable table<RetEmployee> key(id);
 type Xml xml;
 type ByteArr byte[];
+type IntArr int[];
 type MapJson map<json>;
 type MapJsonArr map<json>[];
 type EntityArr mime:Entity[];
 type PersonTableArr PersonTable[];
 type ByteStream stream<byte[], io:Error?>;
+type MapAnydata map<anydata>;
 
 service http:Service on new http:Listener(9090) {
     resource function get callerInfo17(int xyz, @http:CallerInfo {respondType: http:Response} http:Caller abc) {
@@ -57,7 +59,11 @@ service http:Service on new http:Listener(9090) {
     }
 
     resource function get callerInfo22(int xyz, @http:CallerInfo {respondType: json} http:Caller abc) {
-        checkpanic abc->respond({hello: "world"}); // this is also fails and a limitation for inline json
+        checkpanic abc->respond({hello: "world"}); // this is also fails as inline json is considered as map<anydata>
+    }
+
+    resource function get callerInfo22A(int xyz, @http:CallerInfo {respondType: MapAnydata} http:Caller abc) {
+        checkpanic abc->respond({hello: "world"}); // this should not fail
     }
 
     resource function get callerInfo23(int xyz, @http:CallerInfo {respondType: json} http:Caller abc) {
@@ -140,5 +146,10 @@ service http:Service on new http:Listener(9090) {
 
     resource function get callerInfo37(@http:CallerInfo {respondType: ByteStream} http:Caller abc) {
         checkpanic abc->respond("res"); // error
+    }
+
+    resource function get callerInfo38(@http:CallerInfo {respondType: IntArr} http:Caller abc) {
+        int[] arr = [23,343];
+        checkpanic abc->respond(arr);
     }
 }


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1719

Type | Media Type
-- | --
xml | application/xml
string | text/plain
byte[] | application/octet-stream
map\<anydata\>, table<map\<anydata\>>, anydata[] | application/json
int, float, decimal, boolean | application/json

## Examples
```ballerina
type OpenCustomer record {
    string name;
    xml aa;
    byte[] bb;
};

@test:Config {}
public function testSendingOpenRecord() returns error? {
    OpenCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
    http:Response|error resp = outRequestClient->post("/mytest/json", customer);
}
```
## Test matrix

Type | Single | Array | Map | Table
-- | -- | -- | -- |--
string | + | + | + | +
int, float, decimal, boolean, string  | + | + | + | +
xml | + | + | + | +
byte[] | - | + | - | -
Array | +JSON | - | +JSON | +JSON
Map | +JSON | +JSON | - | +JSON
Table | +JSON | +JSON | +JSON | -
Open record | + | + | + | +
Close record  | + | + | + | +



## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests