### PR TITLE
Fix Circuit Breaker forceClose function

### DIFF
--- a/ballerina-tests/tests/resiliency_http_circuit_breaker_test_3.bal
+++ b/ballerina-tests/tests/resiliency_http_circuit_breaker_test_3.bal
@@ -88,7 +88,6 @@ service /unhealthy on new http:Listener(8088) {
 http:Client testForceCloseClient = check new("http://localhost:9308");
 
 @test:Config{
-    enable:false,
     dataProvider:forceCloseResponseDataProvider
 }
 function testForceClose(DataFeed dataFeed) {

--- a/ballerina-tests/tests/resiliency_http_circuit_breaker_test_3.bal
+++ b/ballerina-tests/tests/resiliency_http_circuit_breaker_test_3.bal
@@ -46,7 +46,7 @@ service /cb on circuitBreakerEP02 {
         http:CircuitBreakerClient cbClient = <http:CircuitBreakerClient>unhealthyClientEP.httpClient;
         forceCloseStateCount += 1;
         runtime:sleep(1);
-        if (forceCloseStateCount == 3) {
+        if (forceCloseStateCount == 4) {
             runtime:sleep(5);
             cbClient.forceClose();
         }

--- a/ballerina/resiliency_http_circuit_breaker.bal
+++ b/ballerina/resiliency_http_circuit_breaker.bal
@@ -393,7 +393,11 @@ public client isolated class CircuitBreakerClient {
     # Force the circuit into a closed state in which it will allow requests regardless of the error percentage
     # until the failure threshold exceeds.
     public isolated function forceClose() {
+        log:printInfo("Circuit forcefully switched to CLOSE state.");
         self.setCurrentState(CB_CLOSED_STATE);
+        lock {
+            self.reInitializeBuckets(self.circuitHealth);
+        }
     }
 
     # Force the circuit into a open state in which it will suspend all requests
@@ -635,7 +639,7 @@ public client isolated class CircuitBreakerClient {
                     index -= 1;
                 }
                 int lastIndex = (circuitHealth.totalBuckets.length()) - 1;
-                while (lastIndex > currentBucketId) {
+                while (lastIndex > lastUsedBucketId) {
                     self.resetBucketStats(circuitHealth, lastIndex);
                     lastIndex -= 1;
                 }


### PR DESCRIPTION
## Purpose
Clear and reinitialise buckets in the rolling window when `forceClose()` is called

> Related to [`Intermittent HTTP test failure #305`](https://github.com/ballerina-platform/ballerina-standard-library/issues/305)

## Examples
N/A

## Checklist
- [x] Linked to an issue
- [ ] <s>Updated the changelog</s>
- [x] Added tests