### PR TITLE
Add missing requires directives

### DIFF
--- a/native/src/main/java/module-info.java
+++ b/native/src/main/java/module-info.java
@@ -30,6 +30,15 @@ module io.ballerina.stdlib.http {
     requires org.slf4j;
     requires java.logging;
     requires gson;
+    requires io.netty.codec.http;
+    requires io.netty.buffer;
+    requires io.netty.common;
+    requires io.netty.transport;
+    requires io.netty.codec.http2;
+    requires org.eclipse.osgi;
+    requires io.netty.codec;
+    requires io.netty.handler;
+    requires commons.pool;
     exports io.ballerina.stdlib.http.api;
     exports io.ballerina.stdlib.http.transport.contract.websocket;
     exports io.ballerina.stdlib.http.transport.contract;


### PR DESCRIPTION
## Purpose
Add missing **requires** directives which supports for JAVA11 dependency resolution.

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests