### PR TITLE
Fix interceptor compiler plugin bug

### DIFF
--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -410,7 +410,7 @@ public class CompilerPluginTest {
         Package currentPackage = loadPackage("sample_package_19");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
-        Assert.assertEquals(diagnosticResult.errorCount(), 8);
+        Assert.assertEquals(diagnosticResult.errorCount(), 9);
         assertError(diagnosticResult, 0, "invalid multiple interceptor type reference: " +
                 "'http:RequestErrorInterceptor'", HTTP_123);
         assertError(diagnosticResult, 1, "invalid interceptor resource path: expected default resource" +
@@ -426,6 +426,8 @@ public class CompilerPluginTest {
         assertError(diagnosticResult, 6, "invalid multiple interceptor resource functions", HTTP_124);
         assertError(diagnosticResult, 7, "invalid annotation 'http:ResourceConfig': annotations" +
                 " are not supported for interceptor resource functions", HTTP_125);
+        assertError(diagnosticResult, 8, "invalid interceptor resource path: expected default resource" +
+                " path: '[string... path]', but found '[string path]'", HTTP_127);
     }
 
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_19/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_19/service.bal
@@ -156,3 +156,12 @@ service class InterceptorService13 {
         return ctx.next();
     }
 }
+
+service class InterceptorService14 {
+    *http:RequestErrorInterceptor;
+
+    resource function 'default [string path](http:RequestContext ctx, http:Request req, http:Caller caller) returns http:NextService|error? {
+        req.setTextPayload("interceptor");
+        return ctx.next();
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
@@ -52,7 +52,7 @@ public class Constants {
 
     public static final String COLON = ":";
     public static final String PLUS = "+";
-    public static final String DEFAULT_PATH_REGEX = "\\[\\s*(string)\\s*(...)\\s*\\w*\\s*\\]";
+    public static final String DEFAULT_PATH_REGEX = "\\[\\s*(string)\\s*(\\.{3})\\s*\\w+\\s*\\]";
     public static final String SUFFIX_SEPARATOR_REGEX = "\\+";
     public static final String MEDIA_TYPE_SUBTYPE_REGEX = "^(\\w)+(\\s*\\.\\s*(\\w)+)*(\\s*\\+\\s*(\\w)+)*";
     public static final String UNNECESSARY_CHARS_REGEX = "\"|\\n";


### PR DESCRIPTION
## Purpose
Give compiler error when `[string path]` is used as the resource path inside `RequestErrorInterceptor` service
> Related to : [`Add compiler validation for interceptors #732`](https://github.com/ballerina-platform/module-ballerina-http/pull/732)

## Examples
N/A

## Checklist
- [ ] <s>Linked to an issue</s>
- [ ] <s>Updated the changelog</s>
- [x] Added tests