### PR TITLE
Fix interceptor service reference when there is an error 

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
@@ -284,6 +284,9 @@ public class HttpDispatcher {
                     } else {
                         requestCtx.addNativeData(HttpConstants.INTERCEPTOR_SERVICE, false);
                     }
+                    int interceptorId = httpCarbonMessage.getProperty(HttpConstants.INTERCEPTOR_SERVICE_INDEX) == null
+                            ? 0 : (int) httpCarbonMessage.getProperty(HttpConstants.INTERCEPTOR_SERVICE_INDEX) - 1;
+                    requestCtx.addNativeData(HttpConstants.INTERCEPTOR_SERVICE_INDEX, interceptorId);
                     index = ((NonRecurringParam) param).getIndex();
                     paramFeed[index++] = requestCtx;
                     paramFeed[index] = true;
@@ -490,9 +493,6 @@ public class HttpDispatcher {
             requestContext.addNativeData(HttpConstants.HTTP_INTERCEPTORS, interceptors);
         }
         requestContext.addNativeData(HttpConstants.REQUEST_CONTEXT_NEXT, false);
-        int interceptorId = httpCarbonMessage.getProperty(HttpConstants.INTERCEPTOR_SERVICE_INDEX) == null
-                ? 0 : (int) httpCarbonMessage.getProperty(HttpConstants.INTERCEPTOR_SERVICE_INDEX) - 1;
-        requestContext.addNativeData(HttpConstants.INTERCEPTOR_SERVICE_INDEX, interceptorId);
         httpCarbonMessage.setProperty(HttpConstants.REQUEST_CONTEXT, requestContext);
         return requestContext;
     }


### PR DESCRIPTION
## Purpose
When there is an error in the interceptor service without calling next(), the interceptor service reference id should be updated.

> Fixes [`Request Error Interceptor does not work as expected #2431`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2431)

## Examples
```ballerina
import ballerina/http;
import ballerina/io;

final string interceptor_check_header = "X-requestCheckHeader";
final string interceptor_check_header_value = "RequestErrorInterceptor";

service class RequestInterceptor1 {
    *http:RequestInterceptor;

    resource function 'default [string... path](http:RequestContext ctx, http:Request req) 
                   returns http:NextService|error? {
        io:println("Executing Request Interceptor 1");
        string checkHeader = check req.getHeader(interceptor_check_header);
        io:println("Check Header Value : " + checkHeader);
        return ctx.next();
    }
}

service class RequestInterceptor2 {
    *http:RequestInterceptor;

    resource function get greeting(http:RequestContext ctx) returns http:NextService|error? {
        io:println("Executing Request Interceptor 2");
        return ctx.next();
    }
}

service class RequestInterceptor3 {
    *http:RequestInterceptor;

    resource function get greeting(http:RequestContext ctx) returns http:NextService|error? {
        io:println("Executing Request Interceptor 3");
        return ctx.next();
    }
}

service class RequestErrorInterceptor {
    *http:RequestErrorInterceptor;

    resource function 'default [string... path](http:RequestContext ctx, http:Request req, error err) 
                   returns http:NextService|error? {
        io:println("Executing Request Error Interceptor");
        io:println("Error occurred : " + err.message());
        req.setHeader(interceptor_check_header, interceptor_check_header_value);
        return ctx.next();
    }
}

listener http:Listener interceptorListener = new http:Listener(9090, config = { 
    interceptors: [new RequestInterceptor1(), new RequestInterceptor2(), 
                   new RequestErrorInterceptor(), new RequestInterceptor3()] 
});

service / on interceptorListener {

    resource function get greeting(http:Request req, http:Caller caller) returns error? {
        http:Response res = new;
        res.setHeader(interceptor_check_header, check req.getHeader(interceptor_check_header));
        res.setTextPayload("Greetings!");
        check caller->respond(res);
    }
}

```

Invoke Service : 
`curl http://localhost:9090/greeting`

Output:
```
Executing Request Interceptor 1
error: Http header does not exist
        at ballerina.http.2:externRequestGetHeader(http_request.bal:733)
           ballerina.http.2.Request:getHeader(http_request.bal:147)
           RequestInterceptor1:$default$**(sample3.bal:13)
Executing Request Error Interceptor
Error occurred : Http header does not exist
Executing Request Interceptor 3
```

## Checklist
- [x] Linked to an issue
- [ ] <s>Updated the changelog</s>
- [x] Added tests