### PR TITLE
Fix HTTP Client data-binding logic issue

### DIFF
--- a/ballerina-tests/tests/http_client_data_binding.bal
+++ b/ballerina-tests/tests/http_client_data_binding.bal
@@ -524,8 +524,7 @@ function testAllBindingErrorsWithNillableTypes() returns error? {
     if (response is http:Response) {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         assertHeaderValue(check response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
-        assertTextPayload(response.getTextPayload(), "invalid target type, expected: http:Response, string, xml, json, map<json>, " +
-        "byte[], record, record[] or a union of such a type with nil|Error occurred while retrieving the json payload from the response");
+        assertTextPayload(response.getTextPayload(), "Error occurred while retrieving the xml payload from the response|Error occurred while retrieving the json payload from the response");
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }

--- a/ballerina/http_client_endpoint.bal
+++ b/ballerina/http_client_endpoint.bal
@@ -658,20 +658,21 @@ isolated function performDataBinding(Response response, TargetType targetType) r
         return response.getTextPayload();
     } else if (targetType is typedesc<string?>) {
         string|ClientError payload = response.getTextPayload();
-        return payload is ClientError ? () : payload;
+        return payload is NoContentError ? () : payload;
     } else if (targetType is typedesc<xml>) {
         return response.getXmlPayload();
     } else if (targetType is typedesc<xml?>) {
         xml|ClientError payload = response.getXmlPayload();
-        return payload is ClientError ? () : payload;
+        return payload is NoContentError ? () : payload;
     } else if (targetType is typedesc<byte[]>) {
         return response.getBinaryPayload();
     } else if (targetType is typedesc<byte[]?>) {
         byte[]|ClientError payload = response.getBinaryPayload();
         if payload is byte[] {
             return payload.length() == 0 ? () : payload;
+        } else {
+            return payload is NoContentError ? () : payload;
         }
-        return;
     } else if (targetType is typedesc<record {| anydata...; |}>) {
         json payload = check response.getJsonPayload();
         var result = payload.cloneWithType(targetType);
@@ -680,9 +681,10 @@ isolated function performDataBinding(Response response, TargetType targetType) r
         json|ClientError payload = response.getJsonPayload();
         if payload is json {
             var result = payload.cloneWithType(targetType);
-            return result is error ? () : result;
+            return result is error ? createPayloadBindingError(result) : result;
+        } else {
+            return payload is NoContentError ? () : payload;
         }
-        return;
     } else if (targetType is typedesc<record {| anydata...; |}[]>) {
         json payload = check response.getJsonPayload();
         var result = payload.cloneWithType(targetType);
@@ -691,9 +693,10 @@ isolated function performDataBinding(Response response, TargetType targetType) r
         json|ClientError payload = response.getJsonPayload();
         if payload is json {
             var result = payload.cloneWithType(targetType);
-            return result is error ? () : result;
+            return result is error ? createPayloadBindingError(result) : result;
+        } else {
+            return payload is NoContentError? (): payload;
         }
-        return;
     } else if (targetType is typedesc<map<json>>) {
         json payload = check response.getJsonPayload();
         return <map<json>> payload;

--- a/ballerina/http_client_endpoint.bal
+++ b/ballerina/http_client_endpoint.bal
@@ -670,9 +670,8 @@ isolated function performDataBinding(Response response, TargetType targetType) r
         byte[]|ClientError payload = response.getBinaryPayload();
         if payload is byte[] {
             return payload.length() == 0 ? () : payload;
-        } else {
-            return payload is NoContentError ? () : payload;
         }
+        return payload;
     } else if (targetType is typedesc<record {| anydata...; |}>) {
         json payload = check response.getJsonPayload();
         var result = payload.cloneWithType(targetType);

--- a/ballerina/http_client_endpoint.bal
+++ b/ballerina/http_client_endpoint.bal
@@ -695,7 +695,7 @@ isolated function performDataBinding(Response response, TargetType targetType) r
             var result = payload.cloneWithType(targetType);
             return result is error ? createPayloadBindingError(result) : result;
         } else {
-            return payload is NoContentError? (): payload;
+            return payload is NoContentError ? () : payload;
         }
     } else if (targetType is typedesc<map<json>>) {
         json payload = check response.getJsonPayload();


### PR DESCRIPTION
## Purpose
> $subject

Following are the expected outcome for the HTTP client data-binding.

### 1. `application/json` data with `json` ###
#### Scenario 1 (Valid)
Received response:
```
HTTP/1.1 200 OK
Date: Sun, 05 Aug 2007 19:16:44 GMT
content-type: application/json
content-length: 29

{ "name": "john", "age": 10 }
```

Data binding:
```ballerina
json person = check client->get("/");  // output: { "name": "john", "age": 10 }
```
#### Scenario 2 (Valid)
Received response:
```
HTTP/1.1 200 OK
Date: Sun, 05 Aug 2007 19:16:44 GMT
content-type: application/json
content-length: 4

null
```
Data binding:
```ballerina
json person = check client->get("/");  // output: ()
```

### 2. `application/json` data with a record type ###
#### Scenario 1 (Valid)
Received response:
```
HTTP/1.1 200 OK
Date: Sun, 05 Aug 2007 19:16:44 GMT
content-type: application/json
content-length: 29

{ "name": "john", "age": 10 }
```

Data binding:
```ballerina
type Person record {|
    string name;
    int age;
|};

Person person = check client->get("/");  // output: { "name": "john", "age": 10 }
```
#### Scenario 2 (Invalid)
Received response:
```
HTTP/1.1 200 OK
Date: Sun, 05 Aug 2007 19:16:44 GMT
content-type: application/json
content-length: 4

null
```

Data binding:
```ballerina
Person person = check client->get("/"); // output: data-binding error
```
### 3. `application/json` data with nillable record type ###
#### Scenario 1 (Valid)
Received response:
```
HTTP/1.1 200 OK
Date: Sun, 05 Aug 2007 19:16:44 GMT
content-type: application/json
content-length: 29

{ "name": "john", "age": 10 }
```

Data binding:
```ballerina
Person? person = check client->get("/"); // output: { "name": "john", "age": 10 }
```
#### Scenario 2 (Valid)
Received response:
```
HTTP/1.1 200 OK
Date: Sun, 05 Aug 2007 19:16:44 GMT
content-type: application/json
content-length: 4

null
```

Data binding:
```ballerina
Person? person = check client->get("/"); // output: ()
```
### 4. `text/plain` data with `string` ###
#### Scenario 1 (Valid)
Received response:
```
HTTP/1.1 200 OK
Date: Sun, 05 Aug 2007 19:16:44 GMT
content-type: text/plain
content-length: 13

Hello, World!
```

Data binding:
```ballerina
string message = check client->get("/"); // output: Hello, World!
```
#### Scenario 2 (Invalid)
Received response:
```
HTTP/1.1 200 OK
Date: Sun, 05 Aug 2007 19:16:44 GMT
content-type: text/plain
content-length: 0
```

Data binding:
```ballerina
string message = check client->get("/"); // output: data-binding error
```
### 5. `text/plain` data with `string?` ###
#### Scenario 1 (Valid)
Received response:
```
HTTP/1.1 200 OK
Date: Sun, 05 Aug 2007 19:16:44 GMT
content-type: text/plain
content-length: 13

Hello, World!
```

Data binding:
```ballerina
string? message = check client->get("/"); // output: Hello, World!
```
#### Scenario 2 (Valid)
Received response:
```
HTTP/1.1 200 OK
Date: Sun, 05 Aug 2007 19:16:44 GMT
content-type: application/json
content-length: 0
```

Data binding:
```ballerina
string? person = check client->get("/"); // output: ()
```
### 6. Invalid data binding ###
#### Scenario 1 (Invalid)
Received response:
```
HTTP/1.1 200 OK
Date: Sun, 05 Aug 2007 19:16:44 GMT
content-type: application/json
content-length: 29

{ "name": "john", "age": 10 }
```

Data binding:
```ballerina
xml person = check client->get("/");  // output: data-binding error
```

Fixes [#1840](https://github.com/ballerina-platform/ballerina-standard-library/issues/1840)

## Checklist
- [X] Linked to an issue
- [ ] Updated the changelog
- [X] Added tests