### PR TITLE
Fix invalid usage of forward() in cache validation

### DIFF
--- a/ballerina/caching_cached_response_validation.bal
+++ b/ballerina/caching_cached_response_validation.bal
@@ -89,7 +89,7 @@ isolated function sendValidationRequest(HttpClient httpClient, string path, Requ
 
     // TODO: handle cases where neither of the above 2 headers are present
 
-    var resp = httpClient->forward(path, originalRequest);
+    var resp = httpClient->execute(originalRequest.method, path, originalRequest);
 
     // Have to remove the precondition headers from the request if they weren't user provided.
     if (!userProvidedINMHeader) {


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1917 
> Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1898

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests