### PR TITLE
Introduce interceptors at service level

### DIFF
--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -19,6 +19,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"}
 ]
+modules = [
+	{org = "ballerina", packageName = "auth", moduleName = "auth"}
+]
 
 [[package]]
 org = "ballerina"
@@ -40,6 +43,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
 ]
+modules = [
+	{org = "ballerina", packageName = "crypto", moduleName = "crypto"}
+]
 
 [[package]]
 org = "ballerina"
@@ -52,6 +58,9 @@ dependencies = [
 	{org = "ballerina", name = "os"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
+]
+modules = [
+	{org = "ballerina", packageName = "file", moduleName = "file"}
 ]
 
 [[package]]
@@ -90,11 +99,25 @@ org = "ballerina"
 name = "http_tests"
 version = "2.0.2"
 dependencies = [
+	{org = "ballerina", name = "auth"},
+	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "jwt"},
+	{org = "ballerina", name = "lang.boolean"},
+	{org = "ballerina", name = "lang.float"},
+	{org = "ballerina", name = "lang.int"},
 	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "lang.string"},
+	{org = "ballerina", name = "lang.xml"},
+	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mime"},
-	{org = "ballerina", name = "test"}
+	{org = "ballerina", name = "oauth2"},
+	{org = "ballerina", name = "regex"},
+	{org = "ballerina", name = "test"},
+	{org = "ballerina", name = "url"}
 ]
 modules = [
 	{org = "ballerina", packageName = "http_tests", moduleName = "http_tests"}
@@ -109,12 +132,18 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
+modules = [
+	{org = "ballerina", packageName = "io", moduleName = "io"}
+]
 
 [[package]]
 org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
 scope = "testOnly"
+modules = [
+	{org = "ballerina", packageName = "jballerina.java", moduleName = "jballerina.java"}
+]
 
 [[package]]
 org = "ballerina"
@@ -130,6 +159,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
+]
+modules = [
+	{org = "ballerina", packageName = "jwt", moduleName = "jwt"}
 ]
 
 [[package]]
@@ -154,6 +186,18 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.boolean"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.boolean", moduleName = "lang.boolean"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.decimal"
 version = "0.0.0"
 scope = "testOnly"
@@ -163,11 +207,26 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.float"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.float", moduleName = "lang.float"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.int"
 version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.int", moduleName = "lang.int"}
 ]
 
 [[package]]
@@ -211,6 +270,18 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.xml"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.xml", moduleName = "lang.xml"}
+]
+
+[[package]]
+org = "ballerina"
 name = "log"
 version = "2.0.2"
 scope = "testOnly"
@@ -219,6 +290,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"},
 	{org = "ballerina", name = "observe"}
+]
+modules = [
+	{org = "ballerina", packageName = "log", moduleName = "log"}
 ]
 
 [[package]]
@@ -247,6 +321,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "time"}
 ]
+modules = [
+	{org = "ballerina", packageName = "oauth2", moduleName = "oauth2"}
+]
 
 [[package]]
 org = "ballerina"
@@ -273,6 +350,9 @@ version = "1.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "regex", moduleName = "regex"}
 ]
 
 [[package]]
@@ -313,6 +393,9 @@ version = "2.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "url", moduleName = "url"}
 ]
 
 

--- a/ballerina-tests/tests/interceptors_test_common.bal
+++ b/ballerina-tests/tests/interceptors_test_common.bal
@@ -215,6 +215,25 @@ service class RequestInterceptorWithQueryParam {
     }
 }
 
+service class RequestInterceptorWithVariable {
+    *http:RequestInterceptor;
+    string name;
+
+    function init(string name) {
+        self.name = name;
+    }
+
+    function getName() returns string {
+        return self.name;
+    }
+
+    resource function 'default [string... path](http:RequestContext ctx, http:Request req) returns http:NextService|error? {
+       req.setHeader("request-interceptor", "true");
+       ctx.set("last-interceptor", self.getName());
+       return ctx.next();
+    }
+}
+
 service class RequestInterceptorNegative1 {
     *http:RequestInterceptor;
 

--- a/ballerina-tests/tests/request_interceptor_service_config_test.bal
+++ b/ballerina-tests/tests/request_interceptor_service_config_test.bal
@@ -1,0 +1,152 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/test;
+
+final http:Client requestInterceptorServiceConfigClientEP1 = check new("http://localhost:" + requestInterceptorServiceConfigTestPort1.toString());
+
+listener http:Listener requestInterceptorServiceConfigServerEP1 = new(requestInterceptorServiceConfigTestPort1, config = {
+    interceptors : [new RequestInterceptorWithVariable("interceptor-listener"), new LastRequestInterceptor()]
+});
+
+@http:ServiceConfig {
+    interceptors : [new RequestInterceptorWithVariable("interceptor-service-foo"), new LastRequestInterceptor()]
+}
+service /foo on requestInterceptorServiceConfigServerEP1 {
+
+    resource function 'default .(http:Caller caller, http:Request req) returns error? {
+        http:Response res = new();
+        res.setHeader("request-interceptor", check req.getHeader("request-interceptor"));
+        res.setHeader("last-request-interceptor", check req.getHeader("last-request-interceptor"));
+        res.setHeader("last-interceptor", check req.getHeader("last-interceptor"));
+        check caller->respond(res);
+    }
+}
+
+@http:ServiceConfig {
+    interceptors : [new RequestInterceptorReturnsError(), new DefaultRequestErrorInterceptor(), new RequestInterceptorWithVariable("interceptor-service-bar"), new LastRequestInterceptor()]
+}
+service /bar on requestInterceptorServiceConfigServerEP1 {
+
+    resource function 'default .(http:Caller caller, http:Request req) returns error? {
+        http:Response res = new();
+        res.setHeader("request-interceptor", check req.getHeader("request-interceptor"));
+        res.setHeader("last-request-interceptor", check req.getHeader("last-request-interceptor"));
+        res.setHeader("last-interceptor", check req.getHeader("last-interceptor"));
+        res.setHeader("request-interceptor-error", check req.getHeader("request-interceptor-error"));
+        res.setHeader("default-error-interceptor", check req.getHeader("default-error-interceptor"));
+        check caller->respond(res);
+    }
+}
+
+service /hello on requestInterceptorServiceConfigServerEP1 {
+
+    resource function 'default .(http:Caller caller, http:Request req) returns error? {
+        http:Response res = new();
+        res.setHeader("request-interceptor", check req.getHeader("request-interceptor"));
+        res.setHeader("last-request-interceptor", check req.getHeader("last-request-interceptor"));
+        res.setHeader("last-interceptor", check req.getHeader("last-interceptor"));
+        check caller->respond(res);
+    }
+}
+
+@test:Config{}
+function testRequestInterceptorServiceConfig1() returns error? {
+    http:Response res = check requestInterceptorServiceConfigClientEP1->get("/hello");
+    assertHeaderValue(check res.getHeader("last-interceptor"), "interceptor-listener");
+    assertHeaderValue(check res.getHeader("request-interceptor"), "true");
+    assertHeaderValue(check res.getHeader("last-request-interceptor"), "true");
+
+    res = check requestInterceptorServiceConfigClientEP1->get("/foo");
+    assertHeaderValue(check res.getHeader("last-interceptor"), "interceptor-service-foo");
+    assertHeaderValue(check res.getHeader("request-interceptor"), "true");
+    assertHeaderValue(check res.getHeader("last-request-interceptor"), "true");
+
+    res = check requestInterceptorServiceConfigClientEP1->get("/bar");
+    assertHeaderValue(check res.getHeader("last-interceptor"), "interceptor-service-bar");
+    assertHeaderValue(check res.getHeader("request-interceptor"), "true");
+    assertHeaderValue(check res.getHeader("last-request-interceptor"), "true");
+    assertHeaderValue(check res.getHeader("request-interceptor-error"), "true");
+    assertHeaderValue(check res.getHeader("default-error-interceptor"), "true");
+}
+
+final http:Client requestInterceptorServiceConfigClientEP2 = check new("http://localhost:" + requestInterceptorServiceConfigTestPort2.toString());
+
+listener http:Listener requestInterceptorServiceConfigServerEP2 = new(requestInterceptorServiceConfigTestPort2);
+
+@http:ServiceConfig {
+    interceptors : [new DefaultRequestInterceptor(), new RequestInterceptorSetPayload(), new RequestInterceptorWithVariable("interceptor-service-foo"), new LastRequestInterceptor()]
+}
+service /foo on requestInterceptorServiceConfigServerEP2 {
+
+    resource function 'default .(http:Caller caller, http:Request req) returns error? {
+        http:Response res = new();
+        res.setTextPayload(check req.getTextPayload());
+        res.setHeader("request-interceptor", check req.getHeader("request-interceptor"));
+        res.setHeader("last-request-interceptor", check req.getHeader("last-request-interceptor"));
+        res.setHeader("last-interceptor", check req.getHeader("last-interceptor"));
+        res.setHeader("interceptor-setpayload", check req.getHeader("interceptor-setpayload"));
+        res.setHeader("default-interceptor", check req.getHeader("default-interceptor"));
+        check caller->respond(res);
+    }
+}
+
+@http:ServiceConfig {
+    interceptors : [new RequestInterceptorWithVariable("interceptor-service-bar"), new LastRequestInterceptor()]
+}
+service /bar on requestInterceptorServiceConfigServerEP2 {
+
+    resource function 'default .(http:Caller caller, http:Request req) returns error? {
+        http:Response res = new();
+        res.setHeader("request-interceptor", check req.getHeader("request-interceptor"));
+        res.setHeader("last-request-interceptor", check req.getHeader("last-request-interceptor"));
+        res.setHeader("last-interceptor", check req.getHeader("last-interceptor"));
+        check caller->respond(res);
+    }
+}
+
+service /hello on requestInterceptorServiceConfigServerEP2 {
+
+    resource function 'default .() returns string {
+        return "Response from resource - test";
+    }
+}
+
+@test:Config{}
+function testRequestInterceptorServiceConfig2() returns error? {
+    http:Response res = check requestInterceptorServiceConfigClientEP2->get("/hello");
+    test:assertFalse(res.hasHeader("last-interceptor"));
+    test:assertFalse(res.hasHeader("request-interceptor"));
+    test:assertFalse(res.hasHeader("last-request-interceptor"));
+    assertTextPayload(res.getTextPayload(), "Response from resource - test");
+
+    http:Request req = new();
+    req.setHeader("interceptor", "databinding-interceptor");
+    req.setTextPayload("Request from Client");
+    res = check requestInterceptorServiceConfigClientEP2->post("/foo", req);
+    assertTextPayload(check res.getTextPayload(), "Text payload from interceptor");
+    assertHeaderValue(check res.getHeader("last-interceptor"), "interceptor-service-foo");
+    assertHeaderValue(check res.getHeader("default-interceptor"), "true");
+    assertHeaderValue(check res.getHeader("last-request-interceptor"), "true");
+    assertHeaderValue(check res.getHeader("interceptor-setpayload"), "true");
+    assertHeaderValue(check res.getHeader("request-interceptor"), "true");
+
+    res = check requestInterceptorServiceConfigClientEP2->get("/bar");
+    assertHeaderValue(check res.getHeader("last-interceptor"), "interceptor-service-bar");
+    assertHeaderValue(check res.getHeader("request-interceptor"), "true");
+    assertHeaderValue(check res.getHeader("last-request-interceptor"), "true");
+}

--- a/ballerina-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/tests/test_service_ports.bal
@@ -152,6 +152,8 @@ const int requestInterceptorRecordPayloadBindingTestPort = 9602;
 const int requestInterceptorRecordArrayPayloadBindingTestPort = 9603;
 const int requestInterceptorByteArrayPayloadBindingTestPort = 9604;
 const int requestInterceptorWithQueryParamTestPort = 9605;
+const int requestInterceptorServiceConfigTestPort1 = 9606;
+const int requestInterceptorServiceConfigTestPort2 = 9607;
 
 //HTTP2
 const int serverPushTestPort1 = 9701;

--- a/ballerina/http_annotation.bal
+++ b/ballerina/http_annotation.bal
@@ -23,6 +23,7 @@
 # + auth - Service auth configurations
 # + mediaTypeSubtypePrefix - Service specific media-type subtype prefix
 # + treatNilableAsOptional - Treat Nilable parameters as optional
+# + interceptors - An array of interceptor services
 public type HttpServiceConfig record {|
     string host = "b7a.default";
     CompressionConfig compression = {};
@@ -31,6 +32,7 @@ public type HttpServiceConfig record {|
     ListenerAuthConfig[] auth?;
     string mediaTypeSubtypePrefix?;
     boolean treatNilableAsOptional = true;
+    (RequestInterceptor|RequestErrorInterceptor)[]? interceptors = ();
 |};
 
 # Configurations for CORS support.

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- [Introduce interceptors at service level](https://github.com/ballerina-platform/ballerina-standard-library/issues/2447)
+
 ### Fixed
 - [Fix parseHeader() to support multiple header values](https://github.com/ballerina-platform/ballerina-standard-library/issues/2403)
 - [Fix HTTP caching failure when using the last-modified header as the validator](https://github.com/ballerina-platform/ballerina-standard-library/issues/2402)

--- a/native/src/main/java/io/ballerina/stdlib/http/api/BallerinaHTTPConnectorListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/BallerinaHTTPConnectorListener.java
@@ -35,12 +35,14 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static io.ballerina.runtime.observability.ObservabilityConstants.PROPERTY_TRACE_PROPERTIES;
 import static io.ballerina.runtime.observability.ObservabilityConstants.SERVER_CONNECTOR_HTTP;
 import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_HTTP_METHOD;
 import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_HTTP_URL;
 import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_PROTOCOL;
+import static io.ballerina.stdlib.http.api.HttpConstants.INTERCEPTOR_SERVICES_REGISTRIES;
 
 /**
  * HTTP connector listener for Ballerina.
@@ -65,12 +67,19 @@ public class BallerinaHTTPConnectorListener implements HttpConnectorListener {
     @Override
     public void onMessage(HttpCarbonMessage inboundMessage) {
         try {
+            if (Objects.isNull(inboundMessage.getProperty(INTERCEPTOR_SERVICES_REGISTRIES))) {
+                setTargetServiceToCarbonMsg(inboundMessage);
+            }
+
+            List<HTTPInterceptorServicesRegistry> interceptorServicesRegistries =
+                    (List<HTTPInterceptorServicesRegistry>) inboundMessage.getProperty(INTERCEPTOR_SERVICES_REGISTRIES);
+
             // Executing interceptor services
             InterceptorResource interceptorResource;
             int interceptorServiceIndex = inboundMessage.getProperty(HttpConstants.INTERCEPTOR_SERVICE_INDEX)
                     == null ? 0 : (int)  inboundMessage.getProperty(HttpConstants.INTERCEPTOR_SERVICE_INDEX);
-            while (interceptorServiceIndex < httpInterceptorServicesRegistries.size()) {
-                HTTPInterceptorServicesRegistry interceptorServicesRegistry = httpInterceptorServicesRegistries.
+            while (interceptorServiceIndex < interceptorServicesRegistries.size()) {
+                HTTPInterceptorServicesRegistry interceptorServicesRegistry = interceptorServicesRegistries.
                         get(interceptorServiceIndex);
 
                 // Checking whether the interceptor service state matches the interceptor service registry
@@ -262,6 +271,22 @@ public class BallerinaHTTPConnectorListener implements HttpConnectorListener {
             } else {
                 throw e;
             }
+        }
+    }
+
+    private void setTargetServiceToCarbonMsg(HttpCarbonMessage inboundMessage) {
+        inboundMessage.setProperty(INTERCEPTOR_SERVICES_REGISTRIES, httpInterceptorServicesRegistries);
+        try {
+            HttpService targetService = HttpDispatcher.findService(httpServicesRegistry, inboundMessage, true);
+            inboundMessage.setProperty(HttpConstants.TARGET_SERVICE, targetService.getBalService());
+            if (targetService.hasInterceptors()) {
+            inboundMessage.setProperty(HttpConstants.INTERCEPTORS, targetService.getBalInterceptorServicesArray());
+                inboundMessage.setProperty(INTERCEPTOR_SERVICES_REGISTRIES,
+                                           targetService.getInterceptorServicesRegistries());
+            }
+        } catch (Exception e) {
+            inboundMessage.setProperty(HttpConstants.TARGET_SERVICE, HttpUtil.createHttpError(e.getMessage(),
+                    HttpErrorType.GENERIC_LISTENER_ERROR));
         }
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HTTPServicesRegistry.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HTTPServicesRegistry.java
@@ -153,6 +153,10 @@ public class HTTPServicesRegistry {
         this.runtime = runtime;
     }
 
+    public Map<String, ServicesMapHolder> getServicesMapByHost() {
+        return this.servicesMapByHost;
+    }
+
     /**
      * Holds both serviceByBasePath map and sorted Service basePath list.
      */
@@ -163,6 +167,10 @@ public class HTTPServicesRegistry {
         public ServicesMapHolder(Map<String, HttpService> servicesByBasePath, List<String> sortedServiceURIs) {
             this.servicesByBasePath = servicesByBasePath;
             this.sortedServiceURIs = sortedServiceURIs;
+        }
+
+        public Map<String, HttpService> getServicesByBasePath() {
+            return this.servicesByBasePath;
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -353,8 +353,9 @@ public class HttpConstants {
     public static final String ABSOLUTE_RESOURCE_PATH = "ABSOLUTE_RESOURCE_PATH";
 
     //HTTP Interceptor
-    public static final String HTTP_INTERCEPTORS = "HTTP_INTERCEPTORS";
-    public static final String HTTP_INTERCEPTOR_SERVICE_REGISTRIES = "HTTP_INTERCEPTOR_SERVICE_REGISTRIES";
+    public static final BString ANN_INTERCEPTORS = StringUtils.fromString("interceptors");
+    public static final String INTERCEPTORS = "INTERCEPTORS";
+    public static final String INTERCEPTOR_SERVICES_REGISTRIES = "INTERCEPTOR_SERVICES_REGISTRIES";
     public static final String REQUEST_CONTEXT_NEXT = "REQUEST_CONTEXT_NEXT";
     public static final String REQUEST_CONTEXT = "RequestContext";
     public static final String ENTITY_OBJ = "EntityObj";
@@ -365,6 +366,7 @@ public class HttpConstants {
     public static final String HTTP_NORMAL = "Normal";
     public static final String HTTP_REQUEST_INTERCEPTOR = "RequestInterceptor";
     public static final String HTTP_REQUEST_ERROR_INTERCEPTOR = "RequestErrorInterceptor";
+    public static final String TARGET_SERVICE = "TARGET_SERVICE";
 
     //Service Endpoint
     public static final int SERVICE_ENDPOINT_NAME_INDEX = 0;
@@ -380,7 +382,6 @@ public class HttpConstants {
     public static final String ENDPOINT_CONFIG_CHUNKING = "chunking";
     public static final BString ENDPOINT_CONFIG_VERSION = StringUtils.fromString("httpVersion");
     public static final String ENDPOINT_REQUEST_LIMITS = "requestLimits";
-    public static final BString ENDPOINT_CONFIG_INTERCEPTORS = StringUtils.fromString("interceptors");
 
     public static final BString MAX_URI_LENGTH = StringUtils.fromString("maxUriLength");
     public static final BString MAX_STATUS_LINE_LENGTH = StringUtils.fromString("maxStatusLineLength");

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
@@ -84,7 +84,8 @@ public class HttpDispatcher {
     private static final ArrayType MAP_ARR = TypeCreator.createArrayType(TypeCreator.createMapType(
             PredefinedTypes.TYPE_JSON));
 
-    public static HttpService findService(HTTPServicesRegistry servicesRegistry, HttpCarbonMessage inboundReqMsg) {
+    public static HttpService findService(HTTPServicesRegistry servicesRegistry, HttpCarbonMessage inboundReqMsg,
+                                          boolean forInterceptors) {
         try {
             Map<String, HttpService> servicesOnInterface;
             List<String> sortedServiceURIs;
@@ -103,12 +104,8 @@ public class HttpDispatcher {
             }
 
             String rawUri = (String) inboundReqMsg.getProperty(HttpConstants.TO);
-            inboundReqMsg.setProperty(HttpConstants.RAW_URI, rawUri);
             Map<String, Map<String, String>> matrixParams = new HashMap<>();
             String uriWithoutMatrixParams = URIUtil.extractMatrixParams(rawUri, matrixParams);
-
-            inboundReqMsg.setProperty(HttpConstants.TO, uriWithoutMatrixParams);
-            inboundReqMsg.setProperty(HttpConstants.MATRIX_PARAMS, matrixParams);
 
             URI validatedUri = getValidatedURI(uriWithoutMatrixParams);
 
@@ -122,7 +119,12 @@ public class HttpDispatcher {
             }
 
             HttpService service = servicesOnInterface.get(basePath);
-            setInboundReqProperties(inboundReqMsg, validatedUri, basePath);
+            if (!forInterceptors) {
+                setInboundReqProperties(inboundReqMsg, validatedUri, basePath);
+                inboundReqMsg.setProperty(HttpConstants.RAW_URI, rawUri);
+                inboundReqMsg.setProperty(HttpConstants.TO, uriWithoutMatrixParams);
+                inboundReqMsg.setProperty(HttpConstants.MATRIX_PARAMS, matrixParams);
+            }
             return service;
         } catch (Exception e) {
             throw new BallerinaConnectorException(e.getMessage());
@@ -209,7 +211,7 @@ public class HttpDispatcher {
 
         try {
             // Find the Service TODO can be improved
-            HttpService service = HttpDispatcher.findService(servicesRegistry, inboundMessage);
+            HttpService service = HttpDispatcher.findService(servicesRegistry, inboundMessage, false);
             if (service == null) {
                 throw new BallerinaConnectorException("no Service found to handle the service request");
                 // Finer details of the errors are thrown from the dispatcher itself, Ideally we shouldn't get here.
@@ -488,10 +490,10 @@ public class HttpDispatcher {
 
     static BObject createRequestContext(HttpCarbonMessage httpCarbonMessage, BMap<BString, Object> endpointConfig) {
         BObject requestContext = ValueCreatorUtils.createRequestContextObject();
-        BArray interceptors = endpointConfig.getArrayValue(HttpConstants.ENDPOINT_CONFIG_INTERCEPTORS);
-        if (interceptors != null) {
-            requestContext.addNativeData(HttpConstants.HTTP_INTERCEPTORS, interceptors);
-        }
+        BArray interceptors = httpCarbonMessage.getProperty(HttpConstants.INTERCEPTORS) instanceof BArray ?
+                              (BArray) httpCarbonMessage.getProperty(HttpConstants.INTERCEPTORS) :
+                              endpointConfig.getArrayValue(HttpConstants.ANN_INTERCEPTORS);
+        requestContext.addNativeData(HttpConstants.INTERCEPTORS, interceptors);
         requestContext.addNativeData(HttpConstants.REQUEST_CONTEXT_NEXT, false);
         httpCarbonMessage.setProperty(HttpConstants.REQUEST_CONTEXT, requestContext);
         return requestContext;

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpInterceptorUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpInterceptorUnitCallback.java
@@ -26,8 +26,6 @@ import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.stdlib.http.api.nativeimpl.ModuleUtils;
 import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
 
-import static java.lang.System.err;
-
 /**
  * {@code HttpInterceptorUnitCallback} is the responsible for acting on notifications received from Ballerina side when
  * an interceptor service is invoked.
@@ -107,7 +105,7 @@ public class HttpInterceptorUnitCallback implements Callback {
     private void validateResponseAndProceed(Object result) {
         int interceptorId = (int) requestCtx.getNativeData(HttpConstants.INTERCEPTOR_SERVICE_INDEX);
         requestMessage.setProperty(HttpConstants.INTERCEPTOR_SERVICE_INDEX, interceptorId);
-        BArray interceptors = (BArray) requestCtx.getNativeData(HttpConstants.HTTP_INTERCEPTORS);
+        BArray interceptors = (BArray) requestCtx.getNativeData(HttpConstants.INTERCEPTORS);
         boolean nextCalled = (boolean) requestCtx.getNativeData(HttpConstants.REQUEST_CONTEXT_NEXT);
 
         if (alreadyResponded(result)) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpService.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpService.java
@@ -267,7 +267,7 @@ public class HttpService implements Service {
 
     private static BMap getHttpServiceConfigAnnotation(BObject service) {
         return getServiceConfigAnnotation(service, ModuleUtils.getHttpPackageIdentifier(),
-                HttpConstants.ANN_NAME_HTTP_SERVICE_CONFIG);
+                                          HttpConstants.ANN_NAME_HTTP_SERVICE_CONFIG);
     }
 
     protected static BMap getServiceConfigAnnotation(BObject service, String packagePath,

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -1134,7 +1134,7 @@ public class HttpUtil {
         String boundaryString;
         String boundaryValue = HeaderUtil.extractBoundaryParameter(contentType);
         boundaryString = boundaryValue != null ? boundaryValue : HttpUtil.addBoundaryParameter(transportMessage,
-                contentType);
+                                                                                               contentType);
         return boundaryString;
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -1134,7 +1134,7 @@ public class HttpUtil {
         String boundaryString;
         String boundaryValue = HeaderUtil.extractBoundaryParameter(contentType);
         boundaryString = boundaryValue != null ? boundaryValue : HttpUtil.addBoundaryParameter(transportMessage,
-                                                                                               contentType);
+                contentType);
         return boundaryString;
     }
 
@@ -1500,11 +1500,24 @@ public class HttpUtil {
         return listenerConfiguration;
     }
 
-    public static void getAndPopulateInterceptorsServices(BObject serviceEndpoint, Runtime runtime) {
+    // TODO : Move this to `register` after this issue is fixed
+    //  https://github.com/ballerina-platform/ballerina-lang/issues/33594
+    public static void populateInterceptorServicesFromService(HTTPServicesRegistry servicesRegistry) {
+        Runtime runtime = servicesRegistry.getRuntime();
+        Map<String, HTTPServicesRegistry.ServicesMapHolder> servicesMapByHost = servicesRegistry.getServicesMapByHost();
+        for (HTTPServicesRegistry.ServicesMapHolder servicesMapHolder : servicesMapByHost.values()) {
+            Map<String, HttpService> servicesByBasePath = servicesMapHolder.getServicesByBasePath();
+            for (HttpService service : servicesByBasePath.values()) {
+                HttpService.populateInterceptorServicesRegistries(service, runtime);
+            }
+        }
+    }
+
+    public static void populateInterceptorServicesFromListener(BObject serviceEndpoint, Runtime runtime) {
         BMap endpointConfig = (BMap) serviceEndpoint.getNativeData(SERVICE_ENDPOINT_CONFIG);
         Object[] interceptors = {};
         List<BObject> interceptorServices = new ArrayList<>();
-        BArray interceptorsArray = endpointConfig.getArrayValue(HttpConstants.ENDPOINT_CONFIG_INTERCEPTORS);
+        BArray interceptorsArray = endpointConfig.getArrayValue(HttpConstants.ANN_INTERCEPTORS);
 
         if (interceptorsArray != null) {
             interceptors = interceptorsArray.getValues();

--- a/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternRequestContext.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternRequestContext.java
@@ -67,7 +67,7 @@ public class ExternRequestContext {
     }
 
     private static BArray getInterceptors(BObject requestCtx) {
-        return requestCtx.getNativeData(HttpConstants.HTTP_INTERCEPTORS) == null ? null :
-                (BArray) requestCtx.getNativeData(HttpConstants.HTTP_INTERCEPTORS);
+        return requestCtx.getNativeData(HttpConstants.INTERCEPTORS) == null ? null :
+                (BArray) requestCtx.getNativeData(HttpConstants.INTERCEPTORS);
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/endpoint/AbstractHttpNativeFunction.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/endpoint/AbstractHttpNativeFunction.java
@@ -22,7 +22,7 @@ public abstract class AbstractHttpNativeFunction {
 
     public static List<HTTPInterceptorServicesRegistry> getHttpInterceptorServicesRegistries(BObject serviceEndpoint) {
         return (List<HTTPInterceptorServicesRegistry>) serviceEndpoint.getNativeData(HttpConstants.
-                HTTP_INTERCEPTOR_SERVICE_REGISTRIES);
+                INTERCEPTOR_SERVICES_REGISTRIES);
     }
 
     protected static ServerConnector getServerConnector(BObject serviceEndpoint) {
@@ -44,7 +44,7 @@ public abstract class AbstractHttpNativeFunction {
         for (int i = 0; i < interceptorsSize; i++) {
             httpInterceptorServicesRegistries.add(new HTTPInterceptorServicesRegistry());
         }
-        serviceEndpoint.addNativeData(HttpConstants.HTTP_INTERCEPTOR_SERVICE_REGISTRIES,
+        serviceEndpoint.addNativeData(HttpConstants.INTERCEPTOR_SERVICES_REGISTRIES,
                 httpInterceptorServicesRegistries);
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/endpoint/Start.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/endpoint/Start.java
@@ -52,7 +52,8 @@ public class Start extends AbstractHttpNativeFunction {
         // Get and populate interceptor services
         HTTPServicesRegistry httpServicesRegistry = getHttpServicesRegistry(serviceEndpoint);
         Runtime runtime = httpServicesRegistry.getRuntime();
-        HttpUtil.getAndPopulateInterceptorsServices(serviceEndpoint, runtime);
+        HttpUtil.populateInterceptorServicesFromListener(serviceEndpoint, runtime);
+        HttpUtil.populateInterceptorServicesFromService(httpServicesRegistry);
 
         ServerConnector serverConnector = getServerConnector(serviceEndpoint);
         ServerConnectorFuture serverConnectorFuture = serverConnector.start();


### PR DESCRIPTION
## Purpose
Interceptors are now supported in service level through `http:ServiceConfig`. 

```ballerina
@http:ServiceConfig {
      interceptors : [new RequestInterceptor1(), new RequestInterceptor2()]
}
```

> **Note :** When interceptors are attached to a service, they are registered in the service's base path.

> **Note :** When interceptors are specified at listener and service, the service level interceptors will overwrite the listener level pipeline.

> Fixes [`Introduce interceptors at service level #2447`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2447)

## Examples

```ballerina

import ballerina/http;
import ballerina/io;

// Request interceptor service class definition
service class RequestInterceptor {
      *http:RequestInterceptor;
      string name;

      function init(string name) {
            self.name = name;
      }

      function getName() returns string {
            return self.name;
      }

      resource function get [string... path](http:RequestContext ctx) returns http:NextService|error? {
            io:println("Executing Interceptor : " + self.getName());
            return ctx.next();
      }
}

// Attaching interceptors at Listener level
// The base path of the interceptor services is set as default(/)
listener http:Listener serverEP = new(9090, config = {
      interceptors : [new RequestInterceptor("listener1"), new RequestInterceptor("listener2")]
});

service /foo on serverEP {
      
      resource function get greeting(http:Caller caller) returns error? {
            check caller->respond("Greeting from path foo");
      }
}

// Attaching interceptors at Service level
// The base path of the interceptor services is same as the target service(/bar)
@http:ServiceConfig {
      interceptors : [new RequestInterceptor("service1"), new RequestInterceptor("service2")]
}
service /bar on serverEP {
      
      resource function get greeting(http:Caller caller) returns error? {
            check caller->respond("Greeting from path bar");
      }
}

```

`curl -X GET http://localhost:9090/foo/greeting`

```
Executing Interceptor : listener1
Executing Interceptor : listener2
```

`curl -X GET http://localhost:9090/bar/greeting`

```
Executing Interceptor : service1
Executing Interceptor : service2
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests