### PR TITLE
Return error when there is no next service to be returned

### DIFF
--- a/ballerina-tests/tests/request_interceptors_negative_test.bal
+++ b/ballerina-tests/tests/request_interceptors_negative_test.bal
@@ -100,7 +100,7 @@ service / on requestInterceptorNegativeServerEP4 {
     }
 }
 
-@test:Config{enable : true}
+@test:Config{}
 function testRequestInterceptorNegative4() returns error? {
     http:Response res = check requestInterceptorNegativeClientEP4->get("/");
     test:assertEquals(res.statusCode, 500);

--- a/ballerina-tests/tests/request_interceptors_negative_test.bal
+++ b/ballerina-tests/tests/request_interceptors_negative_test.bal
@@ -84,5 +84,25 @@ service / on requestInterceptorNegativeServerEP3 {
 function testRequestInterceptorNegative3() returns error? {
     http:Response res = check requestInterceptorNegativeClientEP3->get("/");
     assertHeaderValue(check res.getHeader("last-interceptor"), "default-interceptor");
-    assertTextPayload(check res.getTextPayload(), "illegal function invocation : next()");
+    assertTextPayload(check res.getTextPayload(), "no next service to be returned");
+}
+
+final http:Client requestInterceptorNegativeClientEP4 = check new("http://localhost:" + requestInterceptorNegativeTestPort4.toString());
+
+listener http:Listener requestInterceptorNegativeServerEP4 = new(requestInterceptorNegativeTestPort4, config = {
+    interceptors : [new DefaultRequestInterceptor(), new RequestInterceptorSkip()]
+});
+
+service / on requestInterceptorNegativeServerEP4 {
+
+    resource function 'default .() returns string {
+        return "Response from resource - test";
+    }
+}
+
+@test:Config{enable : true}
+function testRequestInterceptorNegative4() returns error? {
+    http:Response res = check requestInterceptorNegativeClientEP4->get("/");
+    test:assertEquals(res.statusCode, 500);
+    assertTextPayload(check res.getTextPayload(), "no next service to be returned");
 }

--- a/ballerina-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/tests/test_service_ports.bal
@@ -145,12 +145,13 @@ const int requestInterceptorSkipTestPort = 9595;
 const int requestInterceptorNegativeTestPort1 = 9596;
 const int requestInterceptorNegativeTestPort2 = 9597;
 const int requestInterceptorNegativeTestPort3 = 9598;
-const int requestInterceptorCallerRespondContinueTestPort = 9599;
-const int requestInterceptorStringPayloadBindingTestPort = 9600;
-const int requestInterceptorRecordPayloadBindingTestPort = 9601;
-const int requestInterceptorRecordArrayPayloadBindingTestPort = 9602;
-const int requestInterceptorByteArrayPayloadBindingTestPort = 9603;
-const int requestInterceptorWithQueryParamTestPort = 9604;
+const int requestInterceptorNegativeTestPort4 = 9599;
+const int requestInterceptorCallerRespondContinueTestPort = 9600;
+const int requestInterceptorStringPayloadBindingTestPort = 9601;
+const int requestInterceptorRecordPayloadBindingTestPort = 9602;
+const int requestInterceptorRecordArrayPayloadBindingTestPort = 9603;
+const int requestInterceptorByteArrayPayloadBindingTestPort = 9604;
+const int requestInterceptorWithQueryParamTestPort = 9605;
 
 //HTTP2
 const int serverPushTestPort1 = 9701;

--- a/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternRequestContext.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternRequestContext.java
@@ -31,7 +31,9 @@ public class ExternRequestContext {
         BArray interceptors = getInterceptors(requestCtx);
         if (interceptors != null) {
             if (!isInterceptorService(requestCtx)) {
-                return HttpUtil.createHttpError("illegal function invocation : next()",
+                // TODO : After introducing response interceptors, calling ctx.next() should return "illegal function
+                //  invocation : next()" if there is a response interceptor service in the pipeline
+                return HttpUtil.createHttpError("no next service to be returned",
                         HttpErrorType.GENERIC_LISTENER_ERROR);
             }
             int interceptorId = (int) requestCtx.getNativeData(HttpConstants.INTERCEPTOR_SERVICE_INDEX) + 1;
@@ -46,6 +48,10 @@ public class ExternRequestContext {
                     break;
                 }
                 interceptorId += 1;
+            }
+            if (interceptorId > interceptors.size()) {
+                return HttpUtil.createHttpError("no next service to be returned",
+                        HttpErrorType.GENERIC_LISTENER_ERROR);
             }
             requestCtx.addNativeData(HttpConstants.INTERCEPTOR_SERVICE_INDEX, interceptorId);
             return interceptorToReturn;


### PR DESCRIPTION
## Purpose
`RequestContext.next()` will return a `GenericListenerError` when there is no service to be returned in the pipeline

> Fixes [`RequestContext.next() should give an error when there is no service to return #2415`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2415)

## Examples

```ballerina
import ballerina/http;
import ballerina/io;

service class Interceptor {
    *http:RequestInterceptor;

    resource function get greeting(http:RequestContext ctx) returns http:NextService|error? {
        io:println("Inside Interceptor");
        // This is the last request interceptor in the pipeline next call will return the main service. 
        // After this, next() call will end up in an error
        http:NextService|error? nextService = ctx.next();
        return ctx.next(); 
    }
}

listener http:Listener serverEP = new (9090, config = {interceptors : [new Interceptor()]});

service / on serverEP {
    resource function get greeting() returns string {
        return "Greeting from Main Service";
    }
}
```

## Checklist
- [x] Linked to an issue
- [ ] <s>Updated the changelog</s>
- [x] Added tests