### PR TITLE
Rename Cache Config annotation

### DIFF
--- a/ballerina-tests/tests/http_cache_config_annotation_test.bal
+++ b/ballerina-tests/tests/http_cache_config_annotation_test.bal
@@ -86,7 +86,7 @@ service / on new http:Listener(cacheAnnotationTestPort1) {
 
 service / on new http:Listener(cacheAnnotationTestPort2) {
 
-    resource function default nocacheBE(http:Request req) returns @http:CacheConfig{noCache : true, maxAge : -1,
+    resource function default nocacheBE(http:Request req) returns @http:Cache{noCache : true, maxAge : -1,
     mustRevalidate : false} json {
         noCacheHitCountNew += 1;
         if noCacheHitCountNew == 1 {
@@ -96,7 +96,7 @@ service / on new http:Listener(cacheAnnotationTestPort2) {
         }
     }
 
-    resource function default maxAgeBE(http:Request req) returns @http:CacheConfig{maxAge : 5, mustRevalidate : false} xml {
+    resource function default maxAgeBE(http:Request req) returns @http:Cache{maxAge : 5, mustRevalidate : false} xml {
         maxAgeHitCountNew += 1;
         if maxAgeHitCountNew == 1 {
             return maxAgePayload1;
@@ -105,7 +105,7 @@ service / on new http:Listener(cacheAnnotationTestPort2) {
         }
     }
 
-    resource function get mustRevalidateBE(http:Request req) returns @http:CacheConfig{maxAge : 5} string|byte[] {
+    resource function get mustRevalidateBE(http:Request req) returns @http:Cache{maxAge : 5} string|byte[] {
         numberOfHitsNew += 1;
         if numberOfHitsNew < 2 {
             return mustRevalidatePayload1;
@@ -114,7 +114,7 @@ service / on new http:Listener(cacheAnnotationTestPort2) {
         }
     }
 
-    resource function get statusResponseBE(http:Request req) returns @http:CacheConfig{noCache : true, maxAge : -1,
+    resource function get statusResponseBE(http:Request req) returns @http:Cache{noCache : true, maxAge : -1,
     mustRevalidate : false} http:Ok|http:InternalServerError {
         statusHits += 1;
         if statusHits < 3 {

--- a/ballerina/http_annotation.bal
+++ b/ballerina/http_annotation.bal
@@ -134,4 +134,4 @@ public type HttpCacheConfig record {|
 # The annotation which is used to define the response cache configuration. This annotation only supports `anydata` and
 # Success(2XX) `StatusCodeResponses` return types. Default annotation adds `must-revalidate,public,max-age=3600` as
 # `cache-control` header in addition to `etag` and `last-modified` headers.
-public annotation HttpCacheConfig CacheConfig on return;
+public annotation HttpCacheConfig Cache on return;

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -149,7 +149,7 @@ public class HttpConstants {
     public static final String DIRTY_RESPONSE = "dirtyResponse";
     public static final BString ANN_FIELD_MEDIA_TYPE = StringUtils.fromString("mediaType");
     public static final BString ANN_FIELD_NAME = StringUtils.fromString("name");
-    public static final String ANN_NAME_CACHE_CONFIG = "CacheConfig";
+    public static final String ANN_NAME_CACHE = "Cache";
 
     public static final String VALUE_ATTRIBUTE = "value";
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpResource.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpResource.java
@@ -293,7 +293,7 @@ public class HttpResource {
                     }
                 }
             }
-            if (ParamHandler.CACHE_CONFIG_ANNOTATION.equals(key.getValue())) {
+            if (ParamHandler.CACHE_ANNOTATION.equals(key.getValue())) {
                 this.cacheConfig = annotations.getMapValue(key);
             }
         }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
@@ -42,7 +42,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static io.ballerina.stdlib.http.api.HttpConstants.ANN_NAME_CACHE_CONFIG;
+import static io.ballerina.stdlib.http.api.HttpConstants.ANN_NAME_CACHE;
 import static io.ballerina.stdlib.http.api.HttpConstants.ANN_NAME_CALLER_INFO;
 import static io.ballerina.stdlib.http.api.HttpConstants.ANN_NAME_HEADER;
 import static io.ballerina.stdlib.http.api.HttpConstants.ANN_NAME_PAYLOAD;
@@ -78,8 +78,8 @@ public class ParamHandler {
             ModuleUtils.getHttpPackageIdentifier() + COLON + ANN_NAME_CALLER_INFO;
     public static final String PAYLOAD_ANNOTATION = ModuleUtils.getHttpPackageIdentifier() + COLON + ANN_NAME_PAYLOAD;
     public static final String HEADER_ANNOTATION = ModuleUtils.getHttpPackageIdentifier() + COLON + ANN_NAME_HEADER;
-    public static final String CACHE_CONFIG_ANNOTATION = ModuleUtils.getHttpPackageIdentifier() + COLON
-            + ANN_NAME_CACHE_CONFIG;
+    public static final String CACHE_ANNOTATION = ModuleUtils.getHttpPackageIdentifier() + COLON
+            + ANN_NAME_CACHE;
 
     public ParamHandler(ResourceMethodType resource, int pathParamCount) {
         this.resource = resource;


### PR DESCRIPTION
## Purpose
`@http:CacheConfig` annotation is renamed as `@http:Cache`

```ballerina
@http:Cache {                 // Default Configuration
    mustRevalidate : true,    // Sets the must-revalidate directive
    noCache : false,          // Sets the no-cache directive
    noStore : false,          // Sets the no-store directive 
    noTransform : false,      // Sets the no-transform directive
    isPrivate : false,        // Sets the private and public directive
    proxyRevalidate : false,  // Sets the proxy-revalidate directive
    maxAge : 3600,            // Sets the max-age directive. Default value is 3600 seconds
    sMaxAge : -1,             // Sets the s-maxage directive
    noCacheFields : [],       // Optional fields for no-cache directive
    privateFields : [],       // Optional fields for private directive
    setETag : true,           // Sets the etag header
    setLastModified : true    // Sets the last-modified header
}
```

## Examples

```ballerina
// Sets the cache-control header as "public,must-revalidate,max-age=5". Also sets the etag header.
// last-modified header will not be set
resource function get cachingBackEnd(http:Request req) returns @http:Cache{maxAge : 5, setLastModified : false} 
            string {

    return "Hello, World!!"
}
```

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests