### PR TITLE
Add test cases for sending inclusive record type as an outbound req/resp

### DIFF
--- a/ballerina-tests/tests/http_outbound_message_type_test.bal
+++ b/ballerina-tests/tests/http_outbound_message_type_test.bal
@@ -37,7 +37,7 @@ public function testSendingNil() {
 
 @test:Config {}
 public function testSendingInt() {
-    int val = 139; 
+    int val = 139;
     http:Response|error resp = outRequestClient->post("/mytest/json", val);
     if (resp is http:Response) {
         test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
@@ -124,7 +124,7 @@ public function testSendingTable() {
     if (resp is http:Response) {
         test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
         assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
-        assertJsonPayload(resp.getJsonPayload(), [{id: 13 , fname: "Dan", lname: "Bing"}, 
+        assertJsonPayload(resp.getJsonPayload(), [{id: 13 , fname: "Dan", lname: "Bing"},
             {id: 23 , fname: "Hay" , lname: "Kelsey"}]);
     } else {
         test:assertFail(msg = "Found unexpected output: " +  resp.message());
@@ -141,11 +141,133 @@ public function testSendingTableArray() {
     if (resp is http:Response) {
         test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
         assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
-        assertJsonPayload(resp.getJsonPayload(), [[{id: 13 , fname: "Dan", lname: "Bing"}], 
+        assertJsonPayload(resp.getJsonPayload(), [[{id: 13 , fname: "Dan", lname: "Bing"}],
             [{id: 13 , fname: "Dan", lname: "Bing"}]]);
     } else {
         test:assertFail(msg = "Found unexpected output: " +  resp.message());
     }
+}
+
+@test:Config {}
+public function testSendingJsonCompatibleOpenRecord() returns error? {
+    // To make json compatible;
+    // 1. Make exclusive record
+    // 2. Have json rest param in open records
+    // 3. Call .toJson() and pass as a json
+    record {| string name; |} customer1 = { name: "ballerina1" };
+    json payload = check outRequestClient->post("/mytest/json", customer1);
+    assertJsonPayload(payload, {"name":"ballerina1"});
+
+    record {| string name; json...; |} customer2 = { name: "ballerina2" };
+    payload = check outRequestClient->post("/mytest/json", customer2);
+    assertJsonPayload(payload, {"name":"ballerina2"});
+
+    record { string name; } customer3 = { name: "ballerina3" };
+    payload = check outRequestClient->post("/mytest/json", customer3.toJson());
+    assertJsonPayload(payload, {"name":"ballerina3"});
+}
+
+type OpenCustomer record {
+    string name;
+    xml aa;
+    byte[] bb;
+};
+
+@test:Config {}
+public function testSendingOpenRecord() returns error? {
+    OpenCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
+    json payload = check outRequestClient->post("/mytest/json", customer.toJson());
+    assertJsonPayload(payload, {"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]});
+}
+
+@test:Config {}
+public function testSendingOpenRecordArray() returns error? {
+    OpenCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
+    OpenCustomer[] custArr = [customer, customer];
+    json payload = check outRequestClient->post("/mytest/json", custArr.toJson());
+    assertJsonPayload(payload, [{"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]},
+        {"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]}]);
+}
+
+@test:Config {}
+public function testSendingOpenRecordMap() returns error? {
+    OpenCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
+    map<OpenCustomer> custMap = {a:customer, b:customer};
+    json payload = check outRequestClient->post("/mytest/json", custMap.toJson());
+    assertJsonPayload(payload,
+        {a:{"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]},
+        b:{"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]}});
+}
+
+@test:Config {}
+public function testSendingOpenRecordTable() returns error? {
+    table<OpenCustomer> customerTab = table [
+        { name: "ballerina1", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()},
+        { name: "ballerina2", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()}
+    ];
+    json payload = check outRequestClient->post("/mytest/json", customerTab.toJson());
+    assertJsonPayload(payload,
+        [{ name: "ballerina1", aa: "<book>Hello World</book>", bb: [97,98,99]},
+        { name: "ballerina2", aa: "<book>Hello World</book>", bb: [97,98,99]}]);
+}
+
+type ClosedCustomer record {|
+    string name;
+    xml aa;
+    byte[] bb;
+|};
+
+@test:Config {}
+public function testSendingClosedRecord() returns error? {
+    ClosedCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
+    json payload = check outRequestClient->post("/mytest/json", customer.toJson());
+    assertJsonPayload(payload, {name: "ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]});
+}
+
+@test:Config {}
+public function testSendingClosedRecordArray() returns error? {
+    ClosedCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
+    ClosedCustomer[] custArr = [customer, customer];
+    json payload = check outRequestClient->post("/mytest/json", custArr.toJson());
+    assertJsonPayload(payload, [{"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]},
+        {"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]}]);
+}
+
+@test:Config {}
+public function testSendingClosedRecordMap() returns error? {
+    ClosedCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
+    map<ClosedCustomer> custMap = {a:customer, b:customer};
+    json payload = check outRequestClient->post("/mytest/json", custMap.toJson());
+    assertJsonPayload(payload,
+        {a:{"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]},
+        b:{"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]}});
+}
+
+@test:Config {}
+public function testSendingClosedRecordTable() returns error? {
+    table<ClosedCustomer> customerTab = table [
+        { name: "ballerina1", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()},
+        { name: "ballerina2", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()}
+    ];
+    json payload = check outRequestClient->post("/mytest/json", customerTab.toJson());
+    assertJsonPayload(payload,
+        [{ name: "ballerina1", aa: "<book>Hello World</book>", bb: [97,98,99]},
+        { name: "ballerina2", aa: "<book>Hello World</book>", bb: [97,98,99]}]);
+}
+
+@test:Config {}
+public function testRequestAnydataNegative() returns error? {
+    json[] x = [];
+    x.push(x);
+    json|error payload = outRequestClient->post("/mytest/json", x);
+    if payload is error {
+        if payload is http:InitializingOutboundRequestError {
+            //Change error after https://github.com/ballerina-platform/ballerina-lang/issues/32001 is fixed
+            test:assertEquals(payload.message(), "json conversion error: java.lang.ClassCastException");
+            return;
+        }
+    }
+    test:assertFail(msg = "Found unexpected output");
 }
 
 service /mytest on outRequestTypeTestEP {
@@ -163,17 +285,17 @@ service /mytest on outRequestTypeTestEP {
     }
 
     resource function get 'int(http:Caller caller) {
-        int val = 1395767; 
+        int val = 1395767;
         checkpanic caller->respond(val);
     }
 
     resource function get 'float(http:Caller caller) {
-        float val = 13.95767; 
+        float val = 13.95767;
         checkpanic caller->respond(val);
     }
 
     resource function get 'decimal(http:Caller caller) {
-        decimal val = 6.7; 
+        decimal val = 6.7;
         checkpanic caller->respond(val);
     }
 
@@ -184,12 +306,12 @@ service /mytest on outRequestTypeTestEP {
 
     resource function get 'map(http:Caller caller) {
         map<string> val = {line1: "a", line2: "b"};
-        checkpanic caller->respond(val);    
+        checkpanic caller->respond(val);
     }
 
     resource function get mapArr(http:Caller caller) {
         map<string>[] val = [{line1: "a", line2: "b"}, {line3: "c", line4: "d"}];
-        checkpanic caller->respond(val);    
+        checkpanic caller->respond(val);
     }
 
     resource function get 'table(http:Caller caller) {
@@ -197,14 +319,42 @@ service /mytest on outRequestTypeTestEP {
             {fname: "John", lname: "Wick"},
             {fname: "Robert", lname: "Downey"}
         ];
-        checkpanic caller->respond(val);    
+        checkpanic caller->respond(val);
     }
 
     resource function get tableArr(http:Caller caller) {
         table<map<string>> val1 = table [{fname: "John", lname: "Wick"}];
         table<map<json>> val2 = table [{name: 23, lname: {a:"go"}}];
         table<map<json>>[] val = [val1, val2];
-        checkpanic caller->respond(val);    
+        checkpanic caller->respond(val);
+    }
+
+    resource function get openRecord(http:Caller caller) returns error? {
+        OpenCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
+        check caller->respond(customer.toJson());
+    }
+
+    resource function get openRecordArr(http:Caller caller) returns error? {
+        OpenCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
+        OpenCustomer[] custArr = [customer, customer];
+        check caller->respond(custArr.toJson());
+    }
+
+    resource function get closedRecord(http:Caller caller) returns error? {
+        ClosedCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
+        check caller->respond(customer.toJson());
+    }
+
+    resource function get closedRecordArr(http:Caller caller) returns error? {
+        ClosedCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
+        ClosedCustomer[] custArr = [customer, customer];
+        check caller->respond(custArr.toJson());
+    }
+
+    resource function get anydataNegative(http:Caller caller) returns error? {
+        json[] x = [];
+        x.push(x);
+        check caller->respond(x);
     }
 }
 
@@ -310,9 +460,69 @@ public function testGettingTableArray() {
     if (resp is http:Response) {
         test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
         assertHeaderValue(checkpanic resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
-        assertJsonPayload(resp.getJsonPayload(), [[{fname: "John", lname: "Wick"}], 
+        assertJsonPayload(resp.getJsonPayload(), [[{fname: "John", lname: "Wick"}],
             [{name: 23, lname: {a:"go"}}]]);
     } else {
         test:assertFail(msg = "Found unexpected output: " +  resp.message());
     }
+}
+
+
+@test:Config {}
+public function testGettingOpenRecord() returns error? {
+    http:Response|error resp = outRequestClient->get("/mytest/openRecord");
+    if (resp is http:Response) {
+        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertJsonPayload(resp.getJsonPayload(), {"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]});
+    } else {
+        test:assertFail(msg = "Found unexpected output: " +  resp.message());
+    }
+}
+
+@test:Config {}
+public function testGettingOpenRecordArray() returns error? {
+    http:Response|error resp = outRequestClient->get("/mytest/openRecordArr");
+    if (resp is http:Response) {
+        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertJsonPayload(resp.getJsonPayload(), [{"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]},
+            {"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]}]);
+    } else {
+        test:assertFail(msg = "Found unexpected output: " +  resp.message());
+    }
+}
+
+@test:Config {}
+public function testGettingClosedRecord() returns error? {
+    http:Response|error resp = outRequestClient->get("/mytest/closedRecord");
+    if (resp is http:Response) {
+        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertJsonPayload(resp.getJsonPayload(), {"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]});
+    } else {
+        test:assertFail(msg = "Found unexpected output: " +  resp.message());
+    }
+}
+
+@test:Config {}
+public function testGettingClosedRecordArray() returns error? {
+    http:Response|error resp = outRequestClient->get("/mytest/closedRecordArr");
+    if (resp is http:Response) {
+        test:assertEquals(resp.statusCode, 200, msg = "Found unexpected output");
+        assertHeaderValue(check resp.getHeader(CONTENT_TYPE), APPLICATION_JSON);
+        assertJsonPayload(resp.getJsonPayload(), [{"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]},
+            {"name":"ballerina","aa":"<book>Hello World</book>","bb":[97,98,99]}]);
+    } else {
+        test:assertFail(msg = "Found unexpected output: " +  resp.message());
+    }
+}
+
+@test:Config {}
+public function testResponseAnydataNegative() returns error? {
+    http:Response resp = check outRequestClient->get("/mytest/anydataNegative");
+    test:assertEquals(resp.statusCode, 500, msg = "Found unexpected output");
+    assertHeaderValue(check resp.getHeader(CONTENT_TYPE), TEXT_PLAIN);
+    //Change error after https://github.com/ballerina-platform/ballerina-lang/issues/32001 is fixed
+    test:assertEquals(check resp.getTextPayload(), "json conversion error: java.lang.ClassCastException");
 }

--- a/ballerina/http_client_endpoint.bal
+++ b/ballerina/http_client_endpoint.bal
@@ -71,7 +71,7 @@ public client isolated class Client {
 
     private isolated function processPost(string path, RequestMessage message, TargetType targetType,
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         Response|ClientError response = self.httpClient->post(path, req);
         if (observabilityEnabled && response is Response) {
@@ -98,7 +98,7 @@ public client isolated class Client {
 
     private isolated function processPut(string path, RequestMessage message, TargetType targetType,
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         Response|ClientError response = self.httpClient->put(path, req);
         if (observabilityEnabled && response is Response) {
@@ -125,7 +125,7 @@ public client isolated class Client {
 
     private isolated function processPatch(string path, RequestMessage message, TargetType targetType,
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         Response|ClientError response = self.httpClient->patch(path, req);
         if (observabilityEnabled && response is Response) {
@@ -152,7 +152,7 @@ public client isolated class Client {
 
     private isolated function processDelete(string path, RequestMessage message, TargetType targetType,
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         Response|ClientError response = self.httpClient->delete(path, req);
         if (observabilityEnabled && response is Response) {
@@ -241,7 +241,7 @@ public client isolated class Client {
     private isolated function processExecute(string httpVerb, string path, RequestMessage message,
             TargetType targetType, string? mediaType, map<string|string[]>? headers)
             returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         Response|ClientError response = self.httpClient->execute(httpVerb, path, req);
         if (observabilityEnabled && response is Response) {
@@ -281,7 +281,7 @@ public client isolated class Client {
     # + message - An HTTP outbound request or any allowed payload
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission fails
     remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         return self.httpClient->submit(httpVerb, path, req);
 
     }

--- a/ballerina/http_commons.bal
+++ b/ballerina/http_commons.bal
@@ -33,7 +33,7 @@ public isolated function parseHeader(string headerValue) returns [string, map<an
     name: "parseHeader"
 } external;
 
-isolated function buildRequest(RequestMessage message) returns Request {
+isolated function buildRequest(RequestMessage message) returns Request|ClientError {
     Request request = new;
     if (message is ()) {
         request.noEntityBody = true;
@@ -51,12 +51,10 @@ isolated function buildRequest(RequestMessage message) returns Request {
         request.setByteStream(message);
     } else if (message is mime:Entity[]) {
         request.setBodyParts(message);
-    } else if (message is json) {
-        request.setJsonPayload(message);
     } else {
         var result = trap val:toJson(message);
         if (result is error) {
-            panic error InitializingOutboundRequestError("json conversion error: " + result.message(), result);
+            return error InitializingOutboundRequestError("json conversion error: " + result.message(), result);
         } else {
             request.setJsonPayload(result);
         }
@@ -64,7 +62,7 @@ isolated function buildRequest(RequestMessage message) returns Request {
     return request;
 }
 
-isolated function buildResponse(ResponseMessage message) returns Response {
+isolated function buildResponse(ResponseMessage message) returns Response|ListenerError {
     Response response = new;
     if (message is ()) {
         return response;
@@ -80,12 +78,10 @@ isolated function buildResponse(ResponseMessage message) returns Response {
         response.setByteStream(message);
     } else if (message is mime:Entity[]) {
         response.setBodyParts(message);
-    } else if (message is json) {
-        response.setJsonPayload(message);
     } else {
         var result = trap val:toJson(message);
         if (result is error) {
-            panic error InitializingOutboundResponseError("json conversion error: " + result.message(), result);
+            return error InitializingOutboundResponseError("json conversion error: " + result.message(), result);
         } else {
             response.setJsonPayload(result);
         }
@@ -94,7 +90,7 @@ isolated function buildResponse(ResponseMessage message) returns Response {
 }
 
 isolated function populateOptions(Request request, string? mediaType, map<string|string[]>? headers) {
-    // This method is called after setting the payload. Hence default content type header will be overriden.
+    // This method is called after setting the payload. Hence default content type header will be overridden.
     // Update content-type header according to the priority. (Highest to lowest)
     // 1. MediaType arg in client method
     // 2. Headers arg in client method

--- a/ballerina/http_connection.bal
+++ b/ballerina/http_connection.bal
@@ -37,7 +37,7 @@ public client class Caller {
     # + message - The outbound response or any allowed payload
     # + return - An `http:ListenerError` if failed to respond or else `()`
     remote isolated function respond(ResponseMessage message = ()) returns ListenerError? {
-        Response response = buildResponse(message);
+        Response response = check buildResponse(message);
         return nativeRespond(self, response);
     }
 

--- a/ballerina/resiliency_failover_client.bal
+++ b/ballerina/resiliency_failover_client.bal
@@ -80,7 +80,7 @@ public client isolated class FailoverClient {
 
     private isolated function processPost(string path, RequestMessage message, TargetType targetType, 
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performFailoverAction(path, req, HTTP_POST);
         if (result is HttpFuture) {
@@ -108,7 +108,7 @@ public client isolated class FailoverClient {
     
     private isolated function processPut(string path, RequestMessage message, TargetType targetType, 
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performFailoverAction(path, req, HTTP_PUT);
         if (result is HttpFuture) {
@@ -136,7 +136,7 @@ public client isolated class FailoverClient {
     
     private isolated function processPatch(string path, RequestMessage message, TargetType targetType, 
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performFailoverAction(path, req, HTTP_PATCH);
         if (result is HttpFuture) {
@@ -164,7 +164,7 @@ public client isolated class FailoverClient {
     
     private isolated function processDelete(string path, RequestMessage message, TargetType targetType, 
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performFailoverAction(path, req, HTTP_DELETE);
         if (result is HttpFuture) {
@@ -257,7 +257,7 @@ public client isolated class FailoverClient {
     private isolated function processExecute(string httpVerb, string path, RequestMessage message,
             TargetType targetType, string? mediaType, map<string|string[]>? headers) 
             returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performExecuteAction(path, req, httpVerb);
         if (result is HttpFuture) {
@@ -300,7 +300,7 @@ public client isolated class FailoverClient {
     # + return - An `http:HttpFuture` that represents an asynchronous service invocation or else an `http:ClientError` if the submission
     #            fails
     remote isolated function submit(string httpVerb, string path, RequestMessage message) returns HttpFuture|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         var result = self.performExecuteAction(path, req, "SUBMIT", verb = httpVerb);
         if (result is Response) {
             return getInvalidTypeError();

--- a/ballerina/resiliency_load_balance_client.bal
+++ b/ballerina/resiliency_load_balance_client.bal
@@ -72,7 +72,7 @@ public client isolated class LoadBalanceClient {
     
     private isolated function processPost(string path, RequestMessage message, TargetType targetType, 
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performLoadBalanceAction(path, req, HTTP_POST);
         return processResponse(result, targetType);
@@ -96,7 +96,7 @@ public client isolated class LoadBalanceClient {
     
     private isolated function processPut(string path, RequestMessage message, TargetType targetType, 
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performLoadBalanceAction(path, req, HTTP_PUT);
         return processResponse(result, targetType);
@@ -120,7 +120,7 @@ public client isolated class LoadBalanceClient {
     
     private isolated function processPatch(string path, RequestMessage message, TargetType targetType, 
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performLoadBalanceAction(path, req, HTTP_PATCH);
         return processResponse(result, targetType);
@@ -144,7 +144,7 @@ public client isolated class LoadBalanceClient {
     
     private isolated function processDelete(string path, RequestMessage message, TargetType targetType, 
             string? mediaType, map<string|string[]>? headers) returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performLoadBalanceAction(path, req, HTTP_DELETE);
         return processResponse(result, targetType);
@@ -220,7 +220,7 @@ public client isolated class LoadBalanceClient {
     private isolated function processExecute(string httpVerb, string path, RequestMessage message,
             TargetType targetType, string? mediaType, map<string|string[]>? headers) 
             returns Response|PayloadType|ClientError {
-        Request req = buildRequest(message);
+        Request req = check buildRequest(message);
         populateOptions(req, mediaType, headers);
         var result = self.performLoadBalanceExecuteAction(path, req, httpVerb);
         return processResponse(result, targetType);


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1719

## Examples
```ballerina
type OpenCustomer record {
    string name;
    xml aa;
    byte[] bb;
};

@test:Config {}
public function testSendingOpenRecord() returns error? {
    OpenCustomer customer = { name: "ballerina", aa: xml `<book>Hello World</book>`, bb: "abc".toBytes()};
    http:Response|error resp = outRequestClient->post("/mytest/json", customer.toJson());
}
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests