### PR TITLE
Add more tests and minor bug fixes for interceptors

### DIFF
--- a/ballerina-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/tests/test_service_ports.bal
@@ -166,6 +166,7 @@ const int interceptorBasicTestsPort2 = 9616;
 const int interceptorBasicTestsPort3 = 9617;
 const int responseInterceptorReturnsErrorTestPort = 9618;
 const int interceptorReturnsStatusTestPort = 9619;
+const int interceptorExecutionOrderTestPort = 9620;
 
 //HTTP2
 const int serverPushTestPort1 = 9701;

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpResponseInterceptorUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpResponseInterceptorUnitCallback.java
@@ -84,12 +84,7 @@ public class HttpResponseInterceptorUnitCallback implements Callback {
     }
 
     public void sendFailureResponse(BError error) {
-        cleanupResponseAndContext();
         HttpUtil.handleFailure(requestMessage, error, false);
-    }
-
-    private void cleanupResponseAndContext() {
-        requestMessage.waitAndReleaseAllEntities();
     }
 
     private void printStacktraceIfError(Object result) {
@@ -146,7 +141,7 @@ public class HttpResponseInterceptorUnitCallback implements Callback {
                 } else {
                     BError err = HttpUtil.createHttpError("next interceptor service did not match " +
                             "with the configuration", HttpErrorType.GENERIC_LISTENER_ERROR);
-                    sendFailureResponse(err);
+                    invokeErrorInterceptors(err, true);
                 }
             }
         }


### PR DESCRIPTION
## Purpose
 **Bug fixes :**
- Consider the following interceptor configuration : 
     ```ballerina
      interceptors : [
         Interceptor1 : ResponseErrorInterceptor, Interceptor2 : RequestInterceptor, 
         Interceptor3 : ResponseErrorInterceptor
      ]
     ```
     When an `error` is returned from the `Interceptor2`, the execution jumps to `Interceptor1` and `Interceptor3` **will not** get executed.
- When there is a data-binding error in `RequestInterceptor` parameters, the execution jumps to the nearest `RequestErrorInterceptor`.
- When the return service from an interceptor mismatch with the configuration, those errors will also invoke the error interceptors in the pipeline. 

**Added tests :**
- Test for interceptor execution order. 
- Tests for interceptors return `StatusCodeResponse` and `string`
- Tests for the above bug fixes.

## Examples
N/A

## Checklist
- [ ] <s>Linked to an issue</s>
- [ ] <s>Updated the changelog</s>
- [x] Added tests
- [ ] <s>Updated the spec</s>
