### PR TITLE
Stop adding sourceHandler for async backend calls

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -13,7 +13,7 @@ distribution = "2201.0.0"
 path = "../native/build/libs/http-native-2.2.0-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/mime-native-2.2.0-20220110-185500-739a5a4.jar"
+path = "./lib/mime-native-2.2.0-20220111-111400-09ccefa.jar"
 
 [[platform.java11.dependency]]
 path = "./lib/netty-common-4.1.71.Final.jar"

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -176,6 +176,7 @@ public class HttpConstants {
     public static final String HTTP_CLIENT = "HttpClient";
     public static final String CLIENT_CONFIG_HASH_CODE = "ClientConfigHashCode";
 
+    public static final String MAIN_STRAND = "MAIN_STRAND";
     public static final String SRC_HANDLER = "SRC_HANDLER";
     public static final String REMOTE_ADDRESS = "REMOTE_ADDRESS";
     public static final String ORIGIN_HOST = "ORIGIN_HOST";

--- a/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/AbstractHTTPAction.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/AbstractHTTPAction.java
@@ -66,6 +66,7 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.BALLERINA_VERSION;
 import static io.ballerina.stdlib.http.api.HttpConstants.ANN_CONFIG_ATTR_COMPRESSION;
@@ -265,12 +266,15 @@ public abstract class AbstractHTTPAction {
         //Make the request associate with this response consumable again so that it can be reused.
         checkDirtiness(dataContext, outboundRequestMsg);
 
-        Object sourceHandler = outboundRequestMsg.getProperty(HttpConstants.SRC_HANDLER);
-        if (sourceHandler == null) {
+        if (Objects.nonNull(dataContext.getEnvironment().getStrandLocal(HttpConstants.MAIN_STRAND))) {
+            Object sourceHandler = outboundRequestMsg.getProperty(HttpConstants.SRC_HANDLER);
+            if (sourceHandler == null) {
 
-            outboundRequestMsg.setProperty(HttpConstants.SRC_HANDLER,
-                    dataContext.getEnvironment().getStrandLocal(HttpConstants.SRC_HANDLER));
+                outboundRequestMsg.setProperty(HttpConstants.SRC_HANDLER,
+                        dataContext.getEnvironment().getStrandLocal(HttpConstants.SRC_HANDLER));
+            }
         }
+
         Object poolableByteBufferFactory = outboundRequestMsg.getProperty(HttpConstants.POOLED_BYTE_BUFFER_FACTORY);
         if (poolableByteBufferFactory == null) {
             outboundRequestMsg.setProperty(HttpConstants.POOLED_BYTE_BUFFER_FACTORY,

--- a/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/HttpClientAction.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/HttpClientAction.java
@@ -37,11 +37,13 @@ import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static io.ballerina.runtime.observability.ObservabilityConstants.KEY_OBSERVER_CONTEXT;
 import static io.ballerina.stdlib.http.api.HttpConstants.CLIENT_ENDPOINT_CONFIG;
 import static io.ballerina.stdlib.http.api.HttpConstants.CLIENT_ENDPOINT_SERVICE_URI;
 import static io.ballerina.stdlib.http.api.HttpConstants.CURRENT_TRANSACTION_CONTEXT_PROPERTY;
+import static io.ballerina.stdlib.http.api.HttpConstants.MAIN_STRAND;
 import static io.ballerina.stdlib.http.api.HttpConstants.ORIGIN_HOST;
 import static io.ballerina.stdlib.http.api.HttpConstants.POOLED_BYTE_BUFFER_FACTORY;
 import static io.ballerina.stdlib.http.api.HttpConstants.REMOTE_ADDRESS;
@@ -183,7 +185,7 @@ public class HttpClientAction extends AbstractHTTPAction {
     }
 
     private static Map<String, Object> getPropertiesToPropagate(Environment env) {
-        String[] keys = {CURRENT_TRANSACTION_CONTEXT_PROPERTY, KEY_OBSERVER_CONTEXT, SRC_HANDLER,
+        String[] keys = {CURRENT_TRANSACTION_CONTEXT_PROPERTY, KEY_OBSERVER_CONTEXT, SRC_HANDLER, MAIN_STRAND,
                 POOLED_BYTE_BUFFER_FACTORY, REMOTE_ADDRESS, ORIGIN_HOST};
         Map<String, Object> subMap = new HashMap<>();
         for (String key : keys) {
@@ -191,6 +193,11 @@ public class HttpClientAction extends AbstractHTTPAction {
             if (value != null) {
                 subMap.put(key, value);
             }
+        }
+        String strandParentFunctionName = Objects.isNull(env.getStrandMetadata()) ? null :
+                env.getStrandMetadata().getParentFunctionName();
+        if (Objects.nonNull(strandParentFunctionName) && strandParentFunctionName.equals("onMessage")) {
+            subMap.put(MAIN_STRAND, true);
         }
         return subMap;
     }


### PR DESCRIPTION
## Purpose

When there is a call to an async backend, that outbound request should not depend on the SourceHandler and a connection should be created from the global connection pool.

> Fixes [`Connection pool does not get recovered after being exhausted #1356`](https://github.com/ballerina-platform/ballerina-standard-library/issues/1356)

> **Note** : Since this fix is related to the strands which are created to execute client actions, it is not possible to add a test case for this scenario. But the behaviour change after this fix is checked by manual debugging and observed that, for async backend call, the connection is created from the **global pool** and the TargetChannel for this connection is **not** associated with a SourceHandler.

## Example

```ballerina
service Hello on new http:Listener(9090) {
    @http:ResourceConfig {
        path: "/sayHello"
    }
    resource function passthrough(http:Caller caller, http:Request req) {
        // creates a connection from global pool
        future<()> publishedEvent = start publishSecondEvent(); 

        // creates a connection from SourceHandler's targetChannelPool
        var clientResponse = clientEP->forward("/sayHello", req); 
        if (clientResponse is http:Response) {
            var result = caller->respond(clientResponse);
            if (result is error) {
                log:printError("Error sending response", result);
            }
        } else {
            http:Response res = new;
            res.statusCode = 500;
            res.setTextPayload(<string>clientResponse.detail()?.message);
            var result = caller->respond(res);
            if (result is error) {
                log:printError("Error sending response", result);
            }
        }
    }
}

public function publishSecondEvent() {
    http:Request clientRequest = new;
    clientRequest.setTextPayload("Hello World");
    var response = clientEP2->post("/sayHello", clientRequest);
    if (response is http:Response) {
        log:printDebug("Second request sent.");
    } else {
        log:printError(response.reason(), err = response);
    }
}
```

## Checklist
- [x] Linked to an issue
- [ ] <s>Updated the changelog</s>
- [ ] <s>Added tests</s>