### PR TITLE
Add support to overwrite the scopes config by resource annotation

### DIFF
--- a/ballerina-tests/tests/auth_listener_declarative_design_test.bal
+++ b/ballerina-tests/tests/auth_listener_declarative_design_test.bal
@@ -453,6 +453,119 @@ function testServiceResourceAuthnFailure() {
     assertUnauthorized(sendNoTokenRequest("/ignoreOAuth2/jwtAuth"));
 }
 
+// Testing scopes configurations overwritten support.
+// JWT auth secured service - scopes overwritten at resource
+
+@http:ServiceConfig {
+    auth: [
+        {
+            jwtValidatorConfig: {
+                issuer: "wso2",
+                audience: "ballerina",
+                signatureConfig: {
+                    trustStoreConfig: {
+                        trustStore: {
+                            path: TRUSTSTORE_PATH,
+                            password: "ballerina"
+                        },
+                        certAlias: "ballerina"
+                    }
+                },
+                scopeKey: "scp"
+            },
+            scopes: ["read"]
+        }
+    ]
+}
+service /ignoreScopes on authListener {
+
+    @http:ResourceConfig {
+        auth: {
+            scopes: ["write", "update"]
+        }
+    }
+    resource function get jwtAuth() returns string {
+        return "Hello World!";
+    }
+}
+
+@test:Config {}
+function testScopesOverwrittenResourceAuthSuccess() {
+    assertSuccess(sendBearerTokenRequest("/ignoreScopes/jwtAuth", JWT1));
+    assertSuccess(sendBearerTokenRequest("/ignoreScopes/jwtAuth", JWT1_1));
+    assertSuccess(sendBearerTokenRequest("/ignoreScopes/jwtAuth", JWT1_2));
+    assertSuccess(sendJwtRequest("/ignoreScopes/jwtAuth"));
+}
+
+@test:Config {}
+function testScopesOverwrittenResourceAuthzFailure() {
+    assertForbidden(sendBearerTokenRequest("/ignoreScopes/jwtAuth", JWT2));
+    assertForbidden(sendBearerTokenRequest("/ignoreScopes/jwtAuth", JWT2_1));
+    assertForbidden(sendBearerTokenRequest("/ignoreScopes/jwtAuth", JWT2_2));
+}
+
+@test:Config {}
+function testScopesOverwrittenResourceAuthnFailure() {
+    assertUnauthorized(sendBearerTokenRequest("/ignoreScopes/jwtAuth", JWT3));
+    assertUnauthorized(sendNoTokenRequest("/ignoreScopes/jwtAuth"));
+}
+
+// Testing scopes configurations appending support.
+// JWT auth secured service - scopes appended at resource
+
+@http:ServiceConfig {
+    auth: [
+        {
+            jwtValidatorConfig: {
+                issuer: "wso2",
+                audience: "ballerina",
+                signatureConfig: {
+                    trustStoreConfig: {
+                        trustStore: {
+                            path: TRUSTSTORE_PATH,
+                            password: "ballerina"
+                        },
+                        certAlias: "ballerina"
+                    }
+                },
+                scopeKey: "scp"
+            }
+        }
+    ]
+}
+service /appendScopes on authListener {
+
+    @http:ResourceConfig {
+        auth: {
+            scopes: ["write", "update"]
+        }
+    }
+    resource function get jwtAuth() returns string {
+        return "Hello World!";
+    }
+}
+
+@test:Config {}
+function testScopesAppendingResourceAuthSuccess() {
+    assertSuccess(sendBearerTokenRequest("/appendScopes/jwtAuth", JWT1));
+    assertSuccess(sendBearerTokenRequest("/appendScopes/jwtAuth", JWT1_1));
+    assertSuccess(sendBearerTokenRequest("/appendScopes/jwtAuth", JWT1_2));
+    assertSuccess(sendJwtRequest("/appendScopes/jwtAuth"));
+}
+
+@test:Config {}
+function testScopesAppendingResourceAuthzFailure() {
+    assertForbidden(sendBearerTokenRequest("/appendScopes/jwtAuth", JWT2));
+    assertForbidden(sendBearerTokenRequest("/appendScopes/jwtAuth", JWT2_1));
+    assertForbidden(sendBearerTokenRequest("/appendScopes/jwtAuth", JWT2_2));
+}
+
+@test:Config {}
+function testScopesAppendingResourceAuthnFailure() {
+    assertUnauthorized(sendBearerTokenRequest("/appendScopes/jwtAuth", JWT3));
+    assertUnauthorized(sendNoTokenRequest("/appendScopes/jwtAuth"));
+}
+
 // Testing multiple auth configurations support.
 // OAuth2, Basic auth & JWT auth secured service - Unsecured resource
 

--- a/ballerina/auth_types.bal
+++ b/ballerina/auth_types.bal
@@ -135,6 +135,13 @@ public type OAuth2IntrospectionConfigWithScopes record {|
    string|string[] scopes?;
 |};
 
+# Represents the annotation used for authorization.
+#
+# + scopes - Scopes allowed for authorization
+public type Scopes record {|
+    string|string[] scopes;
+|};
+
 # Defines the authentication configurations for the HTTP listener.
 public type ListenerAuthConfig FileUserStoreConfigWithScopes|
                                LdapUserStoreConfigWithScopes|

--- a/ballerina/http_annotation.bal
+++ b/ballerina/http_annotation.bal
@@ -20,7 +20,7 @@
 # + compression - The status of compression
 # + chunking - Configures the chunking behaviour for the service
 # + cors - The cross origin resource sharing configurations for the service
-# + auth - Listener authenticaton configurations
+# + auth - Service auth configurations
 # + mediaTypeSubtypePrefix - Service specific media-type subtype prefix
 public type HttpServiceConfig record {|
     string host = "b7a.default";
@@ -57,13 +57,13 @@ public annotation HttpServiceConfig ServiceConfig on service;
 # + produces - The media types which are produced by resource
 # + cors - The cross origin resource sharing configurations for the resource. If not set, the resource will inherit the CORS behaviour of the enclosing service.
 # + transactionInfectable - Allow to participate in the distributed transactions if value is true
-# + auth - Listener authenticaton configurations
+# + auth - Resource auth configurations
 public type HttpResourceConfig record {|
     string[] consumes = [];
     string[] produces = [];
     CorsConfig cors = {};
     boolean transactionInfectable = true;
-    ListenerAuthConfig[] auth?;
+    ListenerAuthConfig[]|Scopes auth?;
 |};
 
 # The annotation which is used to configure an HTTP resource.

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Add support for Map Json as query parameter](https://github.com/ballerina-platform/ballerina-standard-library/issues/1670)
 - [Add OAuth2 JWT bearer grant type support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1788)
 - [Add authorization with JWTs with multiple scopes](https://github.com/ballerina-platform/ballerina-standard-library/issues/1801)
+- [Add support to overwrite the scopes config by resource annotation](https://github.com/ballerina-platform/ballerina-standard-library/issues/973)
 
 ## Fixed
 - [Fix incorrect behaviour of client with mtls](https://github.com/ballerina-platform/ballerina-standard-library/issues/1708)


### PR DESCRIPTION
## Purpose
This PR add support to overwrite the `auth.scopes` config of service annotation by resource annotation.

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/973

## Examples

1. `scopes` config defined at `http:ServiceConfig` annotation will be overwritten by the `scopes` config defined at `http:ResourceConfig`. That means, for the particular `bar` resource, the required scopes are "write" or "update".

    ```ballerina
    @http:ServiceConfig {
        auth: [
            {
                jwtValidatorConfig: {
                    issuer: "wso2",
                    audience: "ballerina",
                    signatureConfig: {
                        certFile: "./resources/public.crt"
                    },
                    scopeKey: "scp"
                },
                scopes: ["read"]
            }
        ]
    }
    service /foo on authListener {
    
        @http:ResourceConfig {
            auth: {
                scopes: ["write", "update"]
            }
        }
        resource function get bar() returns string {
            return "Hello World!";
        }
    }
    ```

2. `scopes` config not defined at `http:ServiceConfig` annotation. So, it will be appended by the `scopes` config defined at `http:ResourceConfig`. That means, for the particular `bar` resource, the required scopes are "write" or "update".

    ```ballerina
    @http:ServiceConfig {
        auth: [
            {
                jwtValidatorConfig: {
                    issuer: "wso2",
                    audience: "ballerina",
                    signatureConfig: {
                        certFile: "./resources/public.crt"
                    },
                    scopeKey: "scp"
                }
            }
        ]
    }
    service /foo on authListener {
      
        @http:ResourceConfig {
            auth: {
                scopes: ["write", "update"]
            }
        }
        resource function get bar() returns string {
            return "Hello World!";
        }
    }
    ```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests