### PR TITLE
Fix `parseHeader()` to support multiple header values

### DIFF
--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -19,9 +19,6 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"}
 ]
-modules = [
-	{org = "ballerina", packageName = "auth", moduleName = "auth"}
-]
 
 [[package]]
 org = "ballerina"
@@ -43,9 +40,6 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
 ]
-modules = [
-	{org = "ballerina", packageName = "crypto", moduleName = "crypto"}
-]
 
 [[package]]
 org = "ballerina"
@@ -58,9 +52,6 @@ dependencies = [
 	{org = "ballerina", name = "os"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
-]
-modules = [
-	{org = "ballerina", packageName = "file", moduleName = "file"}
 ]
 
 [[package]]
@@ -99,25 +90,10 @@ org = "ballerina"
 name = "http_tests"
 version = "2.0.1"
 dependencies = [
-	{org = "ballerina", name = "auth"},
-	{org = "ballerina", name = "crypto"},
-	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
-	{org = "ballerina", name = "io"},
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "jwt"},
-	{org = "ballerina", name = "lang.boolean"},
-	{org = "ballerina", name = "lang.float"},
-	{org = "ballerina", name = "lang.int"},
-	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "lang.string"},
-	{org = "ballerina", name = "lang.xml"},
-	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mime"},
-	{org = "ballerina", name = "oauth2"},
-	{org = "ballerina", name = "regex"},
-	{org = "ballerina", name = "test"},
-	{org = "ballerina", name = "url"}
+	{org = "ballerina", name = "test"}
 ]
 modules = [
 	{org = "ballerina", packageName = "http_tests", moduleName = "http_tests"}
@@ -132,18 +108,12 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
-modules = [
-	{org = "ballerina", packageName = "io", moduleName = "io"}
-]
 
 [[package]]
 org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
 scope = "testOnly"
-modules = [
-	{org = "ballerina", packageName = "jballerina.java", moduleName = "jballerina.java"}
-]
 
 [[package]]
 org = "ballerina"
@@ -159,9 +129,6 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
-]
-modules = [
-	{org = "ballerina", packageName = "jwt", moduleName = "jwt"}
 ]
 
 [[package]]
@@ -186,18 +153,6 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
-name = "lang.boolean"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.boolean", moduleName = "lang.boolean"}
-]
-
-[[package]]
-org = "ballerina"
 name = "lang.decimal"
 version = "0.0.0"
 scope = "testOnly"
@@ -207,26 +162,11 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
-name = "lang.float"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.float", moduleName = "lang.float"}
-]
-
-[[package]]
-org = "ballerina"
 name = "lang.int"
 version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.int", moduleName = "lang.int"}
 ]
 
 [[package]]
@@ -242,9 +182,6 @@ version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
 ]
 
 [[package]]
@@ -270,18 +207,6 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
-name = "lang.xml"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.xml", moduleName = "lang.xml"}
-]
-
-[[package]]
-org = "ballerina"
 name = "log"
 version = "2.0.1"
 scope = "testOnly"
@@ -290,9 +215,6 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"},
 	{org = "ballerina", name = "observe"}
-]
-modules = [
-	{org = "ballerina", packageName = "log", moduleName = "log"}
 ]
 
 [[package]]
@@ -321,9 +243,6 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "time"}
 ]
-modules = [
-	{org = "ballerina", packageName = "oauth2", moduleName = "oauth2"}
-]
 
 [[package]]
 org = "ballerina"
@@ -350,9 +269,6 @@ version = "1.0.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "regex", moduleName = "regex"}
 ]
 
 [[package]]
@@ -393,9 +309,6 @@ version = "2.0.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "url", moduleName = "url"}
 ]
 
 

--- a/ballerina-tests/tests/parse_header.bal
+++ b/ballerina-tests/tests/parse_header.bal
@@ -17,10 +17,6 @@
 import ballerina/test;
 import ballerina/http;
 
-function testParseHeader(string value) returns [string, map<any>]|error {
-    return  http:parseHeader(value);
-}
-
 //Test function with single header value
 @test:Config {}
 function testSingleHeaderValue() {
@@ -28,9 +24,8 @@ function testSingleHeaderValue() {
     if (result is error) {
         test:assertFail(msg = "Found unexpected output type: " + result.message());
     } else {
-        var [value, params] = result;
-        test:assertEquals(value, TEXT_PLAIN, msg = "Found unexpected output");
-        test:assertEquals(params.length(), 0, msg = "Found unexpected output");
+        test:assertEquals(result[0].value, TEXT_PLAIN, msg = "Found unexpected output");
+        test:assertEquals(result[0].params.length(), 0, msg = "Found unexpected output");
     }
 }
 
@@ -41,10 +36,9 @@ function testSingleHeaderValueWithParam() {
     if (result is error) {
         test:assertFail(msg = "Found unexpected output type: " + result.message());
     } else {
-        var [value, params] = result;
-        test:assertEquals(value, TEXT_PLAIN, msg = "Found unexpected output");
-        test:assertEquals(<string>params["a"], "2", msg = "Found unexpected output");
-        test:assertEquals(<string>params["b"], "0.9", msg = "Found unexpected output");
+        test:assertEquals(result[0].value, TEXT_PLAIN, msg = "Found unexpected output");
+        test:assertEquals(result[0].params["a"], "2", msg = "Found unexpected output");
+        test:assertEquals(result[0].params["b"], "0.9", msg = "Found unexpected output");
     }
 }
 
@@ -55,9 +49,10 @@ function testMultipleHeaderValue() {
     if (result is error) {
         test:assertFail(msg = "Found unexpected output type: " + result.message());
     } else {
-        var [value, params] = result;
-        test:assertEquals(value, TEXT_PLAIN, msg = "Found unexpected output");
-        test:assertEquals(params.length(), 0, msg = "Found unexpected output");
+        test:assertEquals(result[0].value, TEXT_PLAIN, msg = "Found unexpected output");
+        test:assertEquals(result[0].params.length(), 0, msg = "Found unexpected output");
+        test:assertEquals(result[1].value, APPLICATION_FORM, msg = "Found unexpected output");
+        test:assertEquals(result[1].params.length(), 0, msg = "Found unexpected output");
     }
 }
 
@@ -68,10 +63,9 @@ function testWithExtraSpaceInBetweenParams() {
     if (result is error) {
         test:assertFail(msg = "Found unexpected output type: " + result.message());
     } else {
-        var [value, params] = result;
-        test:assertEquals(value, APPLICATION_JSON, msg = "Found unexpected output");
-        test:assertEquals(<string>params["a"], "2", msg = "Found unexpected output");
-        test:assertEquals(<string>params["b"], "0.9", msg = "Found unexpected output");
+        test:assertEquals(result[0].value, APPLICATION_JSON, msg = "Found unexpected output");
+        test:assertEquals(result[0].params["a"], "2", msg = "Found unexpected output");
+        test:assertEquals(result[0].params["b"], "0.9", msg = "Found unexpected output");
     }
 }
 
@@ -82,9 +76,8 @@ function testHeaderValueEndingWithSemiColon() {
     if (result is error) {
         test:assertFail(msg = "Found unexpected output type: " + result.message());
     } else {
-        var [value, params] = result;
-        test:assertEquals(value, APPLICATION_XML, msg = "Found unexpected output");
-        test:assertEquals(params.length(), 0, msg = "Found unexpected output");
+        test:assertEquals(result[0].value, APPLICATION_XML, msg = "Found unexpected output");
+        test:assertEquals(result[0].params.length(), 0, msg = "Found unexpected output");
     }
 }
 
@@ -95,22 +88,77 @@ function testWithEmptyValue() {
     if (result is error) {
         test:assertFail(msg = "Found unexpected output type: " + result.message());
     } else {
-        var [value, params] = result;
-        test:assertEquals(value, "", msg = "Found unexpected output");
-        test:assertEquals(params.length(), 0, msg = "Found unexpected output");
+        test:assertEquals(result[0].value, "", msg = "Found unexpected output");
+        test:assertEquals(result[0].params.length(), 0, msg = "Found unexpected output");
     }
 }
 
-//Test function when param value is optional. i.e 'text/plain;a, application/xml' 
+//Test function when param value is optional. i.e 'text/plain;a, application/xml'
 @test:Config {}
 function testValueWithOptionalParam() {
     var result = http:parseHeader(TEXT_PLAIN + ";a, " + APPLICATION_XML);
     if (result is error) {
         test:assertFail(msg = "Found unexpected output type: " + result.message());
     } else {
-        var [value, params] = result;
-        test:assertEquals(value, TEXT_PLAIN, msg = "Found unexpected output");
-        test:assertEquals(<anydata>params["a"], (), msg = "Found unexpected output");
+        test:assertEquals(result[0].value, TEXT_PLAIN, msg = "Found unexpected output");
+        test:assertEquals(result[0].params["a"], (), msg = "Found unexpected output");
+        test:assertEquals(result[1].value, APPLICATION_XML, msg = "Found unexpected output");
+    }
+}
+
+@test:Config {}
+function testMultipleValuesWithMultipleParams() {
+    var result = http:parseHeader(TEXT_PLAIN + ";a=\"hello\", " + APPLICATION_XML + ";a=2;b=0.9");
+    if (result is error) {
+        test:assertFail(msg = "Found unexpected output type: " + result.message());
+    } else {
+        test:assertEquals(result[0].value, TEXT_PLAIN, msg = "Found unexpected output");
+        test:assertEquals(result[0].params["a"], "\"hello\"", msg = "Found unexpected output");
+        test:assertEquals(result[1].value, APPLICATION_XML, msg = "Found unexpected output");
+        test:assertEquals(result[1].params["a"], "2", msg = "Found unexpected output");
+        test:assertEquals(result[1].params["b"], "0.9", msg = "Found unexpected output");
+    }
+}
+
+@test:Config {}
+function testCacheControlHeader() {
+    var result = http:parseHeader(" must-revalidate,public,max-age=15");
+    if (result is error) {
+        test:assertFail(msg = "Found unexpected output type: " + result.message());
+    } else {
+        test:assertEquals(result[0].value, "must-revalidate", msg = "Found unexpected output");
+        test:assertEquals(result[0].params.length(), 0, msg = "Found unexpected output");
+        test:assertEquals(result[1].value, "public", msg = "Found unexpected output");
+        test:assertEquals(result[1].params.length(), 0, msg = "Found unexpected output");
+        test:assertEquals(result[2].value, "max-age=15", msg = "Found unexpected output");
+        test:assertEquals(result[2].params.length(), 0, msg = "Found unexpected output");
+    }
+}
+
+@test:Config {}
+function testLinkHeader() {
+    string linkHeader = "<https://api.github.com/repositories/73930305/stargazers?page=2>; rel=\"next\", "
+                        + "<https://api.github.com/repositories/73930305/stargazers?page=98>; rel=\"last\"";
+    var result = http:parseHeader(linkHeader);
+    if (result is error) {
+        test:assertFail(msg = "Found unexpected output type: " + result.message());
+    } else {
+        test:assertEquals(result[0].value, "<https://api.github.com/repositories/73930305/stargazers?page=2>", msg = "Found unexpected output");
+        test:assertEquals(result[0].params["rel"], "\"next\"", msg = "Found unexpected output");
+        test:assertEquals(result[1].value, "<https://api.github.com/repositories/73930305/stargazers?page=98>", msg = "Found unexpected output");
+        test:assertEquals(result[1].params["rel"], "\"last\"", msg = "Found unexpected output");
+    }
+}
+
+//Test function with empty value
+@test:Config {}
+function testEmptyValue() {
+    var result = http:parseHeader("");
+    if (result is error) {
+        test:assertFail(msg = "Found unexpected output type: " + result.message());
+    } else {
+        test:assertEquals(result[0].value, "", msg = "Found unexpected output");
+        test:assertEquals(result[0].params.length(), 0, msg = "Found unexpected output");
     }
 }
 

--- a/ballerina/http_commons.bal
+++ b/ballerina/http_commons.bal
@@ -26,7 +26,7 @@ final boolean observabilityEnabled = observe:isObservabilityEnabled();
 
 # Parses the header value which contains multiple values or parameters.
 # ```ballerina
-#  http:HeaderValue values = check http:parseHeader("text/plain;level=1;q=0.6, application/xml;level=2");
+#  http:HeaderValue[] values = check http:parseHeader("text/plain;level=1;q=0.6, application/xml;level=2");
 # ```
 #
 # + headerValue - The header value

--- a/ballerina/http_commons.bal
+++ b/ballerina/http_commons.bal
@@ -24,12 +24,15 @@ import ballerina/log;
 
 final boolean observabilityEnabled = observe:isObservabilityEnabled();
 
-# Parses the given header value to extract its value and parameter map.
+# Parses the header value which contains multiple values or parameters.
+# ```ballerina
+#  http:HeaderValue values = check http:parseHeader("text/plain;level=1;q=0.6, application/xml;level=2");
+# ```
 #
 # + headerValue - The header value
-# + return - A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails
-//TODO: Make the error nillable
-public isolated function parseHeader(string headerValue) returns [string, map<any>]|ClientError = @java:Method {
+# + return - An array of `http:HeaderValue` typed record containing the value and its parameter map
+#            or else an `http:ClientError` if the header parsing fails
+public isolated function parseHeader(string headerValue) returns HeaderValue[]|ClientError = @java:Method {
     'class: "io.ballerina.stdlib.http.api.nativeimpl.ParseHeader",
     name: "parseHeader"
 } external;

--- a/ballerina/http_types.bal
+++ b/ballerina/http_types.bal
@@ -119,3 +119,11 @@ public type Links record {|
     # Array of available links
     Link[] links;
 |};
+
+# Represents the parsed header value details
+public type HeaderValue record {|
+    # The header value
+    string value;
+    # Map of header parameters
+    map<string> params;
+|};

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- [Fix parseHeader() to support multiple header values](https://github.com/ballerina-platform/ballerina-standard-library/issues/2403)
+
+## [2.0.1] - 2021-11-20
+
 ### Added
 - [Introduce request and request error interceptors](https://github.com/ballerina-platform/ballerina-standard-library/issues/2062)
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -228,6 +228,9 @@ public class HttpConstants {
     public static final String HTTP_TRAILER_HEADERS = "http_trailer_headers";
     public static final String LEADING_HEADER = "leading";
     public static final BString HEADER_REQUEST_FIELD = StringUtils.fromString("request");
+    public static final String HEADER_VALUE_RECORD = "HeaderValue";
+    public static final BString HEADER_VALUE_FIELD = StringUtils.fromString("value");
+    public static final BString HEADER_VALUE_PARAM_FIELD = StringUtils.fromString("params");
 
     public static final String HTTP_TRANSPORT_CONF = "transports.netty.conf";
     public static final String CIPHERS = "ciphers";


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/2403

## Examples
```ballerina
# Represents the parsed header value details
public type HeaderValue record {|
    # The header value
    string value;
    # Map of header parameters
    map<string> params;
|};

http:HeaderValue[] values = check http:parseHeader("text/plain;level=1;q=0.6, application/xml;level=2");
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests