### PR TITLE
Extend doc comments for http:Response

### DIFF
--- a/ballerina/http_request.bal
+++ b/ballerina/http_request.bal
@@ -223,7 +223,9 @@ public class Request {
         return contentTypeHeaderValue;
     }
 
-    # Extracts `json` payload from the request. If the content type is not JSON, an `http:ClientError` is returned.
+    # Extract `json` payload from the request. For an empty payload, `http:NoContentError` is returned.
+    #
+    # If the content type is not JSON, an `http:ClientError` is returned.
     #
     # + return - The `json` payload or `http:ClientError` in case of errors
     public isolated function getJsonPayload() returns json|ClientError {
@@ -245,7 +247,9 @@ public class Request {
         }
     }
 
-    # Extracts `xml` payload from the request. If the content type is not XML, an `http:ClientError` is returned.
+    # Extracts `xml` payload from the request. For an empty payload, `http:NoContentError` is returned.
+    #
+    # If the content type is not XML, an `http:ClientError` is returned.
     #
     # + return - The `xml` payload or `http:ClientError` in case of errors
     public isolated function getXmlPayload() returns xml|ClientError {
@@ -267,7 +271,9 @@ public class Request {
         }
     }
 
-    # Extracts `text` payload from the request. If the content type is not of type text, an `http:ClientError` is returned.
+    # Extracts `text` payload from the request. For an empty payload, `http:NoContentError` is returned.
+    #
+    # If the content type is not of type text, an `http:ClientError` is returned.
     #
     # + return - The `text` payload or `http:ClientError` in case of errors
     public isolated function getTextPayload() returns string|ClientError {

--- a/ballerina/http_response.bal
+++ b/ballerina/http_response.bal
@@ -194,7 +194,11 @@ public class Response {
         return contentTypeHeaderValue;
     }
 
-    # Extract `json` payload from the response. If the content type is not JSON, an `http:ClientError` is returned.
+    # Extract `json` payload from the response.
+    #
+    # If the payload is empty, a `http:NoContentError` is returned.
+    #
+    # If the content type is not JSON, an `http:ClientError` is returned.
     #
     # + return - The `json` payload or `http:ClientError` in case of errors
     public isolated function getJsonPayload() returns json|ClientError {
@@ -218,6 +222,8 @@ public class Response {
 
     # Extracts `xml` payload from the response.
     #
+    # If the payload is empty, a `http:NoContentError` is returned.
+    #
     # + return - The `xml` payload or `http:ClientError` in case of errors
     public isolated function getXmlPayload() returns xml|ClientError {
         var result = self.getEntityWithBodyAndWithoutHeaders();
@@ -239,6 +245,8 @@ public class Response {
     }
 
     # Extracts `text` payload from the response.
+    #
+    # If the payload is empty, a `http:NoContentError` is returned.
     #
     # + return - The string representation of the message payload or `http:ClientError` in case of errors
     public isolated function getTextPayload() returns string|ClientError {

--- a/ballerina/http_response.bal
+++ b/ballerina/http_response.bal
@@ -194,9 +194,7 @@ public class Response {
         return contentTypeHeaderValue;
     }
 
-    # Extract `json` payload from the response.
-    #
-    # If the payload is empty, a `http:NoContentError` is returned.
+    # Extract `json` payload from the response. For an empty payload, `http:NoContentError` is returned.
     #
     # If the content type is not JSON, an `http:ClientError` is returned.
     #
@@ -220,9 +218,9 @@ public class Response {
         }
     }
 
-    # Extracts `xml` payload from the response.
+    # Extracts `xml` payload from the response. For an empty payload, `http:NoContentError` is returned.
     #
-    # If the payload is empty, a `http:NoContentError` is returned.
+    # If the content type is not XML, an `http:ClientError` is returned.
     #
     # + return - The `xml` payload or `http:ClientError` in case of errors
     public isolated function getXmlPayload() returns xml|ClientError {
@@ -244,9 +242,9 @@ public class Response {
         }
     }
 
-    # Extracts `text` payload from the response.
+    # Extracts `text` payload from the response. For an empty payload, `http:NoContentError` is returned.
     #
-    # If the payload is empty, a `http:NoContentError` is returned.
+    # If the content type is not of type text, an `http:ClientError` is returned.
     #
     # + return - The string representation of the message payload or `http:ClientError` in case of errors
     public isolated function getTextPayload() returns string|ClientError {


### PR DESCRIPTION
## Purpose
Improve doc comments in `http:Response`.

The method `getTextPayload()` returns a `http:NoContentError` if the payload is empty, not an empty string. This patch  extends the doc comment to make this clear. 

For consistency reasons, it extends the doc comments for `getXmlPayload()` and `getJsonPayload()` too.