### PR TITLE
Fix incorrect compiler error positions for resource

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Fix not applying of resource auth annotations for some resources](https://github.com/ballerina-platform/ballerina-standard-library/issues/1838)
 - [Fix SSL test failure due to remote address being null](https://github.com/ballerina-platform/ballerina-standard-library/issues/315)
 - [Return error when trying to access the payload after responding](https://github.com/ballerina-platform/ballerina-standard-library/issues/514)
+- [Fix incorrect compiler error positions for resource](https://github.com/ballerina-platform/ballerina-standard-library/issues/523)
 
 ## [1.1.0-beta.2] - 2021-07-07
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -89,6 +89,11 @@ public class CompilerPluginTest {
         Assert.assertEquals(diagnostic.diagnosticInfo().code(), code);
     }
 
+    private void assertErrorPosition(DiagnosticResult diagnosticResult, int index, String lineRange) {
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.errors().toArray()[index];
+        Assert.assertEquals(diagnostic.location().lineRange().toString(), lineRange);
+    }
+
     @Test
     public void testInvalidMethodTypes() {
         Package currentPackage = loadPackage("sample_package_1");
@@ -176,7 +181,6 @@ public class CompilerPluginTest {
         Package currentPackage = loadPackage("sample_package_6");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
-        diagnosticResult.diagnostics().forEach(System.out::println);
         Assert.assertEquals(diagnosticResult.errorCount(), 5);
         String expectedMsg = "invalid resource method return type: can not use 'http:Caller' " +
                 "and return 'string' from a resource : expected 'error' or nil";
@@ -208,7 +212,6 @@ public class CompilerPluginTest {
         Package currentPackage = loadPackage("sample_package_8");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
-        diagnosticResult.diagnostics().forEach(System.out::println);
         Assert.assertEquals(diagnosticResult.errorCount(), 12);
         assertTrue(diagnosticResult, 0, "invalid resource parameter type: 'ballerina/mime", HTTP_106);
         assertError(diagnosticResult, 1, "invalid union type of query param 'a': 'string', 'int', " +
@@ -339,5 +342,30 @@ public class CompilerPluginTest {
                 "have suffix 'suffix1 + suffix2'", HTTP_119);
         assertError(diagnosticResult, 2, "invalid media-type subtype '+suffix'", HTTP_120);
         assertError(diagnosticResult, 3, "invalid media-type subtype 'vnd.prefix.subtype+'", HTTP_120);
+    }
+
+    @Test
+    public void testResourceErrorPositions() {
+        Package currentPackage = loadPackage("sample_package_15");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errorCount(), 16);
+        // only testing the error locations
+        assertErrorPosition(diagnosticResult, 0, "(64:51,64:57)");
+        assertErrorPosition(diagnosticResult, 1, "(30:44,30:60)");
+        assertErrorPosition(diagnosticResult, 2, "(35:5,35:16)");
+        assertErrorPosition(diagnosticResult, 3, "(40:85,40:86)");
+        assertErrorPosition(diagnosticResult, 4, "(44:57,44:60)");
+        assertErrorPosition(diagnosticResult, 5, "(48:55,48:58)");
+        assertErrorPosition(diagnosticResult, 6, "(52:65,52:68)");
+        assertErrorPosition(diagnosticResult, 7, "(56:77,56:80)");
+        assertErrorPosition(diagnosticResult, 8, "(60:76,60:79)");
+        assertErrorPosition(diagnosticResult, 9, "(64:58,64:61)");
+        assertErrorPosition(diagnosticResult, 10, "(68:47,68:48)");
+        assertErrorPosition(diagnosticResult, 11, "(71:45,71:46)");
+        assertErrorPosition(diagnosticResult, 12, "(79:43,79:46)");
+        assertErrorPosition(diagnosticResult, 13, "(79:61,79:64)");
+        assertErrorPosition(diagnosticResult, 14, "(79:79,79:82)");
+        assertErrorPosition(diagnosticResult, 15, "(83:77,83:93)");
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "http_test"
+name = "sample_15"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/service.bal
@@ -1,0 +1,95 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// DO NOT CHANGE THE EXISTING CODE SINCE IT WILL CAUSE TEST FAILURES
+// TESTS ARE SENSITIVE TO SINGLE LINE/CHARACTER CHANGES
+
+import ballerina/http;
+import ballerina/test;
+
+type Person record {|
+    int id;
+|};
+
+public annotation Person Pp on parameter;
+
+service / on new http:Listener(9999) {
+
+    resource function get test102() returns map<http:Client> {
+        http:Client httpClient = checkpanic new("path");
+        return {name:httpClient};
+    }
+
+    @test:Config {}
+    resource function get test103() returns int|error|string {
+        return error http:Error("hello") ;
+    }
+
+    resource function get test104(int num, @http:Payload json abc, @Pp {id:0} string a) returns string {
+        return "done";
+    }
+
+    resource function get test106(table<Person> key(id)  abc) returns string {
+        return "done";
+    }
+
+    resource function get test107(@http:Payload json[] abc) returns string {
+        return "done"; // error
+    }
+
+    resource function get test108(@http:Payload @http:Header xml abc) returns string {
+        return "done";
+    }
+
+    resource function get test109(@http:Header {name: "x-type"} http:Request abc) returns string {
+        return "done"; //error
+    }
+
+    resource function get test110(@http:Header {name: "x-type"} string|json abc) returns string {
+        return "done"; //error
+    }
+
+    resource function get test111(@http:CallerInfo Caller abc) returns string {
+        return "done"; //error
+    }
+
+    resource function get test112(map<string>? c, map<json> d) returns string {
+        return "done";
+    }
+    resource function get test113(int[]|json c) returns string {
+        return "done";
+    }
+
+    @http:ResourceConfig {
+        consumes: ["fwhbw"]
+    }
+    resource function get test115(@http:CallerInfo {respondType:string} http:Caller abc, http:Request req,
+            http:Headers head, http:Caller xyz, http:Headers noo, http:Request aaa) {
+        checkpanic xyz->respond("done");
+    }
+
+    resource function get test118(http:Caller caller, string action) returns http:BadRequest? {
+        if action == "complete" {
+            error? result = caller->respond("This is successful");
+        } else {
+            http:BadRequest result = {
+                body: "Provided `action` parameter is invalid"
+            };
+            return result;
+        }
+    }
+
+}


### PR DESCRIPTION
## Purpose

> Fixes [`Incorrect line numbers for resource signature errors`](https://github.com/ballerina-platform/ballerina-standard-library/issues/523)

## Example

Running the [`sample_package_15/service.bal`](https://github.com/ballerina-platform/module-ballerina-http/compare/master...TharmiganK:tharmi-new?expand=1#diff-6ae428377a7129c8aea2292d57d78dd243a223ad4d00cbc9791a32a3f5705057)

Compilation results **before the fix** :
```
ERROR [test12.bal:(65:52,65:58)] unknown type 'Caller'
ERROR [test12.bal:(30:4,33:5)] invalid resource method return type: expected anydata|http:Response|http:StatusCodeRecord|error, but found map<http:Client>
ERROR [test12.bal:(35:4,38:5)] invalid resource method annotation type: expected http:ResourceConfig, but found test:Config 
ERROR [test12.bal:(40:4,42:5)] invalid annotation type on param a: expected one of the following types: http:Payload, http:CallerInfo, http:Headers
ERROR [test12.bal:(44:4,46:5)] invalid resource parameter type: table<Person> key(id)
ERROR [test12.bal:(48:4,50:5)] invalid payload parameter type: json[]
ERROR [test12.bal:(52:4,54:5)] invalid multiple resource parameter annotations for abc: expected one of the following types: http:Payload, http:CallerInfo, http:Headers
ERROR [test12.bal:(56:4,58:5)] invalid type of header param abc: expected string or string[]
ERROR [test12.bal:(60:4,62:5)] invalid union type of header param abc: a string or an array of a string can only be union with (). Eg: string|() or string[]|()
ERROR [test12.bal:(64:4,66:5)] invalid type of caller param abc: expected http:Caller
ERROR [test12.bal:(68:4,70:5)] invalid type of query param c: expected one of the string, int, float, boolean, decimal, map<json> types or the array types of them
ERROR [test12.bal:(71:4,73:5)] invalid union type of query param c: string, int, float, boolean, decimal, map<json> type or the array types of them can only be union with (). Eg: string? or int[]?
ERROR [test12.bal:(75:4,81:5)] invalid multiple http:Caller parameter: xyz
ERROR [test12.bal:(75:4,81:5)] invalid multiple http:Headers parameter: noo
ERROR [test12.bal:(75:4,81:5)] invalid multiple http:Request parameter: aaa
ERROR [test12.bal:(83:4,92:5)] invalid resource method return type: can not use http:Caller and return http:BadRequest? from a resource : expected error or nil
```

Compilation results **after the fix** : 
```
ERROR [service.bal:(65:52,65:58)] unknown type 'Caller'
ERROR [service.bal:(30:44,30:60)] invalid resource method return type: expected anydata|http:Response|http:StatusCodeRecord|error, but found map<http:Client>
ERROR [service.bal:(35:5,35:16)] invalid resource method annotation type: expected http:ResourceConfig, but found test:Config 
ERROR [service.bal:(40:85,40:86)] invalid annotation type on param a: expected one of the following types: http:Payload, http:CallerInfo, http:Headers
ERROR [service.bal:(44:57,44:60)] invalid resource parameter type: table<http_test/sample_15:0.1.0:Person> key(id)
ERROR [service.bal:(48:55,48:58)] invalid payload parameter type: json[]
ERROR [service.bal:(52:65,52:68)] invalid multiple resource parameter annotations for abc: expected one of the following types: http:Payload, http:CallerInfo, http:Headers
ERROR [service.bal:(56:77,56:80)] invalid type of header param abc: expected string or string[]
ERROR [service.bal:(60:76,60:79)] invalid union type of header param abc: a string or an array of a string can only be union with (). Eg: string|() or string[]|()
ERROR [service.bal:(64:58,64:61)] invalid type of caller param abc: expected http:Caller
ERROR [service.bal:(68:47,68:48)] invalid type of query param c: expected one of the string, int, float, boolean, decimal, map<json> types or the array types of them
ERROR [service.bal:(71:45,71:46)] invalid union type of query param c: string, int, float, boolean, decimal, map<json> type or the array types of them can only be union with (). Eg: string? or int[]?
ERROR [service.bal:(79:43,79:46)] invalid multiple http:Caller parameter: xyz
ERROR [service.bal:(79:61,79:64)] invalid multiple http:Headers parameter: noo
ERROR [service.bal:(79:79,79:82)] invalid multiple http:Request parameter: aaa
ERROR [service.bal:(83:77,83:93)] invalid resource method return type: can not use http:Caller and return http:BadRequest? from a resource : expected error or nil
```
**Note the changes in line range**

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests