### PR TITLE
Fix SSL test failure due to remote address being null

### DIFF
--- a/ballerina-tests/tests/http2_mutual_ssl_test.bal
+++ b/ballerina-tests/tests/http2_mutual_ssl_test.bal
@@ -175,7 +175,7 @@ public function testHttp2MutualSsl4() returns error? {
     // Without keys - negative test
     http:Client httpClient = check new("https://localhost:9204", http2MutualSslClientConf4);
     http:Response|error resp = httpClient->get("/http2Service/");
-    string expectedErrMsg = "SSL connection failed:javax.net.ssl.SSLHandshakeException: error:10000410:SSL routines:OPENSSL_internal:SSLV3_ALERT_HANDSHAKE_FAILURE null";
+    string expectedErrMsg = "SSL connection failed:javax.net.ssl.SSLHandshakeException: error:10000410:SSL routines:OPENSSL_internal:SSLV3_ALERT_HANDSHAKE_FAILURE localhost/127.0.0.1:9204";
     if (resp is error) {
         test:assertEquals(resp.message(), expectedErrMsg);
     } else {

--- a/ballerina-tests/tests/ssl_cipher_strength_test.bal
+++ b/ballerina-tests/tests/ssl_cipher_strength_test.bal
@@ -71,8 +71,7 @@ service /weakService on weakCipher {
     }
 }
 
-// Issue https://github.com/ballerina-platform/ballerina-standard-library/issues/305
-@test:Config {enable:false}
+@test:Config {}
 public function testWithStrongClientWithWeakService() {
     http:Client clientEP = checkpanic new("https://localhost:9227", {
         secureSocket: {

--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Fix incorrect behaviour of client with mtls](https://github.com/ballerina-platform/ballerina-standard-library/issues/1708)
 - [Fix multiple clients created for same route not using respective config](https://github.com/ballerina-platform/ballerina-standard-library/issues/1727)
 - [Fix not applying of resource auth annotations for some resources](https://github.com/ballerina-platform/ballerina-standard-library/issues/1838)
+- [Fix SSL test failure due to remote address being null](https://github.com/ballerina-platform/ballerina-standard-library/issues/315)
 
 ## [1.1.0-beta.2] - 2021-07-07
 

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/ConnectionAvailabilityFuture.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/ConnectionAvailabilityFuture.java
@@ -52,9 +52,11 @@ public class ConnectionAvailabilityFuture {
     private boolean isFailure;
     private Throwable throwable;
     private boolean forceHttp2 = false;
+    private String remoteAddress;
 
-    public void setSocketAvailabilityFuture(ChannelFuture socketAvailabilityFuture) {
+    public void setSocketAvailabilityFuture(ChannelFuture socketAvailabilityFuture, String remoteAddress) {
         this.socketAvailabilityFuture = socketAvailabilityFuture;
+        this.remoteAddress = remoteAddress;
         socketAvailabilityFuture.addListener(new ChannelFutureListener() {
 
             @Override
@@ -126,12 +128,8 @@ public class ConnectionAvailabilityFuture {
     }
 
     private void notifyErrorState(ChannelFuture channelFuture, Throwable cause) {
-        String socketAddress = null;
-        if (channelFuture.channel().remoteAddress() != null) {
-            socketAddress = channelFuture.channel().remoteAddress().toString();
-        }
         ClientConnectorException connectorException =
-                createSpecificExceptionFromGeneric(channelFuture, cause, socketAddress);
+                createSpecificExceptionFromGeneric(channelFuture, cause, remoteAddress);
 
         listener.onFailure(connectorException);
     }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/https/ServerCloseConnectionDuringSslTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/https/ServerCloseConnectionDuringSslTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static io.ballerina.stdlib.http.transport.contract.Constants.HTTPS_SCHEME;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertNotNull;
 
@@ -88,10 +89,7 @@ public class ServerCloseConnectionDuringSslTest {
         assertTrue(response instanceof ClientConnectorException,
                 "Exception is not an instance of ClientConnectorException");
         String result = response.getMessage();
-        // TODO revert the assertion once the issue is fixed
-        // https://github.com/ballerina-platform/module-ballerina-http/issues/88
-        // assertEquals("Remote host: localhost/127.0.0.1:9000 closed the connection while SSL handshake", result);
-        assertTrue(result.contains("closed the connection while SSL handshake"));
+        assertEquals("Remote host: localhost/127.0.0.1:9000 closed the connection while SSL handshake", result);
     }
 
     private void whenANormalHttpsRequestSent() throws InterruptedException {


### PR DESCRIPTION
## Purpose

> Fixes [` SSL test failure after jdk 11 migration #315 `](https://github.com/ballerina-platform/ballerina-standard-library/issues/315)

## Examples
N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests