### PR TITLE
Avoid stopping observation context twice

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -12,7 +12,7 @@ distribution = "2201.0.0"
 path = "../native/build/libs/http-native-2.2.0-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/mime-native-2.2.0-20211220-124500-69f16e4.jar"
+path = "./lib/mime-native-2.2.0-20211220-222200-7bd9f71.jar"
 
 [[platform.java11.dependency]]
 path = "./lib/netty-common-4.1.71.Final.jar"

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
@@ -54,7 +54,7 @@ public class HttpCallableUnitCallback implements Callback {
 
     @Override
     public void notifySuccess(Object result) {
-        cleanupRequestAndContext();
+        cleanupRequestMessage();
         if (alreadyResponded(result)) {
             return;
         }
@@ -86,7 +86,7 @@ public class HttpCallableUnitCallback implements Callback {
 
     @Override
     public void notifyFailure(BError error) { // handles panic and check_panic
-        cleanupRequestAndContext();
+        cleanupRequestMessage();
         // This check is added to release the failure path since there is an authn/authz failure and responded
         // with 401/403 internally.
         if (error.getMessage().equals("Already responded by auth desugar.")) {
@@ -99,12 +99,12 @@ public class HttpCallableUnitCallback implements Callback {
     }
 
     private void sendFailureResponse(BError error) {
+        stopObservationWithContext();
         HttpUtil.handleFailure(requestMessage, error, true);
     }
 
-    private void cleanupRequestAndContext() {
+    private void cleanupRequestMessage() {
         requestMessage.waitAndReleaseAllEntities();
-        stopObservationWithContext();
     }
 
     private void stopObservationWithContext() {


### PR DESCRIPTION
## Purpose

> $Subject

> Fixes [`[HTTP] stop method for ObserverContext is called twice #2502`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2502)

## Examples

N/A

## Checklist
- [x] Linked to an issue
- [ ] <s>Updated the changelog</s>
- [ ] <s>Added tests</s>