### PR TITLE
Fix support for parameter token with escape characters

### DIFF
--- a/ballerina-tests/tests/service_dispatching_header_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_header_param_binding_test.bal
@@ -67,6 +67,10 @@ service /headerparamservice on HeaderBindingEP {
         json responseJson = { val1: header1, val2: header2, val3: headerBool, val4: header3, val5: headerNames};
         return responseJson;
     }
+
+    resource function get q5(@http:Header string x\-Type) returns string {
+        return x\-Type;
+    }
 }
 
 @test:Config {}
@@ -197,6 +201,16 @@ function testHeaderObjectBinding() {
         json expected = { val1: "foo header not found", val2: "Http header does not exist", val3: false, 
                                 val4: ["Http header does not exist"],  val5: ["bar", "connection", "host", "X-Type"]};
         assertJsonPayloadtoJsonString(response.getJsonPayload(), expected);
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}
+
+@test:Config {}
+function testHeaderParamTokenWithEscapeChar() {
+    http:Response|error response = headerBindingClient->get("/headerparamservice/q5", {"x-Type" : "test"});
+    if response is http:Response {
+        assertTextPayload(response.getTextPayload(), "test");
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }

--- a/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
@@ -74,6 +74,18 @@ service /queryparamservice on QueryBindingEP {
         json responseJson = { objects : objs };
         return responseJson;
     }
+
+    resource function get q9(string x\-Type) returns string {
+        return x\-Type;
+    }
+
+    resource function get q10(string? x\-Type) returns string {
+        if x\-Type is () {
+            return "empty";
+        } else {
+            return x\-Type;
+        }
+    }
 }
 
 @test:Config {}
@@ -239,4 +251,28 @@ function testNillableMapJsonArrayQueryBinding() returns error? {
 
     response = check queryBindingClient->get("/queryparamservice/q8");
     assertJsonPayloadtoJsonString(response.getJsonPayload(), emptyObj);
+}
+
+@test:Config {}
+function testQueryParamTokenWithEscapeChar() {
+    http:Response|error response = queryBindingClient->get("/queryparamservice/q9?x-Type=test");
+    if response is http:Response {
+        assertTextPayload(response.getTextPayload(), "test");
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+
+    response = queryBindingClient->get("/queryparamservice/q10");
+    if response is http:Response {
+        assertTextPayload(response.getTextPayload(), "empty");
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+
+    response = queryBindingClient->get("/queryparamservice/q10?x-Type=test");
+    if response is http:Response {
+        assertTextPayload(response.getTextPayload(), "test");
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Return error when trying to access the payload after responding](https://github.com/ballerina-platform/ballerina-standard-library/issues/514)
 - [Fix incorrect compiler error positions for resource](https://github.com/ballerina-platform/ballerina-standard-library/issues/523)
 - [Fix performance issue with observability metrics for unique URLs](https://github.com/ballerina-platform/ballerina-standard-library/issues/1630)
+- [Fix support for parameter token with escape characters](https://github.com/ballerina-platform/ballerina-standard-library/issues/1925)
 
 ## [1.1.0-beta.2] - 2021-07-07
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
@@ -216,7 +216,7 @@ public class ParamHandler {
             headerParam.setHeaderName(value);
         } else {
             // if the name field is not stated, use the param token as header key
-            headerParam.setHeaderName(paramName);
+            headerParam.setHeaderName(HttpUtil.unescapeAndEncodeValue(paramName));
         }
         this.headerParams.add(headerParam);
     }
@@ -234,12 +234,14 @@ public class ParamHandler {
                 if (type.getTag() == TypeTags.NULL_TAG) {
                     continue;
                 }
-                QueryParam queryParam = new QueryParam(type, balResource.getParamNames()[index], index, true);
+                QueryParam queryParam = new QueryParam(type, HttpUtil.unescapeAndEncodeValue(
+                        balResource.getParamNames()[index]), index, true);
                 this.queryParams.add(queryParam);
                 break;
             }
         } else {
-            QueryParam queryParam = new QueryParam(parameterType, balResource.getParamNames()[index], index, false);
+            QueryParam queryParam = new QueryParam(parameterType, HttpUtil.unescapeAndEncodeValue(
+                    balResource.getParamNames()[index]), index, false);
             this.queryParams.add(queryParam);
         }
     }


### PR DESCRIPTION
## Purpose

This fixes support for parameter token name to have escape characters

> Fixes [`Header key-values are not correctly mapped #1925`](https://github.com/ballerina-platform/ballerina-standard-library/issues/1925)

## Examples

**1. Query Parameter :**

```ballerina
import ballerina/http;

http:Client clientEP = check new("http://localhost:8050");

service / on new http:Listener(8050) {

    resource function get test1(string x\-Type) returns string {
        return x\-Type;
    }

    resource function get test2(string? x\-Type) returns string {
        if x\-Type is () {
            return "empty";
        } else {
            return x\-Type;
        }
    }
}
```

`curl -X GET "http://localhost:8050/test1?x-Type=test1"`
`curl -X GET "http://localhost:8050/test2`
`curl -X GET "http://localhost:8050/test2?x-Type=test2"`

**2. Header Parameter :**

```ballerina
import ballerina/http;

http:Client clientEP = check new("http://localhost:8051");

service / on new http:Listener(8051) {

    resource function get test(@http:Header string x\-Type) returns string {
        return x\-Type;
    }
}
```

`curl -X GET "http://localhost:8051/test" -H "x-Type: test"`

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests