### PR TITLE
Add inline record support for payload in compiler plugin

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -13,7 +13,7 @@ distribution = "2201.0.0"
 path = "../native/build/libs/http-native-2.2.0-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/mime-native-2.2.0-20220123-144100-afba7e0.jar"
+path = "./lib/mime-native-2.2.0-20220124-205900-b566652.jar"
 
 [[platform.java11.dependency]]
 path = "./lib/netty-common-4.1.71.Final.jar"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_21/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_21/service.bal
@@ -81,4 +81,12 @@ service / on new http:Listener(8090) {
     resource function post readonlyMapString(@http:Payload readonly & map<string> album) returns string {
         return "mapOfString";
     }
+
+    resource function post inlineRecord(@http:Payload record {|string name; int age;|} person) returns string {
+        return "inlineRecord";
+    }
+
+    resource function post inlineReadOnlyRecord(@http:Payload readonly & record {|string name; int age;|} person) returns string {
+        return "inlineReadOnlyRecord";
+    }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
@@ -307,7 +307,7 @@ class HttpResourceValidator {
                         }
                         TypeDescKind kind = paramTypeDescriptor.typeKind();
                         if (kind == TypeDescKind.JSON || kind == TypeDescKind.STRING ||
-                                kind == TypeDescKind.XML) {
+                                kind == TypeDescKind.XML || kind == TypeDescKind.RECORD) {
                             continue;
                         } else if (kind == TypeDescKind.ARRAY) {
                             TypeSymbol arrTypeSymbol =


### PR DESCRIPTION
## Purpose

> $Subject

> Fixes  [`Inline record in payload annotation returns a compilation error #2624`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2624)

## Examples

```ballerina
import ballerina/http;

service / on new http:Listener(9090) {

    // With this change the following is valid
    resource function post path(@http:Payload record {|string name; int age;|} person) returns string {
        return "path";
    }
}
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests