### PR TITLE
Change the Listener.getConfig() API to return InferredListenerConfiguration

### DIFF
--- a/ballerina/http_service_endpoint.bal
+++ b/ballerina/http_service_endpoint.bal
@@ -22,7 +22,7 @@ import ballerina/jballerina.java;
 public isolated class Listener {
 
     private int port;
-    private ListenerConfiguration config;
+    private InferredListenerConfiguration inferredConfig;
 
     # Gets invoked during module initialization to initialize the listener.
     #
@@ -30,9 +30,18 @@ public isolated class Listener {
     # + config - Configurations for the HTTP service listener
     # + return - A `ListenerError` if an error occurred during the listener initialization
     public isolated function init(int port, *ListenerConfiguration config) returns ListenerError? {
-        self.config = config.cloneReadOnly();
+        InferredListenerConfiguration inferredListenerConfig = {
+            host: config.host,
+            http1Settings: config.http1Settings,
+            secureSocket: config.secureSocket,
+            httpVersion: config.httpVersion,
+            timeout: config.timeout,
+            server: config.server,
+            requestLimits: config.requestLimits
+        };
+        self.inferredConfig = inferredListenerConfig.cloneReadOnly();
         self.port = port;
-        return externInitEndpoint(self);
+        return externInitEndpoint(self, config);
     }
 
     # Starts the registered service programmatically.
@@ -83,17 +92,18 @@ public isolated class Listener {
         }
     }
 
-    # Retrieves the `ListenerConfiguration` of the HTTP listener.
+    # Retrieves the `InferredListenerConfiguration` of the HTTP listener.
     #
-    # + return - The readonly HTTP listener configuration
-    public isolated function getConfig() returns readonly & ListenerConfiguration {
+    # + return - The readonly HTTP listener inferred configuration
+    public isolated function getConfig() returns readonly & InferredListenerConfiguration {
         lock {
-            return <readonly & ListenerConfiguration> self.config.cloneReadOnly();
+            return <readonly & InferredListenerConfiguration> self.inferredConfig.cloneReadOnly();
         }
     }
 }
 
-isolated function externInitEndpoint(Listener listenerObj) returns ListenerError? = @java:Method {
+isolated function externInitEndpoint(Listener listenerObj, ListenerConfiguration config) returns ListenerError? =
+@java:Method {
     'class: "io.ballerina.stdlib.http.api.service.endpoint.InitEndpoint",
     name: "initEndpoint"
 } external;
@@ -156,6 +166,27 @@ public type ListenerConfiguration record {|
     decimal timeout = DEFAULT_LISTENER_TIMEOUT;
     string? server = ();
     RequestLimitConfigs requestLimits = {};
+|};
+
+# Provides a set of cloneable configurations for HTTP listener.
+#
+# + host - The host name/IP of the endpoint
+# + http1Settings - Configurations related to HTTP/1.x protocol
+# + secureSocket - The SSL configurations for the service endpoint. This needs to be configured in order to
+#                  communicate through HTTPS.
+# + httpVersion - Highest HTTP version supported by the endpoint
+# + timeout - Period of time in seconds that a connection waits for a read/write operation. Use value 0 to
+#                   disable timeout
+# + server - The server name which should appear as a response header
+# + requestLimits - Configurations associated with inbound request size limits
+public type InferredListenerConfiguration record {|
+    string host;
+    ListenerHttp1Settings http1Settings;
+    ListenerSecureSocket? secureSocket;
+    string httpVersion;
+    decimal timeout;
+    string? server;
+    RequestLimitConfigs requestLimits;
 |};
 
 # Provides settings related to HTTP/1.x protocol.

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -351,7 +351,7 @@ public class HttpConstants {
 
     //Service Endpoint
     public static final int SERVICE_ENDPOINT_NAME_INDEX = 0;
-    public static final BString SERVICE_ENDPOINT_CONFIG = StringUtils.fromString("config");
+    public static final String SERVICE_ENDPOINT_CONFIG = "config";
     public static final BString SERVER_NAME = StringUtils.fromString("server");
     public static final String LISTENER_CONFIGURATION = "ListenerConfiguration";
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/endpoint/InitEndpoint.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/endpoint/InitEndpoint.java
@@ -37,10 +37,10 @@ import static io.ballerina.stdlib.http.api.HttpUtil.getListenerConfig;
  * @since 0.966
  */
 public class InitEndpoint extends AbstractHttpNativeFunction {
-    public static Object initEndpoint(BObject serviceEndpoint) {
+    public static Object initEndpoint(BObject serviceEndpoint, BMap serviceEndpointConfig) {
         try {
             // Creating server connector
-            BMap serviceEndpointConfig = serviceEndpoint.getMapValue(HttpConstants.SERVICE_ENDPOINT_CONFIG);
+            serviceEndpoint.addNativeData(HttpConstants.SERVICE_ENDPOINT_CONFIG, serviceEndpointConfig);
             long port = serviceEndpoint.getIntValue(ENDPOINT_CONFIG_PORT);
             ListenerConfiguration listenerConfiguration = getListenerConfig(port, serviceEndpointConfig);
             ServerConnector httpServerConnector =

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/endpoint/Start.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/endpoint/Start.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.stdlib.http.api.service.endpoint;
 
+import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.stdlib.http.api.BallerinaHTTPConnectorListener;
 import io.ballerina.stdlib.http.api.HttpConnectorPortBindingListener;
@@ -48,7 +49,7 @@ public class Start extends AbstractHttpNativeFunction {
         ServerConnectorFuture serverConnectorFuture = serverConnector.start();
         BallerinaHTTPConnectorListener httpListener =
                 new BallerinaHTTPConnectorListener(getHttpServicesRegistry(serviceEndpoint),
-                                                   serviceEndpoint.getMapValue(SERVICE_ENDPOINT_CONFIG));
+                                                   (BMap) serviceEndpoint.getNativeData(SERVICE_ENDPOINT_CONFIG));
         serviceEndpoint.addNativeData(SERVER_CONNECTOR_FUTURE, serverConnectorFuture);
         HttpConnectorPortBindingListener portBindingListener = new HttpConnectorPortBindingListener();
         serverConnectorFuture.setHttpConnectorListener(httpListener);


### PR DESCRIPTION
## Purpose
> This change is required to make the Listener class isolated even after object type inclusion to the ListenerConfiguration.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests