### PR TITLE
Add support for Map Json as query parameter

### DIFF
--- a/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
@@ -51,14 +51,23 @@ service /queryparamservice on QueryBindingEP {
         checkpanic caller->respond(responseJson);
     }
 
-    resource function get q5(map<json>? obj) returns json {
+    resource function get q5(map<json> obj) returns json {
+        return obj;
+    }
+
+    resource function get q6(map<json>? obj) returns json {
         if obj is () {
             return { name : "empty", value : "empty" };
         }
         return obj;
     }
 
-    resource function get q6(map<json>[]? objs) returns json {
+    resource function get q7(map<json>[] objs) returns json {
+        json responseJson = { objects : objs };
+        return responseJson;
+    }
+
+    resource function get q8(map<json>[]? objs) returns json {
         if objs is () {
             return { name : "empty", value : "empty" };
         }
@@ -199,7 +208,7 @@ function testMapJsonArrayQueryBinding() returns error? {
     json expected = { objects : [jsonObj1, jsonObj2] };
     string jsonEncoded1 = check url:encode(jsonObj1.toJsonString(), "UTF-8");
     string jsonEncoded2 = check url:encode(jsonObj2.toJsonString(), "UTF-8");
-    http:Response response = check queryBindingClient->get("/queryparamservice/q6?objs=" + jsonEncoded1 + "," +
+    http:Response response = check queryBindingClient->get("/queryparamservice/q7?objs=" + jsonEncoded1 + "," +
                                 jsonEncoded2);
     assertJsonPayloadtoJsonString(response.getJsonPayload(), expected);
 }
@@ -207,13 +216,27 @@ function testMapJsonArrayQueryBinding() returns error? {
 @test:Config {}
 function testNillableMapJsonQueryBinding() returns error? {
     json emptyObj = { name : "empty", value : "empty" };
-    http:Response response = check queryBindingClient->get("/queryparamservice/q5");
+    map<json> jsonObj = { name : "test", value : "json" };
+    string jsonEncoded = check url:encode(jsonObj.toJsonString(), "UTF-8");
+    http:Response response = check queryBindingClient->get("/queryparamservice/q6?obj=" + jsonEncoded);
+    assertJsonPayloadtoJsonString(response.getJsonPayload(), jsonObj);
+
+    response = check queryBindingClient->get("/queryparamservice/q6");
     assertJsonPayloadtoJsonString(response.getJsonPayload(), emptyObj);
 }
 
 @test:Config {}
 function testNillableMapJsonArrayQueryBinding() returns error? {
     json emptyObj = { name : "empty", value : "empty" };
-    http:Response response = check queryBindingClient->get("/queryparamservice/q6");
+    map<json> jsonObj1 = { name : "test1", value : "json1" };
+    map<json> jsonObj2 = { name : "test2", value : "json2" };
+    json expected = { objects : [jsonObj1, jsonObj2] };
+    string jsonEncoded1 = check url:encode(jsonObj1.toJsonString(), "UTF-8");
+    string jsonEncoded2 = check url:encode(jsonObj2.toJsonString(), "UTF-8");
+    http:Response response = check queryBindingClient->get("/queryparamservice/q8?objs=" + jsonEncoded1 + "," +
+                                jsonEncoded2);
+    assertJsonPayloadtoJsonString(response.getJsonPayload(), expected);
+
+    response = check queryBindingClient->get("/queryparamservice/q8");
     assertJsonPayloadtoJsonString(response.getJsonPayload(), emptyObj);
 }

--- a/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
@@ -51,14 +51,17 @@ service /queryparamservice on QueryBindingEP {
         checkpanic caller->respond(responseJson);
     }
 
-    resource function get q5(json obj) returns json {
+    resource function get q5(map<json>? obj) returns json {
         if obj is () {
             return { name : "empty", value : "empty" };
         }
         return obj;
     }
 
-    resource function get q6(json[] objs) returns json {
+    resource function get q6(map<json>[]? objs) returns json {
+        if objs is () {
+            return { name : "empty", value : "empty" };
+        }
         json responseJson = { objects : objs };
         return responseJson;
     }
@@ -182,22 +185,18 @@ function testNilableAllTypeQueryArrBinding() {
 }
 
 @test:Config {}
-function testJsonQueryBinding() returns error?{
-    json jsonObj = {name : "test", value : "json"};
+function testMapJsonQueryBinding() returns error? {
+    map<json> jsonObj = { name : "test", value : "json" };
     string jsonEncoded = check url:encode(jsonObj.toJsonString(), "UTF-8");
     http:Response response = check queryBindingClient->get("/queryparamservice/q5?obj=" + jsonEncoded);
     assertJsonPayloadtoJsonString(response.getJsonPayload(), jsonObj);
-
-    json emptyObj = {name : "empty", value : "empty"};
-    response = check queryBindingClient->get("/queryparamservice/q5");
-    assertJsonPayloadtoJsonString(response.getJsonPayload(), emptyObj);
 }
 
 @test:Config {}
-function testJsonArrayQueryBinding() returns error?{
-    json jsonObj1 = {name : "test1", value : "json1"};
-    json jsonObj2 = {name : "test2", value : "json2"};
-    json expected = {objects : [jsonObj1, jsonObj2]};
+function testMapJsonArrayQueryBinding() returns error? {
+    map<json> jsonObj1 = { name : "test1", value : "json1" };
+    map<json> jsonObj2 = { name : "test2", value : "json2" };
+    json expected = { objects : [jsonObj1, jsonObj2] };
     string jsonEncoded1 = check url:encode(jsonObj1.toJsonString(), "UTF-8");
     string jsonEncoded2 = check url:encode(jsonObj2.toJsonString(), "UTF-8");
     http:Response response = check queryBindingClient->get("/queryparamservice/q6?objs=" + jsonEncoded1 + "," +
@@ -206,13 +205,15 @@ function testJsonArrayQueryBinding() returns error?{
 }
 
 @test:Config {}
-function testMapJsonQueryBinding() returns error?{
-    map<json> jsonMap = {
-        name : "test",
-        value : 8,
-        objs : [{name : "test1", value: "json1"}, {name : "test2", value: "json2"}]
-        };
-    string jsonEncoded = check url:encode(jsonMap.toJsonString(), "UTF-8");
-    http:Response response = check queryBindingClient->get("/queryparamservice/q5?obj=" + jsonEncoded);
-    assertJsonPayloadtoJsonString(response.getJsonPayload(), jsonMap);
+function testNillableMapJsonQueryBinding() returns error? {
+    json emptyObj = { name : "empty", value : "empty" };
+    http:Response response = check queryBindingClient->get("/queryparamservice/q5");
+    assertJsonPayloadtoJsonString(response.getJsonPayload(), emptyObj);
+}
+
+@test:Config {}
+function testNillableMapJsonArrayQueryBinding() returns error? {
+    json emptyObj = { name : "empty", value : "empty" };
+    http:Response response = check queryBindingClient->get("/queryparamservice/q6");
+    assertJsonPayloadtoJsonString(response.getJsonPayload(), emptyObj);
 }

--- a/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
@@ -208,8 +208,8 @@ function testJsonArrayQueryBinding() returns error?{
 
 @test:Config {}
 function testNilableJsonQueryBinding() returns error?{
-    json jsonObj = { name : "test", value : "json"};
-    json emptyObj = { name : "empty", value : "empty" };
+    json jsonObj = {name : "test", value : "json"};
+    json emptyObj = {name : "empty", value : "empty"};
     string jsonEncoded = check url:encode(jsonObj.toJsonString(), "UTF-8");
     http:Response response = check queryBindingClient->get("/queryparamservice/q7?obj=" + jsonEncoded);
     assertJsonPayloadtoJsonString(response.getJsonPayload(), jsonObj);

--- a/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
@@ -52,20 +52,15 @@ service /queryparamservice on QueryBindingEP {
     }
 
     resource function get q5(json obj) returns json {
+        if obj is () {
+            return { name : "empty", value : "empty" };
+        }
         return obj;
     }
 
     resource function get q6(json[] objs) returns json {
         json responseJson = { objects : objs };
         return responseJson;
-    }
-
-    resource function get q7(json? obj) returns json {
-        if obj is () {
-            return { name : "empty", value : "empty" };
-        } else {
-            return obj;
-        }
     }
 }
 
@@ -192,6 +187,10 @@ function testJsonQueryBinding() returns error?{
     string jsonEncoded = check url:encode(jsonObj.toJsonString(), "UTF-8");
     http:Response response = check queryBindingClient->get("/queryparamservice/q5?obj=" + jsonEncoded);
     assertJsonPayloadtoJsonString(response.getJsonPayload(), jsonObj);
+
+    json emptyObj = {name : "empty", value : "empty"};
+    response = check queryBindingClient->get("/queryparamservice/q5");
+    assertJsonPayloadtoJsonString(response.getJsonPayload(), emptyObj);
 }
 
 @test:Config {}
@@ -207,13 +206,13 @@ function testJsonArrayQueryBinding() returns error?{
 }
 
 @test:Config {}
-function testNilableJsonQueryBinding() returns error?{
-    json jsonObj = {name : "test", value : "json"};
-    json emptyObj = {name : "empty", value : "empty"};
-    string jsonEncoded = check url:encode(jsonObj.toJsonString(), "UTF-8");
-    http:Response response = check queryBindingClient->get("/queryparamservice/q7?obj=" + jsonEncoded);
-    assertJsonPayloadtoJsonString(response.getJsonPayload(), jsonObj);
-
-    response = check queryBindingClient->get("/queryparamservice/q7");
-    assertJsonPayloadtoJsonString(response.getJsonPayload(), emptyObj);
+function testMapJsonQueryBinding() returns error?{
+    map<json> jsonMap = {
+        name : "test",
+        value : 8,
+        objs : [{name : "test1", value: "json1"}, {name : "test2", value: "json2"}]
+        };
+    string jsonEncoded = check url:encode(jsonMap.toJsonString(), "UTF-8");
+    http:Response response = check queryBindingClient->get("/queryparamservice/q5?obj=" + jsonEncoded);
+    assertJsonPayloadtoJsonString(response.getJsonPayload(), jsonMap);
 }

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Enable HTTP trace and access log support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1073)
 - [Add HATEOS link support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1637)
 - [Introduce http:CacheConfig annotation to the resource signature](https://github.com/ballerina-platform/ballerina-standard-library/issues/1533)
+- [Add support for Json object as query parameter](https://github.com/ballerina-platform/ballerina-standard-library/issues/1670)
 
 ## Fixed
 - [Fix incorrect behaviour of client with mtls](https://github.com/ballerina-platform/ballerina-standard-library/issues/1708)

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Enable HTTP trace and access log support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1073)
 - [Add HATEOS link support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1637)
 - [Introduce http:CacheConfig annotation to the resource signature](https://github.com/ballerina-platform/ballerina-standard-library/issues/1533)
-- [Add support for Json object as query parameter](https://github.com/ballerina-platform/ballerina-standard-library/issues/1670)
+- [Add support for Map Json as query parameter](https://github.com/ballerina-platform/ballerina-standard-library/issues/1670)
 
 ## Fixed
 - [Fix incorrect behaviour of client with mtls](https://github.com/ballerina-platform/ballerina-standard-library/issues/1708)

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -206,20 +206,19 @@ public class CompilerPluginTest {
         Package currentPackage = loadPackage("sample_package_8");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
-        Assert.assertEquals(diagnosticResult.diagnosticCount(), 6);
-        assertError(diagnosticResult, 0, "invalid resource parameter type: 'json'", HTTP_106);
-        assertTrue(diagnosticResult, 1, "invalid resource parameter type: 'ballerina/mime", HTTP_106);
+        Assert.assertEquals(diagnosticResult.diagnosticCount(), 5);
+        assertTrue(diagnosticResult, 0, "invalid resource parameter type: 'ballerina/mime", HTTP_106);
+        assertError(diagnosticResult, 1, "invalid union type of query param 'a': 'string', 'int', 'float', " +
+                "'boolean', 'decimal', 'json' type or the array types of them can only be union with '()'. Eg: " +
+                "string? or int[]?", HTTP_113);
         assertError(diagnosticResult, 2, "invalid union type of query param 'a': 'string', 'int', 'float', " +
-                "'boolean', 'decimal' type or the array types of them can only be union with '()'. Eg: string? or " +
-                "int[]?", HTTP_113);
+                "'boolean', 'decimal', 'json' type or the array types of them can only be union with '()'. Eg: " +
+                "string? or int[]?", HTTP_113);
         assertError(diagnosticResult, 3, "invalid union type of query param 'a': 'string', 'int', 'float', " +
-                "'boolean', 'decimal' type or the array types of them can only be union with '()'. Eg: string? or " +
-                "int[]?", HTTP_113);
-        assertError(diagnosticResult, 4, "invalid union type of query param 'a': 'string', 'int', 'float', " +
-                "'boolean', 'decimal' type or the array types of them can only be union with '()'. Eg: string? or " +
-                "int[]?", HTTP_113);
-        assertError(diagnosticResult, 5, "invalid type of query param 'a': expected one of the 'string', " +
-                "'int', 'float', 'boolean', 'decimal' types or the array types of them", HTTP_112);
+                "'boolean', 'decimal', 'json' type or the array types of them can only be union with '()'. Eg: " +
+                "string? or int[]?", HTTP_113);
+        assertError(diagnosticResult, 4, "invalid type of query param 'a': expected one of the 'string', " +
+                "'int', 'float', 'boolean', 'decimal', 'json' types or the array types of them", HTTP_112);
     }
 
     @Test

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -206,16 +206,38 @@ public class CompilerPluginTest {
         Package currentPackage = loadPackage("sample_package_8");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
-        Assert.assertEquals(diagnosticResult.diagnosticCount(), 5);
+        diagnosticResult.diagnostics().forEach(System.out::println);
+        Assert.assertEquals(diagnosticResult.diagnosticCount(), 12);
         assertTrue(diagnosticResult, 0, "invalid resource parameter type: 'ballerina/mime", HTTP_106);
-        assertError(diagnosticResult, 1, "invalid union type of query param 'a': 'json' type or union " +
-                "of a 'json' subtype and nil is allowed. Eg: string? or int[]?", HTTP_113);
-        assertError(diagnosticResult, 2, "invalid union type of query param 'a': 'json' type or union " +
-                "of a 'json' subtype and nil is allowed. Eg: string? or int[]?", HTTP_113);
-        assertError(diagnosticResult, 3, "invalid union type of query param 'a': 'json' type or union " +
-                "of a 'json' subtype and nil is allowed. Eg: string? or int[]?", HTTP_113);
-        assertError(diagnosticResult, 4, "invalid type of query param 'a': expected one of the 'string', " +
-                "'int', 'float', 'boolean', 'decimal', 'json' types or the array types of them", HTTP_112);
+        assertError(diagnosticResult, 1, "invalid union type of query param 'a': 'string', 'int', " +
+                "'float', 'boolean', 'decimal', 'map<json>' type or the array types of them can only be union with " +
+                "'()'. Eg: string? or int[]?", HTTP_113);
+        assertError(diagnosticResult, 2, "invalid union type of query param 'b': 'string', 'int', " +
+                "'float', 'boolean', 'decimal', 'map<json>' type or the array types of them can only be union with " +
+                "'()'. Eg: string? or int[]?", HTTP_113);
+        assertError(diagnosticResult, 3, "invalid union type of query param 'c': 'string', 'int', " +
+                "'float', 'boolean', 'decimal', 'map<json>' type or the array types of them can only be union with " +
+                "'()'. Eg: string? or int[]?", HTTP_113);
+        assertError(diagnosticResult, 4, "invalid type of query param 'd': expected one of the " +
+                "'string', 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them",
+                HTTP_112);
+        assertTrue(diagnosticResult, 5, "invalid resource parameter type: 'json'", HTTP_106);
+        assertError(diagnosticResult, 6, "invalid type of query param 'aa': expected one of the " +
+                "'string', 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them",
+                HTTP_112);
+        assertError(diagnosticResult, 7, "invalid type of query param 'a': expected one of the " +
+                "'string', 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them",
+                HTTP_112);
+        assertError(diagnosticResult, 8, "invalid type of query param 'b': expected one of the " +
+                "'string', 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them",
+                HTTP_112);
+        assertError(diagnosticResult, 9, "invalid type of query param 'c': expected one of the " +
+                "'string', 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them",
+                HTTP_112);
+        assertError(diagnosticResult, 10, "invalid type of query param 'd': expected one of the " +
+                "'string', 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them",
+                HTTP_112);
+        assertTrue(diagnosticResult, 11, "invalid resource parameter type: 'xml'", HTTP_106);
     }
 
     @Test

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -208,15 +208,12 @@ public class CompilerPluginTest {
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         Assert.assertEquals(diagnosticResult.diagnosticCount(), 5);
         assertTrue(diagnosticResult, 0, "invalid resource parameter type: 'ballerina/mime", HTTP_106);
-        assertError(diagnosticResult, 1, "invalid union type of query param 'a': 'string', 'int', 'float', " +
-                "'boolean', 'decimal', 'json' type or the array types of them can only be union with '()'. Eg: " +
-                "string? or int[]?", HTTP_113);
-        assertError(diagnosticResult, 2, "invalid union type of query param 'a': 'string', 'int', 'float', " +
-                "'boolean', 'decimal', 'json' type or the array types of them can only be union with '()'. Eg: " +
-                "string? or int[]?", HTTP_113);
-        assertError(diagnosticResult, 3, "invalid union type of query param 'a': 'string', 'int', 'float', " +
-                "'boolean', 'decimal', 'json' type or the array types of them can only be union with '()'. Eg: " +
-                "string? or int[]?", HTTP_113);
+        assertError(diagnosticResult, 1, "invalid union type of query param 'a': 'json' type or union " +
+                "of a 'json' subtype and nil is allowed. Eg: string? or int[]?", HTTP_113);
+        assertError(diagnosticResult, 2, "invalid union type of query param 'a': 'json' type or union " +
+                "of a 'json' subtype and nil is allowed. Eg: string? or int[]?", HTTP_113);
+        assertError(diagnosticResult, 3, "invalid union type of query param 'a': 'json' type or union " +
+                "of a 'json' subtype and nil is allowed. Eg: string? or int[]?", HTTP_113);
         assertError(diagnosticResult, 4, "invalid type of query param 'a': expected one of the 'string', " +
                 "'int', 'float', 'boolean', 'decimal', 'json' types or the array types of them", HTTP_112);
     }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/service.bal
@@ -101,5 +101,5 @@ service http:Service on new http:Listener(9090) {
 
     resource function get callerErr10(json[] d, xml e) returns string {
             return "done";
-        }
+    }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/service.bal
@@ -47,31 +47,35 @@ service http:Service on new http:Listener(9090) {
         return "done";
     }
 
-    resource function get callerErr1(json a) returns string {
+    resource function get callerInfo7(json a) returns string {
         return "done";
     }
 
-    resource function get callerErr2(mime:Entity abc) returns string {
+    resource function get callerInfo8(json[] a) returns string {
         return "done";
     }
 
-    resource function get callerErr3(int|string a) returns string {
+    resource function get callerInfo9(json? a) returns string {
         return "done";
     }
 
-    resource function get callerErr4(int|string[]|float a) returns string {
+    resource function get callerErr1(mime:Entity abc) returns string {
         return "done";
     }
 
-    resource function get callerErr5(int[]|json a) returns string {
+    resource function get callerErr2(int|string a) returns string {
         return "done";
     }
 
-    resource function get callerErr6(json[] a) returns string {
+    resource function get callerErr3(int|string[]|float a) returns string {
         return "done";
     }
 
-    resource function get callerErr7(json? a) returns string {
+    resource function get callerErr4(int[]|json a) returns string {
+        return "done";
+    }
+
+    resource function get callerErr5(xml? a) returns string {
         return "done";
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/service.bal
@@ -47,15 +47,19 @@ service http:Service on new http:Listener(9090) {
         return "done";
     }
 
-    resource function get callerInfo7(json a) returns string {
+    resource function get callerInfo7(map<json> aa, string? ab, boolean[] ac) returns string {
         return "done";
     }
 
-    resource function get callerInfo8(json[] a) returns string {
+    resource function get callerInfo8(map<json>[] ba, int bb, decimal[]? bc) returns string {
         return "done";
     }
 
-    resource function get callerInfo9(json? a) returns string {
+    resource function get callerInfo9(float[] cb, int[]? cc, map<json>? ca) returns string {
+        return "done";
+    }
+
+    resource function get callerInfo10(string[] db, boolean dc, map<json>[]? da) returns string {
         return "done";
     }
 
@@ -67,15 +71,35 @@ service http:Service on new http:Listener(9090) {
         return "done";
     }
 
-    resource function get callerErr3(int|string[]|float a) returns string {
+    resource function get callerErr3(int|string[]|float b) returns string {
         return "done";
     }
 
-    resource function get callerErr4(int[]|json a) returns string {
+    resource function get callerErr4(int[]|json c) returns string {
         return "done";
     }
 
-    resource function get callerErr5(xml? a) returns string {
+    resource function get callerErr5(xml? d, string e) returns string {
         return "done";
     }
+
+    resource function get callerErr6(int[]? b, json a, json[] aa) returns string {
+        return "done";
+    }
+
+    resource function get callerErr7(string? b, map<int> a) returns string {
+        return "done";
+    }
+
+    resource function get callerErr8(map<int>[] b, int[] c) returns string {
+        return "done";
+    }
+
+    resource function get callerErr9(map<string>? c, map<json> d) returns string {
+        return "done";
+    }
+
+    resource function get callerErr10(json[] d, xml e) returns string {
+            return "done";
+        }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
@@ -45,9 +45,10 @@ public enum HttpDiagnosticCodes {
             "only be union with '()'. Eg: string|() or string[]|()", ERROR),
     HTTP_111("HTTP_111", "invalid type of caller param '%s': expected 'http:Caller'", ERROR),
     HTTP_112("HTTP_112", "invalid type of query param '%s': expected one of the 'string', 'int', 'float', " +
-            "'boolean', 'decimal' types or the array types of them", ERROR),
+            "'boolean', 'decimal', 'json' types or the array types of them", ERROR),
     HTTP_113("HTTP_113", "invalid union type of query param '%s': 'string', 'int', 'float', 'boolean', " +
-            "'decimal' type or the array types of them can only be union with '()'. Eg: string? or int[]?", ERROR),
+            "'decimal', 'json' type or the array types of them can only be union with '()'. Eg: string? or int[]?",
+            ERROR),
     HTTP_114("HTTP_114", "incompatible respond method argument type : expected '%s' according " +
             "to the 'http:CallerInfo' annotation", ERROR),
     HTTP_115("HTTP_115", "invalid multiple 'http:Caller' parameter: '%s'", ERROR),

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
@@ -45,9 +45,10 @@ public enum HttpDiagnosticCodes {
             "only be union with '()'. Eg: string|() or string[]|()", ERROR),
     HTTP_111("HTTP_111", "invalid type of caller param '%s': expected 'http:Caller'", ERROR),
     HTTP_112("HTTP_112", "invalid type of query param '%s': expected one of the 'string', 'int', 'float', " +
-            "'boolean', 'decimal', 'json' types or the array types of them", ERROR),
-    HTTP_113("HTTP_113", "invalid union type of query param 'a': 'json' type or union of a 'json' " +
-            "subtype and nil is allowed. Eg: string? or int[]?", ERROR),
+            "'boolean', 'decimal', 'map<json>' types or the array types of them", ERROR),
+    HTTP_113("HTTP_113", "invalid union type of query param '%s': 'string', 'int', 'float', 'boolean', " +
+            "'decimal', 'map<json>' type or the array types of them can only be union with '()'. Eg: string? or int[]?",
+            ERROR),
     HTTP_114("HTTP_114", "incompatible respond method argument type : expected '%s' according " +
             "to the 'http:CallerInfo' annotation", ERROR),
     HTTP_115("HTTP_115", "invalid multiple 'http:Caller' parameter: '%s'", ERROR),

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
@@ -46,9 +46,8 @@ public enum HttpDiagnosticCodes {
     HTTP_111("HTTP_111", "invalid type of caller param '%s': expected 'http:Caller'", ERROR),
     HTTP_112("HTTP_112", "invalid type of query param '%s': expected one of the 'string', 'int', 'float', " +
             "'boolean', 'decimal', 'json' types or the array types of them", ERROR),
-    HTTP_113("HTTP_113", "invalid union type of query param '%s': 'string', 'int', 'float', 'boolean', " +
-            "'decimal', 'json' type or the array types of them can only be union with '()'. Eg: string? or int[]?",
-            ERROR),
+    HTTP_113("HTTP_113", "invalid union type of query param 'a': 'json' type or union of a 'json' " +
+            "subtype and nil is allowed. Eg: string? or int[]?", ERROR),
     HTTP_114("HTTP_114", "incompatible respond method argument type : expected '%s' according " +
             "to the 'http:CallerInfo' annotation", ERROR),
     HTTP_115("HTTP_115", "invalid multiple 'http:Caller' parameter: '%s'", ERROR),

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
@@ -171,11 +171,27 @@ class HttpResourceValidator {
                     }
                 } else if (isAllowedQueryParamType(kind)) {
                     // Allowed query param types
+                } else if (kind == TypeDescKind.MAP) {
+                    TypeSymbol constrainedTypeSymbol = ((MapTypeSymbol) typeSymbol).typeParam();
+                    TypeDescKind constrainedType = constrainedTypeSymbol.typeKind();
+                    if (constrainedType != TypeDescKind.JSON) {
+                        reportInvalidQueryParameterType(ctx, member, paramName);
+                        continue;
+                    }
                 } else if (kind == TypeDescKind.ARRAY) {
                     // Allowed query param array types
                     TypeSymbol arrTypeSymbol = ((ArrayTypeSymbol) typeSymbol).memberTypeDescriptor();
                     TypeDescKind elementKind = arrTypeSymbol.typeKind();
-                    if (isAllowedQueryParamType(elementKind)) {
+                    if (elementKind == TypeDescKind.MAP) {
+                        TypeSymbol constrainedTypeSymbol = ((MapTypeSymbol) arrTypeSymbol).typeParam();
+                        TypeDescKind constrainedType = constrainedTypeSymbol.typeKind();
+                        if (constrainedType != TypeDescKind.JSON) {
+                            reportInvalidQueryParameterType(ctx, member, paramName);
+                        }
+                        continue;
+                    }
+                    if (!isAllowedQueryParamType(elementKind)) {
+                        reportInvalidQueryParameterType(ctx, member, paramName);
                         continue;
                     }
                 } else if (kind == TypeDescKind.UNION) {
@@ -195,7 +211,20 @@ class HttpResourceValidator {
                         if (elementKind == TypeDescKind.ARRAY) {
                             TypeSymbol arrTypeSymbol = ((ArrayTypeSymbol) type).memberTypeDescriptor();
                             TypeDescKind arrElementKind = arrTypeSymbol.typeKind();
+                            if (arrElementKind == TypeDescKind.MAP) {
+                                TypeSymbol constrainedTypeSymbol = ((MapTypeSymbol) arrTypeSymbol).typeParam();
+                                TypeDescKind constrainedType = constrainedTypeSymbol.typeKind();
+                                if (constrainedType == TypeDescKind.JSON) {
+                                    continue;
+                                }
+                            }
                             if (isAllowedQueryParamType(arrElementKind)) {
+                                continue;
+                            }
+                        } else if (elementKind == TypeDescKind.MAP) {
+                            TypeSymbol constrainedTypeSymbol = ((MapTypeSymbol) type).typeParam();
+                            TypeDescKind constrainedType = constrainedTypeSymbol.typeKind();
+                            if (constrainedType == TypeDescKind.JSON) {
                                 continue;
                             }
                         } else {
@@ -440,7 +469,7 @@ class HttpResourceValidator {
 
     private static boolean isAllowedQueryParamType(TypeDescKind kind) {
         return kind == TypeDescKind.STRING || kind == TypeDescKind.INT || kind == TypeDescKind.FLOAT ||
-                kind == TypeDescKind.DECIMAL || kind == TypeDescKind.BOOLEAN || kind == TypeDescKind.JSON;
+                kind == TypeDescKind.DECIMAL || kind == TypeDescKind.BOOLEAN;
     }
 
     private static void extractReturnTypeAndValidate(SyntaxNodeAnalysisContext ctx, FunctionDefinitionNode member) {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
@@ -440,7 +440,7 @@ class HttpResourceValidator {
 
     private static boolean isAllowedQueryParamType(TypeDescKind kind) {
         return kind == TypeDescKind.STRING || kind == TypeDescKind.INT || kind == TypeDescKind.FLOAT ||
-                kind == TypeDescKind.DECIMAL || kind == TypeDescKind.BOOLEAN;
+                kind == TypeDescKind.DECIMAL || kind == TypeDescKind.BOOLEAN || kind == TypeDescKind.JSON;
     }
 
     private static void extractReturnTypeAndValidate(SyntaxNodeAnalysisContext ctx, FunctionDefinitionNode member) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
@@ -23,6 +23,7 @@ import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.utils.JsonUtils;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BError;
@@ -60,6 +61,7 @@ import static io.ballerina.runtime.api.TypeTags.BOOLEAN_TAG;
 import static io.ballerina.runtime.api.TypeTags.DECIMAL_TAG;
 import static io.ballerina.runtime.api.TypeTags.FLOAT_TAG;
 import static io.ballerina.runtime.api.TypeTags.INT_TAG;
+import static io.ballerina.runtime.api.TypeTags.JSON_TAG;
 import static io.ballerina.runtime.api.TypeTags.STRING_TAG;
 import static io.ballerina.stdlib.http.api.HttpConstants.DEFAULT_HOST;
 import static io.ballerina.stdlib.http.api.HttpConstants.EXTRA_PATH_INDEX;
@@ -76,6 +78,7 @@ public class HttpDispatcher {
     private static final ArrayType FLOAT_ARR = TypeCreator.createArrayType(PredefinedTypes.TYPE_FLOAT);
     private static final ArrayType BOOLEAN_ARR = TypeCreator.createArrayType(PredefinedTypes.TYPE_BOOLEAN);
     private static final ArrayType DECIMAL_ARR = TypeCreator.createArrayType(PredefinedTypes.TYPE_DECIMAL);
+    private static final ArrayType JSON_ARR = TypeCreator.createArrayType(PredefinedTypes.TYPE_JSON);
 
     public static HttpService findService(HTTPServicesRegistry servicesRegistry, HttpCarbonMessage inboundReqMsg) {
         try {
@@ -300,6 +303,8 @@ public class HttpDispatcher {
                 return Boolean.parseBoolean(argValue);
             case DECIMAL_TAG:
                 return ValueCreator.createDecimalValue(argValue);
+            case JSON_TAG:
+                return JsonUtils.parse(argValue);
             default:
                 return StringUtils.fromString(argValue);
         }
@@ -314,6 +319,8 @@ public class HttpDispatcher {
             return getBArray(argValueArr, BOOLEAN_ARR, targetElementTypeTag);
         } else if (targetElementTypeTag == DECIMAL_TAG) {
             return getBArray(argValueArr, DECIMAL_ARR, targetElementTypeTag);
+        } else if (targetElementTypeTag == JSON_TAG) {
+            return getBArray(argValueArr, JSON_ARR, targetElementTypeTag);
         } else {
             return StringUtils.fromStringArray(argValueArr);
         }
@@ -335,6 +342,9 @@ public class HttpDispatcher {
                     break;
                 case DECIMAL_TAG:
                     arrayValue.add(index++, ValueCreator.createDecimalValue(element));
+                    break;
+                case JSON_TAG:
+                    arrayValue.add(index++, JsonUtils.parse(element));
                     break;
                 default:
                     throw new BallerinaConnectorException("Illegal state error: unexpected param type");

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
@@ -76,7 +76,6 @@ import static io.ballerina.stdlib.mime.util.MimeConstants.REQUEST_ENTITY_FIELD;
 public class HttpDispatcher {
 
     private static final MapType MAP_TYPE = TypeCreator.createMapType(PredefinedTypes.TYPE_JSON);
-
     private static final ArrayType INT_ARR = TypeCreator.createArrayType(PredefinedTypes.TYPE_INT);
     private static final ArrayType FLOAT_ARR = TypeCreator.createArrayType(PredefinedTypes.TYPE_FLOAT);
     private static final ArrayType BOOLEAN_ARR = TypeCreator.createArrayType(PredefinedTypes.TYPE_BOOLEAN);

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
@@ -223,7 +223,10 @@ public class ParamHandler {
     }
 
     private void validateQueryParam(int index, ResourceMethodType balResource, Type parameterType) {
-        if (parameterType instanceof UnionType && !(parameterType instanceof JsonType)) {
+        if (parameterType instanceof JsonType) {
+            QueryParam queryParam = new QueryParam(parameterType, balResource.getParamNames()[index], index, true);
+            this.queryParams.add(queryParam);
+        } else if (parameterType instanceof UnionType) {
             List<Type> memberTypes = ((UnionType) parameterType).getMemberTypes();
             int size = memberTypes.size();
             if (size > 2 || !parameterType.isNilable()) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
@@ -23,6 +23,7 @@ import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.ArrayType;
+import io.ballerina.runtime.api.types.JsonType;
 import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.types.ResourceMethodType;
 import io.ballerina.runtime.api.types.Type;
@@ -222,7 +223,7 @@ public class ParamHandler {
     }
 
     private void validateQueryParam(int index, ResourceMethodType balResource, Type parameterType) {
-        if (parameterType instanceof UnionType) {
+        if (parameterType instanceof UnionType && !(parameterType instanceof JsonType)) {
             List<Type> memberTypes = ((UnionType) parameterType).getMemberTypes();
             int size = memberTypes.size();
             if (size > 2 || !parameterType.isNilable()) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
@@ -23,7 +23,6 @@ import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.ArrayType;
-import io.ballerina.runtime.api.types.JsonType;
 import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.types.ResourceMethodType;
 import io.ballerina.runtime.api.types.Type;
@@ -223,10 +222,7 @@ public class ParamHandler {
     }
 
     private void validateQueryParam(int index, ResourceMethodType balResource, Type parameterType) {
-        if (parameterType instanceof JsonType) {
-            QueryParam queryParam = new QueryParam(parameterType, balResource.getParamNames()[index], index, true);
-            this.queryParams.add(queryParam);
-        } else if (parameterType instanceof UnionType) {
+        if (parameterType instanceof UnionType) {
             List<Type> memberTypes = ((UnionType) parameterType).getMemberTypes();
             int size = memberTypes.size();
             if (size > 2 || !parameterType.isNilable()) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/QueryParam.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/QueryParam.java
@@ -57,7 +57,7 @@ public class QueryParam {
 
     private boolean isValidBasicType(int typeTag) {
         return typeTag == TypeTags.STRING_TAG || typeTag == TypeTags.INT_TAG || typeTag == TypeTags.FLOAT_TAG ||
-                typeTag == TypeTags.BOOLEAN_TAG || typeTag == TypeTags.DECIMAL_TAG;
+                typeTag == TypeTags.BOOLEAN_TAG || typeTag == TypeTags.DECIMAL_TAG || typeTag == TypeTags.JSON_TAG;
     }
 
     public String getToken() {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/QueryParam.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/QueryParam.java
@@ -20,6 +20,7 @@ package io.ballerina.stdlib.http.api.service.signature;
 
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.types.ArrayType;
+import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.stdlib.http.api.HttpErrorType;
 import io.ballerina.stdlib.http.api.HttpUtil;
@@ -47,17 +48,29 @@ public class QueryParam {
     }
 
     private void validateQueryParamType() {
-        if (isValidBasicType(typeTag) || (typeTag == TypeTags.ARRAY_TAG && isValidBasicType(
-                ((ArrayType) type).getElementType().getTag()))) {
+        if (isValidBasicType(typeTag) || isValidJsonMap() || (typeTag == TypeTags.ARRAY_TAG && (isValidBasicType(
+                ((ArrayType) type).getElementType().getTag()) || isValidJsonMap()))) {
             return;
         }
         throw HttpUtil.createHttpError("incompatible query parameter type: '" + type.getName() + "'",
                                        HttpErrorType.GENERIC_LISTENER_ERROR);
     }
 
+    private boolean isValidJsonMap() {
+        if (typeTag == TypeTags.MAP_TAG) {
+            return ((MapType) type).getConstrainedType().getTag() == TypeTags.JSON_TAG;
+        } else if (typeTag == TypeTags.ARRAY_TAG) {
+            Type elementType = ((ArrayType) type).getElementType();
+            if (elementType.getTag() == TypeTags.MAP_TAG) {
+                return ((MapType) elementType).getConstrainedType().getTag() == TypeTags.JSON_TAG;
+            }
+        }
+        return false;
+    }
+
     private boolean isValidBasicType(int typeTag) {
         return typeTag == TypeTags.STRING_TAG || typeTag == TypeTags.INT_TAG || typeTag == TypeTags.FLOAT_TAG ||
-                typeTag == TypeTags.BOOLEAN_TAG || typeTag == TypeTags.DECIMAL_TAG || typeTag == TypeTags.JSON_TAG;
+                typeTag == TypeTags.BOOLEAN_TAG || typeTag == TypeTags.DECIMAL_TAG;
     }
 
     public String getToken() {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/QueryParam.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/QueryParam.java
@@ -18,12 +18,7 @@
 
 package io.ballerina.stdlib.http.api.service.signature;
 
-import io.ballerina.runtime.api.TypeTags;
-import io.ballerina.runtime.api.types.ArrayType;
-import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.types.Type;
-import io.ballerina.stdlib.http.api.HttpErrorType;
-import io.ballerina.stdlib.http.api.HttpUtil;
 
 /**
  * {@code {@link QueryParam }} represents a query parameter details.
@@ -44,33 +39,6 @@ public class QueryParam {
         this.token = token;
         this.index = index;
         this.nilable = nilable;
-        validateQueryParamType();
-    }
-
-    private void validateQueryParamType() {
-        if (isValidBasicType(typeTag) || isValidJsonMap() || (typeTag == TypeTags.ARRAY_TAG && (isValidBasicType(
-                ((ArrayType) type).getElementType().getTag()) || isValidJsonMap()))) {
-            return;
-        }
-        throw HttpUtil.createHttpError("incompatible query parameter type: '" + type.getName() + "'",
-                                       HttpErrorType.GENERIC_LISTENER_ERROR);
-    }
-
-    private boolean isValidJsonMap() {
-        if (typeTag == TypeTags.MAP_TAG) {
-            return ((MapType) type).getConstrainedType().getTag() == TypeTags.JSON_TAG;
-        } else if (typeTag == TypeTags.ARRAY_TAG) {
-            Type elementType = ((ArrayType) type).getElementType();
-            if (elementType.getTag() == TypeTags.MAP_TAG) {
-                return ((MapType) elementType).getConstrainedType().getTag() == TypeTags.JSON_TAG;
-            }
-        }
-        return false;
-    }
-
-    private boolean isValidBasicType(int typeTag) {
-        return typeTag == TypeTags.STRING_TAG || typeTag == TypeTags.INT_TAG || typeTag == TypeTags.FLOAT_TAG ||
-                typeTag == TypeTags.BOOLEAN_TAG || typeTag == TypeTags.DECIMAL_TAG;
     }
 
     public String getToken() {


### PR DESCRIPTION
## Purpose

The supported query parameter types :
```ballerina
type QueryParamType boolean|int|float|decimal|string|map<json>|()|QueryParamType[];
```

> Fixes [` Ballerina does not support object type query parameters #1670 `](https://github.com/ballerina-platform/ballerina-standard-library/issues/1670)

## Example
```ballerina
listener http:Listener QueryBindingEP = new(queryParamBindingTest);
http:Client queryBindingClient = check new("http://localhost:" + queryParamBindingTest.toString());

service /queryparamservice on QueryBindingEP {

    resource function get jsonObject(map<json> obj) returns json {
        return obj;
    }

    resource function get jsonObjects(map<json>[] objs) returns json {
        return { objects : objs };
    }
}
```
Sample Tests : 
```ballerina
@test:Config {}
function testMapJsonQueryBinding() returns error?{
    map<json> jsonObj = { name : "test", value : 10 };
    // Object should be encoded appropriately
    string jsonEncoded = check url:encode(jsonObj.toJsonString(), "UTF-8");
    http:Response response = check queryBindingClient->get("/queryparamservice/jsonObjects?objs=" 
                                                                     + jsonEncoded);
    assertJsonPayloadtoJsonString(response.getJsonPayload(), jsonObj);
}

@test:Config {}
function testMapJsonArrayQueryBinding() returns error?{
    map<json> jsonObj1 = { name : "test1", value : 5 };
    map<json> jsonObj2 = { name : "test2", value : 10 };
    json expected = { objects : [ jsonObj1, jsonObj2 ] };
    // Object should be encoded appropriately
    string jsonEncoded1 = check url:encode(jsonObj1.toJsonString(), "UTF-8");
    string jsonEncoded2 = check url:encode(jsonObj2.toJsonString(), "UTF-8");
    http:Response response = check queryBindingClient->get("/queryparamservice/jsonObject?obj=" 
                                                                     + jsonEncoded1 + "," + jsonEncoded2);
    assertJsonPayloadtoJsonString(response.getJsonPayload(), expected);
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests