### PR TITLE
Fix possible intermittent test failure

### DIFF
--- a/ballerina-tests/tests/http_dirty_response_test.bal
+++ b/ballerina-tests/tests/http_dirty_response_test.bal
@@ -17,6 +17,7 @@
 import ballerina/io;
 import ballerina/test;
 import ballerina/http;
+import ballerina/lang.runtime;
 
 listener http:Listener dirtyResponseListener = new(dirtyResponseTestPort);
 http:Client dirtyResponseTestClient = check new("http://localhost:" + dirtyResponseTestPort.toString());
@@ -40,8 +41,7 @@ function getSingletonResponse() returns http:Response {
     return res;
 }
 
-// Disabled due to https://github.com/ballerina-platform/ballerina-standard-library/issues/305#issuecomment-824047016
-@test:Config {enable:false}
+@test:Config {}
 function testDirtyResponse() {
     http:Response|error response = dirtyResponseTestClient->get("/hello");
     if (response is http:Response) {
@@ -56,6 +56,7 @@ function testDirtyResponse() {
         assertHeaderValue(checkpanic response.getHeader(CONTENT_TYPE), TEXT_PLAIN);
         assertTextPayload(response.getTextPayload(), "Couldn't complete the respond operation as the response has" +
                         " been already used.");
+        runtime:sleep(5);
         test:assertEquals(dirtyErrorLog, "Couldn't complete the respond operation as the response has" +
                         " been already used.");
     } else {


### PR DESCRIPTION
Test intermittently fails since the test is executed before the dirtyErrorLog get the value. Add a time delay before asserting log value.

## Purpose

> Related to [`Intermittent HTTP test failure #305`](https://github.com/ballerina-platform/ballerina-standard-library/issues/305)

## Examples

N/A

## Checklist
- [x] Linked to an issue
- [ ] <s>Updated the changelog</s>
- [ ] <s>Added tests</s>