### PR TITLE
Return error for request interceptors without resource function

### DIFF
--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -444,8 +444,8 @@ public class CompilerPluginTest {
                 " path: '[string... path]', but found '[string path]'", HTTP_127);
         assertError(diagnosticResult, 9, "invalid usage of payload annotation for a non entity body " +
                 "resource : 'get'. Use an accessor that supports entity body", HTTP_129);
-        assertError(diagnosticResult, 10, "RequestInterceptor should have a resource method", HTTP_132);
-        assertError(diagnosticResult, 11, "RequestErrorInterceptor should have a resource method",
+        assertError(diagnosticResult, 10, "RequestInterceptor must have a resource method", HTTP_132);
+        assertError(diagnosticResult, 11, "RequestErrorInterceptor must have a resource method",
                 HTTP_132);
     }
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -74,6 +74,7 @@ public class CompilerPluginTest {
     private static final String HTTP_129 = "HTTP_129";
     private static final String HTTP_130 = "HTTP_130";
     private static final String HTTP_131 = "HTTP_131";
+    private static final String HTTP_132 = "HTTP_132";
 
     private static final String REMOTE_METHODS_NOT_ALLOWED = "remote methods are not allowed in http:Service";
 
@@ -423,7 +424,7 @@ public class CompilerPluginTest {
         Package currentPackage = loadPackage("sample_package_19");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
-        Assert.assertEquals(diagnosticResult.errorCount(), 10);
+        Assert.assertEquals(diagnosticResult.errorCount(), 12);
         assertError(diagnosticResult, 0, "invalid multiple interceptor type reference: " +
                 "'http:RequestErrorInterceptor'", HTTP_123);
         assertError(diagnosticResult, 1, "invalid interceptor resource path: expected default resource" +
@@ -443,6 +444,9 @@ public class CompilerPluginTest {
                 " path: '[string... path]', but found '[string path]'", HTTP_127);
         assertError(diagnosticResult, 9, "invalid usage of payload annotation for a non entity body " +
                 "resource : 'get'. Use an accessor that supports entity body", HTTP_129);
+        assertError(diagnosticResult, 10, "RequestInterceptor should have a resource method", HTTP_132);
+        assertError(diagnosticResult, 11, "RequestErrorInterceptor should have a resource method",
+                HTTP_132);
     }
 
     @Test

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_19/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_19/service.bal
@@ -173,3 +173,11 @@ service class InterceptorService15 {
         return ctx.next();
     }
 }
+
+service class InterceptorService16 {
+    *http:RequestInterceptor;
+}
+
+service class InterceptorService17 {
+    *http:RequestErrorInterceptor;
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
@@ -79,6 +79,7 @@ public enum HttpDiagnosticCodes {
     HTTP_130("HTTP_130", "invalid usage of cache annotation with return type : '%s'. " +
             "Cache annotation only supports return types of anydata and SuccessStatusCodeResponse", ERROR),
     HTTP_131("HTTP_131", "invalid usage of payload annotation with return type : '%s'", ERROR),
+    HTTP_132("HTTP_132", "%s should have a resource method", ERROR),
     HTTP_HINT_101("HTTP_HINT_101", "Payload annotation can be added", INTERNAL),
     HTTP_HINT_102("HTTP_HINT_102", "Header annotation can be added", INTERNAL),
     HTTP_HINT_103("HTTP_HINT_103", "Response content-type can be added", INTERNAL),

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
@@ -79,7 +79,7 @@ public enum HttpDiagnosticCodes {
     HTTP_130("HTTP_130", "invalid usage of cache annotation with return type : '%s'. " +
             "Cache annotation only supports return types of anydata and SuccessStatusCodeResponse", ERROR),
     HTTP_131("HTTP_131", "invalid usage of payload annotation with return type : '%s'", ERROR),
-    HTTP_132("HTTP_132", "%s should have a resource method", ERROR),
+    HTTP_132("HTTP_132", "%s must have a resource method", ERROR),
     HTTP_HINT_101("HTTP_HINT_101", "Payload annotation can be added", INTERNAL),
     HTTP_HINT_102("HTTP_HINT_102", "Header annotation can be added", INTERNAL),
     HTTP_HINT_103("HTTP_HINT_103", "Response content-type can be added", INTERNAL),

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpInterceptorServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpInterceptorServiceValidator.java
@@ -106,6 +106,8 @@ public class HttpInterceptorServiceValidator implements AnalysisTask<SyntaxNodeA
         }
         if (resourceFunctionNode != null) {
             HttpInterceptorResourceValidator.validateResource(ctx, resourceFunctionNode, type);
+        } else {
+            reportResourceFunctionNotFound(ctx, type);
         }
     }
 
@@ -119,5 +121,9 @@ public class HttpInterceptorServiceValidator implements AnalysisTask<SyntaxNodeA
         DiagnosticInfo diagnosticInfo = new DiagnosticInfo(HttpDiagnosticCodes.HTTP_124.getCode(),
                 HttpDiagnosticCodes.HTTP_124.getMessage(), HttpDiagnosticCodes.HTTP_124.getSeverity());
         ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(diagnosticInfo, node.location()));
+    }
+
+    private static void reportResourceFunctionNotFound(SyntaxNodeAnalysisContext ctx, String type) {
+        HttpCompilerPluginUtil.updateDiagnostic(ctx, ctx.node().location(), type, HttpDiagnosticCodes.HTTP_132);
     }
 }


### PR DESCRIPTION
## Purpose

> $Subject

> Fixes [`Compiler error should be returned for request interceptors without resource function #2693`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2693)

## Examples

```ballerina
import ballerina/http;

service class RequestInterceptor1 {
    *http:RequestInterceptor;
}

RequestInterceptor1  requestInterceptor1 = new;

listener http:Listener interceptorListener = new http:Listener(9090, config = { 
    interceptors: [requestInterceptor1] 
});

service / on interceptorListener {

    resource function get greeting() returns string {
        return "Greetings!";
    }
}
```

```
Compiling source
        test1.bal

ERROR : RequestInterceptor must have a resource method

```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests