### PR TITLE
Add `handleFailure` API back

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -453,6 +453,11 @@ public class HttpUtil {
         return responseFuture;
     }
 
+    public static void handleFailure(HttpCarbonMessage requestMessage, String errorMsg) {
+        int statusCode = getStatusCode(requestMessage, errorMsg);
+        PipeliningHandler.sendPipelinedResponse(requestMessage, createErrorMessage(errorMsg, statusCode));
+    }
+
     public static void handleFailure(HttpCarbonMessage requestMessage, BError error, Boolean printStackTrace) {
         String errorMsg = getErrorMessage(error);
         int statusCode = getStatusCode(requestMessage, errorMsg);


### PR DESCRIPTION
## Purpose

Add `handleFailure(HttpCarbonMessage requestMessage, String errorMsg)` API back, since it is accidentally removed in interceptor implementation which causes build failure in gRPC
```
/home/runner/work/ballerina-release/ballerina-release/module-ballerina-grpc/
native/src/main/java/io/ballerina/stdlib/grpc/ServerConnectorListener.java:81: 
error: method handleFailure in class HttpUtil cannot be applied to given types;
                HttpUtil.handleFailure(inboundMessage, ex.getMessage());
                        ^
  required: HttpCarbonMessage,BError,Boolean
  found: HttpCarbonMessage,String
```

## Examples
N/A

## Checklist
- [ ] <s>Linked to an issue</s>
- [ ] <s>Updated the changelog</s>
- [ ] <s>Added tests</s>
- [ ] <s>Updated the spec</s>
