### PR TITLE
Add compiler validation for payload annotation usage

### DIFF
--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -19,6 +19,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"}
 ]
+modules = [
+	{org = "ballerina", packageName = "auth", moduleName = "auth"}
+]
 
 [[package]]
 org = "ballerina"
@@ -40,6 +43,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
 ]
+modules = [
+	{org = "ballerina", packageName = "crypto", moduleName = "crypto"}
+]
 
 [[package]]
 org = "ballerina"
@@ -52,6 +58,9 @@ dependencies = [
 	{org = "ballerina", name = "os"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
+]
+modules = [
+	{org = "ballerina", packageName = "file", moduleName = "file"}
 ]
 
 [[package]]
@@ -90,9 +99,22 @@ org = "ballerina"
 name = "http_tests"
 version = "2.2.0"
 dependencies = [
+	{org = "ballerina", name = "auth"},
+	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "jwt"},
+	{org = "ballerina", name = "lang.boolean"},
+	{org = "ballerina", name = "lang.float"},
+	{org = "ballerina", name = "lang.int"},
+	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "lang.string"},
+	{org = "ballerina", name = "lang.xml"},
+	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mime"},
+	{org = "ballerina", name = "oauth2"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "url"}
@@ -110,12 +132,18 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
+modules = [
+	{org = "ballerina", packageName = "io", moduleName = "io"}
+]
 
 [[package]]
 org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
 scope = "testOnly"
+modules = [
+	{org = "ballerina", packageName = "jballerina.java", moduleName = "jballerina.java"}
+]
 
 [[package]]
 org = "ballerina"
@@ -131,6 +159,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
+]
+modules = [
+	{org = "ballerina", packageName = "jwt", moduleName = "jwt"}
 ]
 
 [[package]]
@@ -155,6 +186,18 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.boolean"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.boolean", moduleName = "lang.boolean"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.decimal"
 version = "0.0.0"
 scope = "testOnly"
@@ -164,11 +207,26 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.float"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.float", moduleName = "lang.float"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.int"
 version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.int", moduleName = "lang.int"}
 ]
 
 [[package]]
@@ -184,6 +242,9 @@ version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
 ]
 
 [[package]]
@@ -209,6 +270,18 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.xml"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.xml", moduleName = "lang.xml"}
+]
+
+[[package]]
+org = "ballerina"
 name = "log"
 version = "2.2.0"
 scope = "testOnly"
@@ -217,6 +290,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"},
 	{org = "ballerina", name = "observe"}
+]
+modules = [
+	{org = "ballerina", packageName = "log", moduleName = "log"}
 ]
 
 [[package]]
@@ -245,6 +321,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "time"}
 ]
+modules = [
+	{org = "ballerina", packageName = "oauth2", moduleName = "oauth2"}
+]
 
 [[package]]
 org = "ballerina"
@@ -271,6 +350,9 @@ version = "1.2.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "regex", moduleName = "regex"}
 ]
 
 [[package]]
@@ -311,6 +393,9 @@ version = "2.2.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "url", moduleName = "url"}
 ]
 
 

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -13,7 +13,7 @@ distribution = "2201.0.0"
 path = "../native/build/libs/http-native-2.2.0-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/mime-native-2.2.0-20220112-203600-f0ceda0.jar"
+path = "./lib/mime-native-2.2.0-20220112-235000-6b80bc1.jar"
 
 [[platform.java11.dependency]]
 path = "./lib/netty-common-4.1.71.Final.jar"

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - [Implement Typed `headers` for HTTP response](https://github.com/ballerina-platform/ballerina-standard-library/issues/2563)
 - [Add map<string> data binding support for application/www-x-form-urlencoded](https://github.com/ballerina-platform/ballerina-standard-library/issues/2526)
+- [Add compiler validation for payload annotation usage](https://github.com/ballerina-platform/ballerina-standard-library/issues/2561)
 
 ## [2.1.0] - 2021-12-14
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -148,16 +148,21 @@ public class CompilerPluginTest {
         Package currentPackage = loadPackage("sample_package_4");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
-        Assert.assertEquals(diagnosticResult.errorCount(), 6);
+        Assert.assertEquals(diagnosticResult.errorCount(), 8);
         assertError(diagnosticResult, 0, "invalid multiple resource parameter annotations for 'abc': expected one of " +
                 "the following types: 'http:Payload', 'http:CallerInfo', 'http:Headers'", HTTP_108);
-        assertError(diagnosticResult, 1, "invalid payload annotation usage for GET resource", HTTP_129);
-        assertError(diagnosticResult, 2, "invalid payload parameter type: 'json[]'", HTTP_107);
-        assertError(diagnosticResult, 3, "invalid annotation type on param 'a': expected one of the following types: " +
+        assertError(diagnosticResult, 1, "invalid payload annotation usage for non entity body " +
+                "resource : 'get'", HTTP_129);
+        assertError(diagnosticResult, 2, "invalid payload annotation usage for non entity body " +
+                "resource : 'head'", HTTP_129);
+        assertError(diagnosticResult, 3, "invalid payload annotation usage for non entity body " +
+                "resource : 'options'", HTTP_129);
+        assertError(diagnosticResult, 4, "invalid payload parameter type: 'json[]'", HTTP_107);
+        assertError(diagnosticResult, 5, "invalid annotation type on param 'a': expected one of the following types: " +
                 "'http:Payload', 'http:CallerInfo', 'http:Headers'", HTTP_104);
-        assertError(diagnosticResult, 4,
+        assertError(diagnosticResult, 6,
                     "invalid resource parameter type: 'table<http_test/sample_4:0.1.0:Person> key(id)'", HTTP_106);
-        assertError(diagnosticResult, 5, "invalid payload parameter type: 'map<int>'", HTTP_107);
+        assertError(diagnosticResult, 7, "invalid payload parameter type: 'map<int>'", HTTP_107);
     }
 
     @Test
@@ -431,7 +436,8 @@ public class CompilerPluginTest {
                 " are not supported for interceptor resource functions", HTTP_125);
         assertError(diagnosticResult, 8, "invalid interceptor resource path: expected default resource" +
                 " path: '[string... path]', but found '[string path]'", HTTP_127);
-        assertError(diagnosticResult, 9, "invalid payload annotation usage for GET resource", HTTP_129);
+        assertError(diagnosticResult, 9, "invalid payload annotation usage for non entity body " +
+                "resource : 'get'", HTTP_129);
     }
 
     @Test

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -152,11 +152,11 @@ public class CompilerPluginTest {
         assertError(diagnosticResult, 0, "invalid multiple resource parameter annotations for 'abc': expected one of " +
                 "the following types: 'http:Payload', 'http:CallerInfo', 'http:Headers'", HTTP_108);
         assertError(diagnosticResult, 1, "invalid payload annotation usage for non entity body " +
-                "resource : 'get'", HTTP_129);
+                "resource : 'get'. Use accessor that supports entity", HTTP_129);
         assertError(diagnosticResult, 2, "invalid payload annotation usage for non entity body " +
-                "resource : 'head'", HTTP_129);
+                "resource : 'head'. Use accessor that supports entity", HTTP_129);
         assertError(diagnosticResult, 3, "invalid payload annotation usage for non entity body " +
-                "resource : 'options'", HTTP_129);
+                "resource : 'options'. Use accessor that supports entity", HTTP_129);
         assertError(diagnosticResult, 4, "invalid payload parameter type: 'json[]'", HTTP_107);
         assertError(diagnosticResult, 5, "invalid annotation type on param 'a': expected one of the following types: " +
                 "'http:Payload', 'http:CallerInfo', 'http:Headers'", HTTP_104);
@@ -437,7 +437,7 @@ public class CompilerPluginTest {
         assertError(diagnosticResult, 8, "invalid interceptor resource path: expected default resource" +
                 " path: '[string... path]', but found '[string path]'", HTTP_127);
         assertError(diagnosticResult, 9, "invalid payload annotation usage for non entity body " +
-                "resource : 'get'", HTTP_129);
+                "resource : 'get'. Use accessor that supports entity", HTTP_129);
     }
 
     @Test

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -71,6 +71,7 @@ public class CompilerPluginTest {
     private static final String HTTP_126 = "HTTP_126";
     private static final String HTTP_127 = "HTTP_127";
     private static final String HTTP_128 = "HTTP_128";
+    private static final String HTTP_129 = "HTTP_129";
 
     private static final String REMOTE_METHODS_NOT_ALLOWED = "remote methods are not allowed in http:Service";
 
@@ -147,15 +148,16 @@ public class CompilerPluginTest {
         Package currentPackage = loadPackage("sample_package_4");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
-        Assert.assertEquals(diagnosticResult.errorCount(), 5);
+        Assert.assertEquals(diagnosticResult.errorCount(), 6);
         assertError(diagnosticResult, 0, "invalid multiple resource parameter annotations for 'abc': expected one of " +
                 "the following types: 'http:Payload', 'http:CallerInfo', 'http:Headers'", HTTP_108);
-        assertError(diagnosticResult, 1, "invalid payload parameter type: 'json[]'", HTTP_107);
-        assertError(diagnosticResult, 2, "invalid annotation type on param 'a': expected one of the following types: " +
+        assertError(diagnosticResult, 1, "invalid payload annotation usage for GET resource", HTTP_129);
+        assertError(diagnosticResult, 2, "invalid payload parameter type: 'json[]'", HTTP_107);
+        assertError(diagnosticResult, 3, "invalid annotation type on param 'a': expected one of the following types: " +
                 "'http:Payload', 'http:CallerInfo', 'http:Headers'", HTTP_104);
-        assertError(diagnosticResult, 3,
+        assertError(diagnosticResult, 4,
                     "invalid resource parameter type: 'table<http_test/sample_4:0.1.0:Person> key(id)'", HTTP_106);
-        assertError(diagnosticResult, 4, "invalid payload parameter type: 'map<int>'", HTTP_107);
+        assertError(diagnosticResult, 5, "invalid payload parameter type: 'map<int>'", HTTP_107);
     }
 
     @Test
@@ -362,10 +364,10 @@ public class CompilerPluginTest {
         // only testing the error locations
         assertErrorPosition(diagnosticResult, 0, "(30:44,30:60)");
         assertErrorPosition(diagnosticResult, 1, "(35:5,35:16)");
-        assertErrorPosition(diagnosticResult, 2, "(40:85,40:86)");
+        assertErrorPosition(diagnosticResult, 2, "(40:86,40:87)");
         assertErrorPosition(diagnosticResult, 3, "(44:57,44:60)");
-        assertErrorPosition(diagnosticResult, 4, "(48:55,48:58)");
-        assertErrorPosition(diagnosticResult, 5, "(52:65,52:68)");
+        assertErrorPosition(diagnosticResult, 4, "(48:56,48:59)");
+        assertErrorPosition(diagnosticResult, 5, "(52:66,52:69)");
         assertErrorPosition(diagnosticResult, 6, "(56:77,56:80)");
         assertErrorPosition(diagnosticResult, 7, "(60:76,60:79)");
         assertErrorPosition(diagnosticResult, 8, "(64:76,64:82)");
@@ -411,7 +413,7 @@ public class CompilerPluginTest {
         Package currentPackage = loadPackage("sample_package_19");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
-        Assert.assertEquals(diagnosticResult.errorCount(), 9);
+        Assert.assertEquals(diagnosticResult.errorCount(), 10);
         assertError(diagnosticResult, 0, "invalid multiple interceptor type reference: " +
                 "'http:RequestErrorInterceptor'", HTTP_123);
         assertError(diagnosticResult, 1, "invalid interceptor resource path: expected default resource" +
@@ -429,6 +431,7 @@ public class CompilerPluginTest {
                 " are not supported for interceptor resource functions", HTTP_125);
         assertError(diagnosticResult, 8, "invalid interceptor resource path: expected default resource" +
                 " path: '[string... path]', but found '[string path]'", HTTP_127);
+        assertError(diagnosticResult, 9, "invalid payload annotation usage for GET resource", HTTP_129);
     }
 
     @Test

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -151,12 +151,12 @@ public class CompilerPluginTest {
         Assert.assertEquals(diagnosticResult.errorCount(), 8);
         assertError(diagnosticResult, 0, "invalid multiple resource parameter annotations for 'abc': expected one of " +
                 "the following types: 'http:Payload', 'http:CallerInfo', 'http:Headers'", HTTP_108);
-        assertError(diagnosticResult, 1, "invalid payload annotation usage for non entity body " +
-                "resource : 'get'. Use accessor that supports entity", HTTP_129);
-        assertError(diagnosticResult, 2, "invalid payload annotation usage for non entity body " +
-                "resource : 'head'. Use accessor that supports entity", HTTP_129);
-        assertError(diagnosticResult, 3, "invalid payload annotation usage for non entity body " +
-                "resource : 'options'. Use accessor that supports entity", HTTP_129);
+        assertError(diagnosticResult, 1, "invalid usage of payload annotation for a non entity body " +
+                "resource : 'get'. Use an accessor that supports entity body", HTTP_129);
+        assertError(diagnosticResult, 2, "invalid usage of payload annotation for a non entity body " +
+                "resource : 'head'. Use an accessor that supports entity body", HTTP_129);
+        assertError(diagnosticResult, 3, "invalid usage of payload annotation for a non entity body " +
+                "resource : 'options'. Use an accessor that supports entity body", HTTP_129);
         assertError(diagnosticResult, 4, "invalid payload parameter type: 'json[]'", HTTP_107);
         assertError(diagnosticResult, 5, "invalid annotation type on param 'a': expected one of the following types: " +
                 "'http:Payload', 'http:CallerInfo', 'http:Headers'", HTTP_104);
@@ -436,8 +436,8 @@ public class CompilerPluginTest {
                 " are not supported for interceptor resource functions", HTTP_125);
         assertError(diagnosticResult, 8, "invalid interceptor resource path: expected default resource" +
                 " path: '[string... path]', but found '[string path]'", HTTP_127);
-        assertError(diagnosticResult, 9, "invalid payload annotation usage for non entity body " +
-                "resource : 'get'. Use accessor that supports entity", HTTP_129);
+        assertError(diagnosticResult, 9, "invalid usage of payload annotation for a non entity body " +
+                "resource : 'get'. Use an accessor that supports entity body", HTTP_129);
     }
 
     @Test

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/service.bal
@@ -38,7 +38,7 @@ service / on new http:Listener(9999) {
         return error http:Error("hello") ;
     }
 
-    resource function get test104(int num, @http:Payload json abc, @Pp {id:0} string a) returns string {
+    resource function post test104(int num, @http:Payload json abc, @Pp {id:0} string a) returns string {
         return "done";
     }
 
@@ -46,11 +46,11 @@ service / on new http:Listener(9999) {
         return "done";
     }
 
-    resource function get test107(@http:Payload json[] abc) returns string {
+    resource function post test107(@http:Payload json[] abc) returns string {
         return "done"; // error
     }
 
-    resource function get test108(@http:Payload @http:Header xml abc) returns string {
+    resource function post test108(@http:Payload @http:Header xml abc) returns string {
         return "done";
     }
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_19/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_19/service.bal
@@ -55,7 +55,7 @@ service class InterceptorService2 {
 service class InterceptorService3 {
     *http:RequestInterceptor;
 
-    resource function default [string... path](http:Caller caller, http:RequestContext ctx, http:Request req) {
+    resource function 'default [string... path](http:Caller caller, http:RequestContext ctx, http:Request req) {
         req.setTextPayload("interceptor");
     }
 }
@@ -80,7 +80,7 @@ service class InterceptorService5 {
 service class InterceptorService6 {
     *http:RequestInterceptor;
 
-    resource function get [string... path](string q1, int q2, @http:Payload string payload, @http:Header string foo, http:Caller caller) returns error? {
+    resource function post [string... path](string q1, int q2, @http:Payload string payload, @http:Header string foo, http:Caller caller) returns error? {
         check caller->respond(payload);
     }
 }
@@ -162,6 +162,14 @@ service class InterceptorService14 {
 
     resource function 'default [string path](http:RequestContext ctx, http:Request req, http:Caller caller) returns http:NextService|error? {
         req.setTextPayload("interceptor");
+        return ctx.next();
+    }
+}
+
+service class InterceptorService15 {
+    *http:RequestInterceptor;
+
+    resource function get greeting(http:RequestContext ctx, @http:Payload string abc) returns http:NextService|error? {
         return ctx.next();
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_2/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_2/service.bal
@@ -103,11 +103,11 @@ service http:Service on new http:Listener(9090) {
         return [{id:123, name: "john"}, {id:124, name: "khan"}];
     }
 
-    resource function get greeting16() returns @http:Payload {mediaType:["application/json+123"]} json {
+    resource function post greeting16() returns @http:Payload {mediaType:["application/json+123"]} json {
         return {hello: "world"};
     }
 
-    resource function get greeting17() returns @http:Payload {mediaType:["text/xml", "app/xml"]} xml {
+    resource function post greeting17() returns @http:Payload {mediaType:["text/xml", "app/xml"]} xml {
         return xml `<book>Hello World</book>`;
     }
 
@@ -116,7 +116,7 @@ service http:Service on new http:Listener(9090) {
         return resp;
     }
 
-    resource function get greeting19() returns @http:Payload {mediaType:["text/plain"]} int {
+    resource function post greeting19() returns @http:Payload {mediaType:["text/plain"]} int {
         return 56;
     }
 
@@ -132,7 +132,7 @@ service http:Service on new http:Listener(9090) {
         return true;
     }
 
-    resource function get greeting23() returns @http:Payload {mediaType:"application/json"} http:Created|http:Ok {
+    resource function post greeting23() returns @http:Payload {mediaType:"application/json"} http:Created|http:Ok {
         http:Created cre = { body: {hello:"World"}, headers: { xtest: "Elle"}, mediaType:"application/json+id" };
         return cre;
     }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_4/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_4/service.bal
@@ -36,6 +36,14 @@ service http:Service on new http:Listener(9090) {
         return "done"; // error
     }
 
+    resource function head dbString(@http:Payload string abc) returns string {
+        return "done"; // error
+    }
+
+    resource function options dbString(@http:Payload string abc) returns string {
+        return "done"; // error
+    }
+
     resource function post dbMapOfString(@http:Payload map<string> abc) returns string {
         return "done";
     }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_4/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_4/service.bal
@@ -24,47 +24,47 @@ public annotation Person Pp on parameter;
 
 service http:Service on new http:Listener(9090) {
 
-    resource function get dbJson(@http:Payload json abc) returns string {
+    resource function post dbJson(@http:Payload json abc) returns string {
         return "done";
     }
 
-    resource function get dbXml(@http:Payload @http:Header xml abc) returns string {
-        return "done";
+    resource function post dbXml(@http:Payload @http:Header xml abc) returns string {
+        return "done"; // error
     }
 
     resource function get dbString(@http:Payload string abc) returns string {
-        return "done";
-    }
-
-    resource function get dbMapOfString(@http:Payload map<string> abc) returns string {
-        return "done";
-    }
-
-    resource function get dbByteArr(@http:Payload byte[] abc) returns string {
-        return "done";
-    }
-
-    resource function get dbRecord(@http:Payload Person abc) returns string {
-        return "done";
-    }
-
-    resource function get dbRecArr(@http:Payload Person[] abc) returns string {
-        return "done";
-    }
-
-    resource function get dbJsonArr(@http:Payload json[] abc) returns string {
         return "done"; // error
     }
 
-    resource function get greeting1(int num, @http:Payload json abc, @Pp {id:0} string a) returns string {
+    resource function post dbMapOfString(@http:Payload map<string> abc) returns string {
+        return "done";
+    }
+
+    resource function post dbByteArr(@http:Payload byte[] abc) returns string {
+        return "done";
+    }
+
+    resource function post dbRecord(@http:Payload Person abc) returns string {
+        return "done";
+    }
+
+    resource function post dbRecArr(@http:Payload Person[] abc) returns string {
+        return "done";
+    }
+
+    resource function post dbJsonArr(@http:Payload json[] abc) returns string {
         return "done"; // error
     }
 
-    resource function get dbTable(table<Person> key(id)  abc) returns string {
+    resource function post greeting1(int num, @http:Payload json abc, @Pp {id:0} string a) returns string {
         return "done"; // error
     }
 
-    resource function get dbMapOfIntNegative(@http:Payload map<int> abc) returns string {
+    resource function post dbTable(table<Person> key(id)  abc) returns string {
+        return "done"; // error
+    }
+
+    resource function post dbMapOfIntNegative(@http:Payload map<int> abc) returns string {
         return "done"; // error
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_5/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_5/service.bal
@@ -38,7 +38,7 @@ service http:Service on new http:Listener(9090) {
         return "done"; //error
     }
 
-    resource function get headerErr2(@http:Header @http:Payload string abc) returns string {
+    resource function post headerErr2(@http:Header @http:Payload string abc) returns string {
         return "done"; //error
     }
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_6/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_6/service.bal
@@ -30,7 +30,7 @@ service a:Service on new a:Listener(9090) {
         return "done"; //error
     }
 
-    resource function get callerErr2(@a:CallerInfo @a:Payload a:Caller abc) returns string {
+    resource function post callerErr2(@a:CallerInfo @a:Payload a:Caller abc) returns string {
         return "done"; //error
     }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
@@ -49,6 +49,7 @@ public class Constants {
     public static final String HTTP_REQUEST_ERROR_INTERCEPTOR = "http:RequestErrorInterceptor";
     public static final String ALLOWED_INTERCEPTOR_RETURN_UNION = "http:NextService|error?";
     public static final String DEFAULT = "default";
+    public static final String GET = "get";
 
     public static final String COLON = ":";
     public static final String PLUS = "+";

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
@@ -50,6 +50,8 @@ public class Constants {
     public static final String ALLOWED_INTERCEPTOR_RETURN_UNION = "http:NextService|error?";
     public static final String DEFAULT = "default";
     public static final String GET = "get";
+    public static final String HEAD = "head";
+    public static final String OPTIONS = "options";
 
     public static final String COLON = ":";
     public static final String PLUS = "+";

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
@@ -74,8 +74,8 @@ public enum HttpDiagnosticCodes {
             "'[string... path]', but found '%s'", ERROR),
     HTTP_128("HTTP_128", "invalid interceptor resource method: expected default resource method: " +
             "'default', but found '%s'", ERROR),
-    HTTP_129("HTTP_129", "invalid payload annotation usage for non entity body resource : '%s'. " +
-            "Use accessor that supports entity", ERROR),
+    HTTP_129("HTTP_129", "invalid usage of payload annotation for a non entity body resource : '%s'. " +
+            "Use an accessor that supports entity body", ERROR),
     HTTP_HINT_101("HTTP_HINT_101", "A resource annotation can be added", INTERNAL);
 
     private final String code;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
@@ -74,7 +74,8 @@ public enum HttpDiagnosticCodes {
             "'[string... path]', but found '%s'", ERROR),
     HTTP_128("HTTP_128", "invalid interceptor resource method: expected default resource method: " +
             "'default', but found '%s'", ERROR),
-    HTTP_129("HTTP_129", "invalid payload annotation usage for non entity body resource : '%s'", ERROR),
+    HTTP_129("HTTP_129", "invalid payload annotation usage for non entity body resource : '%s'. " +
+            "Use accessor that supports entity", ERROR),
     HTTP_HINT_101("HTTP_HINT_101", "A resource annotation can be added", INTERNAL);
 
     private final String code;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
@@ -74,6 +74,7 @@ public enum HttpDiagnosticCodes {
             "'[string... path]', but found '%s'", ERROR),
     HTTP_128("HTTP_128", "invalid interceptor resource method: expected default resource method: " +
             "'default', but found '%s'", ERROR),
+    HTTP_129("HTTP_129", "invalid payload annotation usage for GET resource", ERROR),
     HTTP_HINT_101("HTTP_HINT_101", "A resource annotation can be added", INTERNAL);
 
     private final String code;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
@@ -74,7 +74,7 @@ public enum HttpDiagnosticCodes {
             "'[string... path]', but found '%s'", ERROR),
     HTTP_128("HTTP_128", "invalid interceptor resource method: expected default resource method: " +
             "'default', but found '%s'", ERROR),
-    HTTP_129("HTTP_129", "invalid payload annotation usage for GET resource", ERROR),
+    HTTP_129("HTTP_129", "invalid payload annotation usage for non entity body resource : '%s'", ERROR),
     HTTP_HINT_101("HTTP_HINT_101", "A resource annotation can be added", INTERNAL);
 
     private final String code;


### PR DESCRIPTION
## Purpose

A compiler error is returned when a non entity body resource (`get`, `options` and `head`) has a parameter with payload annotation(`@http:Payload`)

> Fixes [`No validation for get with @http:Payload #2561`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2561)

## Example
```ballerina
import ballerina/http;

service / on new http:Listener(9090) {
    // will return a compiler error saying : 
    // invalid usage of payload annotation for non entity body resource : 'get'. 
    // Use an accessor that supports entity body
    resource function get hello(@http:Payload string request) returns string {
        return request;
    }
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests