### PR TITLE
Add code-actions to resource return type

### DIFF
--- a/ballerina-tests/Ballerina.toml
+++ b/ballerina-tests/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http_tests"
-version = "2.2.0"
+version = "2.2.1"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/http-native-2.2.0.jar"
+path = "../native/build/libs/http-native-2.2.1-SNAPSHOT.jar"

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -97,7 +97,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_tests"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "crypto"},

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -66,7 +66,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.2.0"
+version = "2.2.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - [Add code-actions to generate payload and header parameter templates](https://github.com/ballerina-platform/ballerina-standard-library/issues/2642)
+- [Add code-actions to add content-type and cache configuration for response](https://github.com/ballerina-platform/ballerina-standard-library/issues/2662)
 
 ## [2.2.0] - 2022-02-01
 

--- a/compiler-plugin-tests/spotbugs-exclude.xml
+++ b/compiler-plugin-tests/spotbugs-exclude.xml
@@ -28,4 +28,8 @@
         <Class name="io.ballerina.stdlib.http.compiler.codeaction.AddResourceParameterTest" />
         <Bug pattern="UPM_UNCALLED_PRIVATE_METHOD" />
     </Match>
+    <Match>
+        <Class name="io.ballerina.stdlib.http.compiler.codeaction.AddAnnotationsToReturnTypeTest" />
+        <Bug pattern="UPM_UNCALLED_PRIVATE_METHOD" />
+    </Match>
 </FindBugsFilter>

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -72,6 +72,8 @@ public class CompilerPluginTest {
     private static final String HTTP_127 = "HTTP_127";
     private static final String HTTP_128 = "HTTP_128";
     private static final String HTTP_129 = "HTTP_129";
+    private static final String HTTP_130 = "HTTP_130";
+    private static final String HTTP_131 = "HTTP_131";
 
     private static final String REMOTE_METHODS_NOT_ALLOWED = "remote methods are not allowed in http:Service";
 
@@ -461,5 +463,23 @@ public class CompilerPluginTest {
         long availableErrors = diagnosticResult.diagnostics().stream()
                 .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR)).count();
         Assert.assertEquals(availableErrors, 0);
+    }
+
+    @Test
+    public void testAnnotationUsageWithReturnType() {
+        Package currentPackage = loadPackage("sample_package_22");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errorCount(), 4);
+        assertError(diagnosticResult, 0, "invalid usage of cache annotation with return type : " +
+                "'error'. Cache annotation only supports return types of anydata and SuccessStatusCodeResponse",
+                HTTP_130);
+        assertError(diagnosticResult, 1, "invalid usage of payload annotation with return type : " +
+                "'error'", HTTP_131);
+        assertError(diagnosticResult, 2, "invalid usage of payload annotation with return type : " +
+                "'error?'", HTTP_131);
+        assertError(diagnosticResult, 3, "invalid usage of cache annotation with return type : " +
+                "'error?'. Cache annotation only supports return types of anydata and SuccessStatusCodeResponse",
+                HTTP_130);
     }
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/codeaction/AddAnnotationsToReturnTypeTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/codeaction/AddAnnotationsToReturnTypeTest.java
@@ -12,15 +12,15 @@ import java.nio.file.Path;
 import java.util.List;
 
 /**
- * Test for adding parameters to the resource signature.
+ * Test for adding annotations to the resource return statement.
  */
-public class AddResourceParameterTest extends AbstractCodeActionTest {
+public class AddAnnotationsToReturnTypeTest extends AbstractCodeActionTest {
 
     @Test(dataProvider = "testDataProvider")
     public void testCodeActions(String srcFile, int line, int offset, CodeActionInfo expected, String resultFile)
             throws IOException {
         Path filePath = RESOURCE_PATH.resolve("ballerina_sources")
-                .resolve("sample_codeaction_package_2")
+                .resolve("sample_codeaction_package_1")
                 .resolve(srcFile);
         Path resultPath = RESOURCE_PATH.resolve("codeaction")
                 .resolve(getConfigDir())
@@ -32,34 +32,30 @@ public class AddResourceParameterTest extends AbstractCodeActionTest {
     @DataProvider
     private Object[][] testDataProvider() {
         return new Object[][]{
-                {"service.bal", 19, 29, getAddHeaderCodeAction(LinePosition.from(19, 28),
-                        LinePosition.from(19, 45)), "result1.bal"},
-                {"service.bal", 23, 58, getAddHeaderCodeAction(LinePosition.from(23, 29),
-                        LinePosition.from(23, 74)), "result2.bal"},
-                {"service.bal", 27, 33, getAddPayloadCodeAction(LinePosition.from(27, 32),
-                        LinePosition.from(27, 49)), "result3.bal"},
-                {"service.bal", 31, 57, getAddPayloadCodeAction(LinePosition.from(31, 30),
-                        LinePosition.from(31, 73)), "result4.bal"}
+                {"service.bal", 24, 63, getAddResponseCacheConfigCodeAction(LinePosition.from(24, 60),
+                        LinePosition.from(24, 66)), "result1.bal"},
+                {"service.bal", 24, 63, getAddResponseContentTypeCodeAction(LinePosition.from(24, 60),
+                        LinePosition.from(24, 66)), "result2.bal"}
         };
     }
 
-    private CodeActionInfo getAddPayloadCodeAction(LinePosition startLine, LinePosition endLine) {
+    private CodeActionInfo getAddResponseCacheConfigCodeAction(LinePosition startLine, LinePosition endLine) {
         LineRange lineRange = LineRange.from("service.bal", startLine, endLine);
         CodeActionArgument locationArg = CodeActionArgument.from(CodeActionUtil.NODE_LOCATION_KEY, lineRange);
-        CodeActionInfo codeAction = CodeActionInfo.from("Add payload parameter", List.of(locationArg));
-        codeAction.setProviderName("HTTP_HINT_101/ballerina/http/ADD_PAYLOAD_PARAM");
+        CodeActionInfo codeAction = CodeActionInfo.from("Add response cache configuration", List.of(locationArg));
+        codeAction.setProviderName("HTTP_HINT_104/ballerina/http/ADD_RESPONSE_CACHE_CONFIG");
         return codeAction;
     }
 
-    private CodeActionInfo getAddHeaderCodeAction(LinePosition startLine, LinePosition endLine) {
+    private CodeActionInfo getAddResponseContentTypeCodeAction(LinePosition startLine, LinePosition endLine) {
         LineRange lineRange = LineRange.from("service.bal", startLine, endLine);
         CodeActionArgument locationArg = CodeActionArgument.from(CodeActionUtil.NODE_LOCATION_KEY, lineRange);
-        CodeActionInfo codeAction = CodeActionInfo.from("Add header parameter", List.of(locationArg));
-        codeAction.setProviderName("HTTP_HINT_102/ballerina/http/ADD_HEADER_PARAM");
+        CodeActionInfo codeAction = CodeActionInfo.from("Add response content-type", List.of(locationArg));
+        codeAction.setProviderName("HTTP_HINT_103/ballerina/http/ADD_RESPONSE_CONTENT_TYPE");
         return codeAction;
     }
 
     protected String getConfigDir() {
-        return "add_annotated_param";
+        return "add_annotations_to_return_type";
     }
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/codeaction/AddAnnotationsToReturnTypeTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/codeaction/AddAnnotationsToReturnTypeTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.ballerina.stdlib.http.compiler.codeaction;
 
 import io.ballerina.projects.plugins.codeaction.CodeActionArgument;

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/codeaction/AddResourceParameterTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/codeaction/AddResourceParameterTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.ballerina.stdlib.http.compiler.codeaction;
 
 import io.ballerina.projects.plugins.codeaction.CodeActionArgument;

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_1/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_1/service.bal
@@ -26,7 +26,7 @@ service http:Service on new http:Listener(9090) {
     isolated resource function post noGreeting() {
     }
 
-    resource function get hello() returns @http:Payload{mediaType: "text/plain"} string {
+    private function hello() returns string {
         return "yo";
     }
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_22/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_22/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "http_test"
+name = "sample_22"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_22/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_22/service.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+service / on new http:Listener(8080) {
+    resource function get helloError() returns @http:Cache error {
+        return error("hello");
+    }
+
+    resource function get heyError() returns @http:Payload{mediaType: "mediaType"} error {
+        return error("hey");
+    }
+
+    resource function get greeting(http:Caller caller) returns @http:Payload{mediaType: "mediaType"} @http:Cache error? {
+        check caller->respond("Greetings!");
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/codeaction/add_annotations_to_return_type/result1.bal
+++ b/compiler-plugin-tests/src/test/resources/codeaction/add_annotations_to_return_type/result1.bal
@@ -16,34 +16,13 @@
 
 import ballerina/http;
 
-service http:Service on new http:Listener(9090) {
-
-    string abc = "as";
-
-    resource function get greeting() {
+service / on new http:Listener(9999) {
+    
+    resource function get . (@http:Header int length) {
+        
     }
 
-    isolated resource function post noGreeting() {
-    }
-
-    resource function get hello() returns @http:Payload{mediaType: "text/plain"} string {
-        return "yo";
-    }
-
-    isolated remote function greeting() returns string {
-        return "Hello";
-    }
-
-    function hello2() returns string {
-        return "yo";
-    }
-
-    remote function greeting2() returns string|http:Response {
-        return "Hello";
-    }
-}
-
-service http:Service on new http:Listener(9091) {
-    remote function greeting2(http:Caller caller) {
+    resource function get path1(http:Caller caller) returns @http:Cache string {
+        return "";
     }
 }

--- a/compiler-plugin-tests/src/test/resources/codeaction/add_annotations_to_return_type/result2.bal
+++ b/compiler-plugin-tests/src/test/resources/codeaction/add_annotations_to_return_type/result2.bal
@@ -16,34 +16,13 @@
 
 import ballerina/http;
 
-service http:Service on new http:Listener(9090) {
-
-    string abc = "as";
-
-    resource function get greeting() {
+service / on new http:Listener(9999) {
+    
+    resource function get . (@http:Header int length) {
+        
     }
 
-    isolated resource function post noGreeting() {
-    }
-
-    resource function get hello() returns @http:Payload{mediaType: "text/plain"} string {
-        return "yo";
-    }
-
-    isolated remote function greeting() returns string {
-        return "Hello";
-    }
-
-    function hello2() returns string {
-        return "yo";
-    }
-
-    remote function greeting2() returns string|http:Response {
-        return "Hello";
-    }
-}
-
-service http:Service on new http:Listener(9091) {
-    remote function greeting2(http:Caller caller) {
+    resource function get path1(http:Caller caller) returns @http:Payload{mediaType: ""} string {
+        return "";
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
@@ -31,6 +31,8 @@ public class Constants {
     public static final String REQUEST_OBJ_NAME = "Request";
     public static final String REQUEST_CONTEXT_OBJ_NAME = "RequestContext";
     public static final String HEADER_OBJ_NAME = "Headers";
+    public static final String PAYLOAD_ANNOTATION = "Payload";
+    public static final String CACHE_ANNOTATION = "Cache";
     public static final String SERVICE_CONFIG_ANNOTATION = "ServiceConfig";
     public static final String MEDIA_TYPE_SUBTYPE_PREFIX = "mediaTypeSubtypePrefix";
     public static final String RESOURCE_CONFIG_ANNOTATION = "ResourceConfig";

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpCompilerPlugin.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpCompilerPlugin.java
@@ -23,6 +23,8 @@ import io.ballerina.projects.plugins.CompilerPluginContext;
 import io.ballerina.projects.plugins.codeaction.CodeAction;
 import io.ballerina.stdlib.http.compiler.codeaction.AddHeaderParameterCodeAction;
 import io.ballerina.stdlib.http.compiler.codeaction.AddPayloadParameterCodeAction;
+import io.ballerina.stdlib.http.compiler.codeaction.AddResponseCacheConfigCodeAction;
+import io.ballerina.stdlib.http.compiler.codeaction.AddResponseContentTypeCodeAction;
 import io.ballerina.stdlib.http.compiler.codeaction.ChangeHeaderParamTypeToStringArrayCodeAction;
 import io.ballerina.stdlib.http.compiler.codeaction.ChangeHeaderParamTypeToStringCodeAction;
 import io.ballerina.stdlib.http.compiler.codeaction.ChangeReturnTypeWithCallerCodeAction;
@@ -46,7 +48,9 @@ public class HttpCompilerPlugin extends CompilerPlugin {
                 new ChangeHeaderParamTypeToStringArrayCodeAction(),
                 new ChangeReturnTypeWithCallerCodeAction(),
                 new AddPayloadParameterCodeAction(),
-                new AddHeaderParameterCodeAction()
+                new AddHeaderParameterCodeAction(),
+                new AddResponseContentTypeCodeAction(),
+                new AddResponseCacheConfigCodeAction()
         );
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
@@ -76,8 +76,13 @@ public enum HttpDiagnosticCodes {
             "'default', but found '%s'", ERROR),
     HTTP_129("HTTP_129", "invalid usage of payload annotation for a non entity body resource : '%s'. " +
             "Use an accessor that supports entity body", ERROR),
+    HTTP_130("HTTP_130", "invalid usage of cache annotation with return type : '%s'. " +
+            "Cache annotation only supports return types of anydata and SuccessStatusCodeResponse", ERROR),
+    HTTP_131("HTTP_131", "invalid usage of payload annotation with return type : '%s'", ERROR),
     HTTP_HINT_101("HTTP_HINT_101", "Payload annotation can be added", INTERNAL),
-    HTTP_HINT_102("HTTP_HINT_102", "Header annotation can be added", INTERNAL);
+    HTTP_HINT_102("HTTP_HINT_102", "Header annotation can be added", INTERNAL),
+    HTTP_HINT_103("HTTP_HINT_103", "Response content-type can be added", INTERNAL),
+    HTTP_HINT_104("HTTP_HINT_104", "Response cache configuration can be added", INTERNAL);
 
     private final String code;
     private final String message;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
@@ -70,8 +70,6 @@ import static io.ballerina.stdlib.http.compiler.Constants.REQUEST_CONTEXT_OBJ_NA
 import static io.ballerina.stdlib.http.compiler.Constants.REQUEST_OBJ_NAME;
 import static io.ballerina.stdlib.http.compiler.Constants.RESOURCE_CONFIG_ANNOTATION;
 import static io.ballerina.stdlib.http.compiler.Constants.RESPONSE_OBJ_NAME;
-import static io.ballerina.stdlib.http.compiler.HttpDiagnosticCodes.HTTP_HINT_101;
-import static io.ballerina.stdlib.http.compiler.HttpDiagnosticCodes.HTTP_HINT_102;
 
 /**
  * Validates a ballerina http resource.
@@ -96,7 +94,7 @@ class HttpResourceValidator {
                 Node annotReference = annotation.annotReference();
                 String annotName = annotReference.toString();
                 if (annotReference.kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE) {
-                    String[] strings = annotName.split(":");
+                    String[] strings = annotName.split(Constants.COLON);
                     if (RESOURCE_CONFIG_ANNOTATION.equals(strings[strings.length - 1].trim())) {
                         continue;
                     }
@@ -456,28 +454,28 @@ class HttpResourceValidator {
             }
         }
         if (resourceMethodOptional.isPresent() && !payloadAnnotationPresent) {
-            enableAddPayloadParamCodeAction(ctx, member.location(), resourceMethodOptional.get());
+            enableAddPayloadParamCodeAction(ctx, member.functionSignature().location(), resourceMethodOptional.get());
         }
         if (!headerAnnotationPresent) {
-            enableAddHeaderParamCodeAction(ctx, member.location());
+            enableAddHeaderParamCodeAction(ctx, member.functionSignature().location());
         }
     }
 
     private static void enableAddPayloadParamCodeAction(SyntaxNodeAnalysisContext ctx, Location location,
                                                         String methodName) {
         if (!methodName.equals(GET) && !methodName.equals(HEAD) && !methodName.equals(OPTIONS)) {
-            HttpCompilerPluginUtil.updateDiagnostic(ctx, location, HTTP_HINT_101);
+            HttpCompilerPluginUtil.updateDiagnostic(ctx, location, HttpDiagnosticCodes.HTTP_HINT_101);
         }
     }
 
     private static void enableAddHeaderParamCodeAction(SyntaxNodeAnalysisContext ctx, Location location) {
-        HttpCompilerPluginUtil.updateDiagnostic(ctx, location, HTTP_HINT_102);
+        HttpCompilerPluginUtil.updateDiagnostic(ctx, location, HttpDiagnosticCodes.HTTP_HINT_102);
     }
 
     private static void validatePayloadAnnotationUsage(SyntaxNodeAnalysisContext ctx, Location location,
                                                        String methodName) {
         if (methodName.equals(GET) || methodName.equals(HEAD) || methodName.equals(OPTIONS)) {
-            reportInvalidUsageOfPayloadAnnotation(ctx, location, methodName);
+            reportInvalidUsageOfPayloadAnnotation(ctx, location, methodName, HttpDiagnosticCodes.HTTP_129);
         }
     }
 
@@ -553,12 +551,52 @@ class HttpResourceValidator {
         }
         FunctionTypeSymbol functionTypeSymbol = ((FunctionSymbol) functionSymbol.get()).typeDescriptor();
         Optional<TypeSymbol> returnTypeSymbol = functionTypeSymbol.returnTypeDescriptor();
-        returnTypeSymbol.ifPresent(typeSymbol -> validateReturnType(ctx, returnTypeNode, returnTypeStringValue,
-                typeSymbol));
+        if (returnTypeSymbol.isEmpty()) {
+            return;
+        }
+        validateReturnType(ctx, returnTypeNode, returnTypeStringValue, returnTypeSymbol.get());
+        validateAnnotationsAndEnableCodeActions(ctx, returnTypeNode, returnTypeSymbol.get(), returnTypeStringValue,
+                                                returnTypeDescriptorNode.get());
     }
 
-    private static void validateReturnType(SyntaxNodeAnalysisContext ctx, Node node,
-                                           String returnTypeStringValue, TypeSymbol returnTypeSymbol) {
+    private static void validateAnnotationsAndEnableCodeActions(SyntaxNodeAnalysisContext ctx, Node returnTypeNode,
+                                                                TypeSymbol returnTypeSymbol, String returnTypeString,
+                                                                ReturnTypeDescriptorNode returnTypeDescriptorNode) {
+        boolean payloadAnnotationPresent = false;
+        boolean cacheAnnotationPresent = false;
+        NodeList<AnnotationNode> annotations = returnTypeDescriptorNode.annotations();
+        for (AnnotationNode annotation : annotations) {
+            Node annotReference = annotation.annotReference();
+            String annotName = annotReference.toString();
+            if (annotReference.kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE) {
+                String[] strings = annotName.split(Constants.COLON);
+                if (Constants.PAYLOAD_ANNOTATION.equals(strings[strings.length - 1].trim())) {
+                    payloadAnnotationPresent = true;
+                } else if (Constants.CACHE_ANNOTATION.equals(strings[strings.length - 1].trim())) {
+                    cacheAnnotationPresent = true;
+                }
+            }
+        }
+        if (checkForSupportedReturnTypes(returnTypeSymbol)) {
+            if (!payloadAnnotationPresent) {
+                enableConfigureReturnMediaTypeCodeAction(ctx, returnTypeNode);
+            }
+            if (!cacheAnnotationPresent) {
+                enableResponseCacheConfigCodeAction(ctx, returnTypeNode);
+            }
+        } else {
+            if (payloadAnnotationPresent) {
+                reportInvalidUsageOfPayloadAnnotation(ctx, returnTypeNode.location(), returnTypeString,
+                        HttpDiagnosticCodes.HTTP_131);
+            }
+            if (cacheAnnotationPresent) {
+                reportInvalidUsageOfCacheAnnotation(ctx, returnTypeNode.location(), returnTypeString);
+            }
+        }
+    }
+
+    private static void validateReturnType(SyntaxNodeAnalysisContext ctx, Node node, String returnTypeStringValue,
+                                           TypeSymbol returnTypeSymbol) {
         TypeDescKind kind = returnTypeSymbol.typeKind();
         if (isBasicTypeDesc(kind) || kind == TypeDescKind.ERROR || kind == TypeDescKind.NIL) {
             return;
@@ -614,6 +652,35 @@ class HttpResourceValidator {
         } else {
             reportInvalidReturnType(ctx, node, typeStringValue);
         }
+    }
+
+    private static void enableConfigureReturnMediaTypeCodeAction(SyntaxNodeAnalysisContext ctx, Node node) {
+        HttpCompilerPluginUtil.updateDiagnostic(ctx, node.location(), HttpDiagnosticCodes.HTTP_HINT_103);
+    }
+
+    private static void enableResponseCacheConfigCodeAction(SyntaxNodeAnalysisContext ctx, Node node) {
+        HttpCompilerPluginUtil.updateDiagnostic(ctx, node.location(), HttpDiagnosticCodes.HTTP_HINT_104);
+    }
+
+    private static boolean checkForSupportedReturnTypes(TypeSymbol returnTypeSymbol) {
+        TypeDescKind kind = returnTypeSymbol.typeKind();
+        if (kind == TypeDescKind.ERROR || kind == TypeDescKind.NIL) {
+            return false;
+        }
+        if (kind == TypeDescKind.UNION) {
+            List<TypeSymbol> typeSymbols = ((UnionTypeSymbol) returnTypeSymbol).memberTypeDescriptors();
+            if (typeSymbols.size() == 2) {
+                return checkForSupportedReturnTypes(typeSymbols.get(0))
+                        || checkForSupportedReturnTypes(typeSymbols.get(1));
+            }
+        } else if (kind == TypeDescKind.TYPE_REFERENCE) {
+            TypeSymbol typeDescriptor = ((TypeReferenceTypeSymbol) returnTypeSymbol).typeDescriptor();
+            TypeDescKind typeDescKind = retrieveEffectiveTypeDesc(typeDescriptor);
+            if (typeDescKind == TypeDescKind.ERROR) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static TypeDescKind retrieveEffectiveTypeDesc(TypeSymbol descriptor) {
@@ -769,7 +836,12 @@ class HttpResourceValidator {
     }
 
     private static void reportInvalidUsageOfPayloadAnnotation(SyntaxNodeAnalysisContext ctx, Location location,
-                                                              String methodName) {
-        HttpCompilerPluginUtil.updateDiagnostic(ctx, location, methodName, HttpDiagnosticCodes.HTTP_129);
+                                                              String name, HttpDiagnosticCodes code) {
+        HttpCompilerPluginUtil.updateDiagnostic(ctx, location, name, code);
+    }
+
+    private static void reportInvalidUsageOfCacheAnnotation(SyntaxNodeAnalysisContext ctx, Location location,
+                                                            String returnType) {
+        HttpCompilerPluginUtil.updateDiagnostic(ctx, location, returnType, HttpDiagnosticCodes.HTTP_130);
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/AddResponseCacheConfigCodeAction.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/AddResponseCacheConfigCodeAction.java
@@ -1,0 +1,76 @@
+package io.ballerina.stdlib.http.compiler.codeaction;
+
+import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.plugins.codeaction.CodeAction;
+import io.ballerina.projects.plugins.codeaction.CodeActionArgument;
+import io.ballerina.projects.plugins.codeaction.CodeActionContext;
+import io.ballerina.projects.plugins.codeaction.CodeActionExecutionContext;
+import io.ballerina.projects.plugins.codeaction.CodeActionInfo;
+import io.ballerina.projects.plugins.codeaction.DocumentEdit;
+import io.ballerina.stdlib.http.compiler.HttpDiagnosticCodes;
+import io.ballerina.tools.text.LineRange;
+import io.ballerina.tools.text.TextDocument;
+import io.ballerina.tools.text.TextDocumentChange;
+import io.ballerina.tools.text.TextEdit;
+import io.ballerina.tools.text.TextRange;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * CodeAction to add response cache configuration.
+ */
+public class AddResponseCacheConfigCodeAction implements CodeAction {
+    @Override
+    public List<String> supportedDiagnosticCodes() {
+        return List.of(HttpDiagnosticCodes.HTTP_HINT_104.getCode());
+    }
+
+    @Override
+    public Optional<CodeActionInfo> codeActionInfo(CodeActionContext context) {
+        NonTerminalNode node = CodeActionUtil.findNode(context.currentDocument().syntaxTree(),
+                context.diagnostic().location().lineRange());
+        if (node == null || node.parent().kind() != SyntaxKind.RETURN_TYPE_DESCRIPTOR) {
+            return Optional.empty();
+        }
+
+        CodeActionArgument locationArg = CodeActionArgument.from(CodeActionUtil.NODE_LOCATION_KEY,
+                node.location().lineRange());
+        return Optional.of(CodeActionInfo.from("Add response cache configuration", List.of(locationArg)));
+    }
+
+    @Override
+    public List<DocumentEdit> execute(CodeActionExecutionContext context) {
+        LineRange lineRange = null;
+        for (CodeActionArgument arg : context.arguments()) {
+            if (CodeActionUtil.NODE_LOCATION_KEY.equals(arg.key())) {
+                lineRange = arg.valueAs(LineRange.class);
+            }
+        }
+        if (lineRange == null) {
+            return Collections.emptyList();
+        }
+
+        SyntaxTree syntaxTree = context.currentDocument().syntaxTree();
+        NonTerminalNode node = CodeActionUtil.findNode(syntaxTree, lineRange);
+
+        String mediaTypedPayload = "@http:Cache ";
+        int start = node.position();
+        TextRange textRange = TextRange.from(start, 0);
+
+        List<TextEdit> textEdits = new ArrayList<>();
+        textEdits.add(TextEdit.from(textRange, mediaTypedPayload));
+        TextDocumentChange change = TextDocumentChange.from(textEdits.toArray(new TextEdit[0]));
+        TextDocument modifiedTextDocument = syntaxTree.textDocument().apply(change);
+        return Collections.singletonList(new DocumentEdit(context.fileUri(), SyntaxTree.from(modifiedTextDocument)));
+    }
+
+    @Override
+    public String name() {
+        return "ADD_RESPONSE_CACHE_CONFIG";
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/AddResponseCacheConfigCodeAction.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/AddResponseCacheConfigCodeAction.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.ballerina.stdlib.http.compiler.codeaction;
 
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
@@ -58,12 +76,12 @@ public class AddResponseCacheConfigCodeAction implements CodeAction {
         SyntaxTree syntaxTree = context.currentDocument().syntaxTree();
         NonTerminalNode node = CodeActionUtil.findNode(syntaxTree, lineRange);
 
-        String mediaTypedPayload = "@http:Cache ";
+        String cacheConfig = "@http:Cache ";
         int start = node.position();
         TextRange textRange = TextRange.from(start, 0);
 
         List<TextEdit> textEdits = new ArrayList<>();
-        textEdits.add(TextEdit.from(textRange, mediaTypedPayload));
+        textEdits.add(TextEdit.from(textRange, cacheConfig));
         TextDocumentChange change = TextDocumentChange.from(textEdits.toArray(new TextEdit[0]));
         TextDocument modifiedTextDocument = syntaxTree.textDocument().apply(change);
         return Collections.singletonList(new DocumentEdit(context.fileUri(), SyntaxTree.from(modifiedTextDocument)));

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/AddResponseContentTypeCodeAction.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/AddResponseContentTypeCodeAction.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.ballerina.stdlib.http.compiler.codeaction;
 
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/AddResponseContentTypeCodeAction.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codeaction/AddResponseContentTypeCodeAction.java
@@ -1,0 +1,76 @@
+package io.ballerina.stdlib.http.compiler.codeaction;
+
+import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.plugins.codeaction.CodeAction;
+import io.ballerina.projects.plugins.codeaction.CodeActionArgument;
+import io.ballerina.projects.plugins.codeaction.CodeActionContext;
+import io.ballerina.projects.plugins.codeaction.CodeActionExecutionContext;
+import io.ballerina.projects.plugins.codeaction.CodeActionInfo;
+import io.ballerina.projects.plugins.codeaction.DocumentEdit;
+import io.ballerina.stdlib.http.compiler.HttpDiagnosticCodes;
+import io.ballerina.tools.text.LineRange;
+import io.ballerina.tools.text.TextDocument;
+import io.ballerina.tools.text.TextDocumentChange;
+import io.ballerina.tools.text.TextEdit;
+import io.ballerina.tools.text.TextRange;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * CodeAction to add response content-type.
+ */
+public class AddResponseContentTypeCodeAction implements CodeAction {
+    @Override
+    public List<String> supportedDiagnosticCodes() {
+        return List.of(HttpDiagnosticCodes.HTTP_HINT_103.getCode());
+    }
+
+    @Override
+    public Optional<CodeActionInfo> codeActionInfo(CodeActionContext context) {
+        NonTerminalNode node = CodeActionUtil.findNode(context.currentDocument().syntaxTree(),
+                context.diagnostic().location().lineRange());
+        if (node == null || node.parent().kind() != SyntaxKind.RETURN_TYPE_DESCRIPTOR) {
+            return Optional.empty();
+        }
+
+        CodeActionArgument locationArg = CodeActionArgument.from(CodeActionUtil.NODE_LOCATION_KEY,
+                node.location().lineRange());
+        return Optional.of(CodeActionInfo.from("Add response content-type", List.of(locationArg)));
+    }
+
+    @Override
+    public List<DocumentEdit> execute(CodeActionExecutionContext context) {
+        LineRange lineRange = null;
+        for (CodeActionArgument arg : context.arguments()) {
+            if (CodeActionUtil.NODE_LOCATION_KEY.equals(arg.key())) {
+                lineRange = arg.valueAs(LineRange.class);
+            }
+        }
+        if (lineRange == null) {
+            return Collections.emptyList();
+        }
+
+        SyntaxTree syntaxTree = context.currentDocument().syntaxTree();
+        NonTerminalNode node = CodeActionUtil.findNode(syntaxTree, lineRange);
+
+        String mediaTypedPayload = "@http:Payload{mediaType: \"\"} ";
+        int start = node.position();
+        TextRange textRange = TextRange.from(start, 0);
+
+        List<TextEdit> textEdits = new ArrayList<>();
+        textEdits.add(TextEdit.from(textRange, mediaTypedPayload));
+        TextDocumentChange change = TextDocumentChange.from(textEdits.toArray(new TextEdit[0]));
+        TextDocument modifiedTextDocument = syntaxTree.textDocument().apply(change);
+        return Collections.singletonList(new DocumentEdit(context.fileUri(), SyntaxTree.from(modifiedTextDocument)));
+    }
+
+    @Override
+    public String name() {
+        return "ADD_RESPONSE_CONTENT_TYPE";
+    }
+}


### PR DESCRIPTION
## Purpose

The following two code-actions are introduced for resource return type :
1. `Add response content-type` : will add `@http:Payload{mediaType: ""}` annotation to return type

2. `Add response cache configuration` : will add `@http:Cache` annotation to return type

> Fixes [`Create code-actions to add annotations for resource return statement #2662`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2662)

> **Note :** The `Add response content-type` code-action can be further improved by adding the default content-type correspond to the return type

In addition to the code-actions the following compiler errors are also introduced : 
1. Using `@http:Cache` with return type : `error` (or `error?`) will return the following compiler error : 
`invalid usage of cache annotation with return type : 'error'. Cache annotation only supports return types of anydata and SuccessStatusCodeResponse `

> Fixes [`@http:CacheConfig should returns a compiler error when the return type is an error #1825`](https://github.com/ballerina-platform/ballerina-standard-library/issues/1825)

2. Using `@http:Payload` with return type : `error` (or `error?`) will return the following compiler error : 
`invalid usage of payload annotation with return type : 'error'`

## Example

**Code Actions :**

![Feb-11-2022 13-02-51](https://user-images.githubusercontent.com/63336800/153552951-264669ed-391c-499f-b238-ac52c3762c4c.gif)

**Compiler Errors :**

```ballerina
import ballerina/http;

service / on new http:Listener(8080) {

    // invalid usage of cache annotation with return type : error. Cache annotation only supports
    // return types of anydata and SuccessStatusCodeResponse
    resource function get helloError() returns @http:Cache error {
        return error("hello");
    }
    
    // invalid usage of payload annotation with return type : error
    resource function get heyError() returns @http:Payload{mediaType: "mediaType"} error {
        return error("hey");
    }
   
    // invalid usage of payload annotation with return type : error?
    // invalid usage of cache annotation with return type : error?. Cache annotation only supports
    // return types of anydata and SuccessStatusCodeResponse
    resource function get greeting(http:Caller caller) returns @http:Payload{mediaType: "mediaType"} 
            @http:Cache error? {
        check caller->respond("Greetings!");
    }
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests