### PR TITLE
Add compiler support for intersection type in payload annotation

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -13,7 +13,7 @@ distribution = "2201.0.0"
 path = "../native/build/libs/http-native-2.2.0-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/mime-native-2.2.0-20220119-160200-95f5266.jar"
+path = "./lib/mime-native-2.2.0-20220123-144100-afba7e0.jar"
 
 [[platform.java11.dependency]]
 path = "./lib/netty-common-4.1.71.Final.jar"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_21/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_21/service.bal
@@ -18,6 +18,13 @@ import ballerina/http;
 
 // Positive Cases
 
+type NewAlbum record {|
+    string id;
+    string title;
+    string artist;
+    decimal price;
+|};
+
 type Album readonly & record {|
     string id;
     string title;
@@ -43,5 +50,35 @@ service / on new http:Listener(8080) {
             store.add(album);
         }
         return albums;
+    }
+}
+
+service / on new http:Listener(8090) {
+    resource function post album(@http:Payload readonly & NewAlbum album) returns string {
+        return "album";
+    }
+
+    resource function post albumArray(@http:Payload readonly & NewAlbum[] albums) returns string {
+        return "albumArray";
+    }
+
+    resource function post byteArray(@http:Payload readonly & byte[] albums) returns string {
+        return "byteArray";
+    }
+
+    resource function post readonlyString(@http:Payload readonly & string album) returns string {
+        return "string";
+    }
+
+    resource function post readonlyJson(@http:Payload readonly & json album) returns string {
+        return "json";
+    }
+
+    resource function post readonlyXml(@http:Payload readonly & xml album) returns string {
+        return "xml";
+    }
+
+    resource function post readonlyMapString(@http:Payload readonly & map<string> album) returns string {
+        return "mapOfString";
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
@@ -300,14 +300,23 @@ class HttpResourceValidator {
                             continue;
                         }
                         annotated = true;
-                        TypeDescKind kind = param.typeDescriptor().typeKind();
+                        TypeSymbol paramTypeDescriptor = param.typeDescriptor();
+                        if (paramTypeDescriptor.typeKind() == TypeDescKind.INTERSECTION) {
+                            paramTypeDescriptor =
+                                    ((IntersectionTypeSymbol) param.typeDescriptor()).effectiveTypeDescriptor();
+                        }
+                        TypeDescKind kind = paramTypeDescriptor.typeKind();
                         if (kind == TypeDescKind.JSON || kind == TypeDescKind.STRING ||
                                 kind == TypeDescKind.XML) {
                             continue;
                         } else if (kind == TypeDescKind.ARRAY) {
                             TypeSymbol arrTypeSymbol =
-                                    ((ArrayTypeSymbol) param.typeDescriptor()).memberTypeDescriptor();
+                                    ((ArrayTypeSymbol) paramTypeDescriptor).memberTypeDescriptor();
                             TypeDescKind elementKind = arrTypeSymbol.typeKind();
+                            if (elementKind == TypeDescKind.INTERSECTION) {
+                                arrTypeSymbol = ((IntersectionTypeSymbol) arrTypeSymbol).effectiveTypeDescriptor();
+                                elementKind = arrTypeSymbol.typeKind();
+                            }
                             if (elementKind == TypeDescKind.BYTE) {
                                 continue;
                             } else if (elementKind == TypeDescKind.TYPE_REFERENCE) {
@@ -319,13 +328,13 @@ class HttpResourceValidator {
                             }
                         } else if (kind == TypeDescKind.TYPE_REFERENCE) {
                             TypeSymbol typeDescriptor =
-                                    ((TypeReferenceTypeSymbol) param.typeDescriptor()).typeDescriptor();
+                                    ((TypeReferenceTypeSymbol) paramTypeDescriptor).typeDescriptor();
                             TypeDescKind typeDescKind = retrieveEffectiveTypeDesc(typeDescriptor);
                             if (typeDescKind == TypeDescKind.RECORD) {
                                 continue;
                             }
                         } else if (kind == TypeDescKind.MAP) {
-                            TypeSymbol typeDescriptor = ((MapTypeSymbol) param.typeDescriptor()).typeParam();
+                            TypeSymbol typeDescriptor = ((MapTypeSymbol) paramTypeDescriptor).typeParam();
                             TypeDescKind typeDescKind = typeDescriptor.typeKind();
                             if (typeDescKind == TypeDescKind.STRING) {
                                 continue;


### PR DESCRIPTION
## Purpose

> Fixes [`Add compiler validation for intersection type #2609`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2609)

This will enable support to have explicit intersection types in payload annotation.

## Example

```ballerina
import ballerina/http;

service / on new http:Listener(9090) {

    resource function post test(@http:Payload readonly & byte[] content) returns string {
        return "Hello, World!";
    }
}
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests