### PR TITLE
Introduce `DefaultErrorInterceptor`

### DIFF
--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -328,7 +328,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.2"
+version = "1.0.3"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -256,7 +256,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/http_interceptors.bal
+++ b/ballerina/http_interceptors.bal
@@ -37,4 +37,17 @@ public type ResponseErrorInterceptor distinct service object {
 # The return type of an interceptor service function
 public type NextService RequestInterceptor|ResponseInterceptor|Service;
 
+# Types of HTTP interceptor services
 public type Interceptor RequestInterceptor|ResponseInterceptor|RequestErrorInterceptor|ResponseErrorInterceptor;
+
+// Default error interceptors to handle all the unhandled errors
+service class DefaultErrorInterceptor {
+    *ResponseErrorInterceptor;
+
+    remote function interceptResponseError(error err, Response alreadyBuiltErrorResponse) returns Response {
+        // Returning the already built response for simplicity. This has been built with proper 
+        // status code and headers (for `ApplicationResponseError` types)
+        // For any other custom responses the `err` object can be used with type check
+        return alreadyBuiltErrorResponse;
+    }
+}

--- a/ballerina/http_service_endpoint.bal
+++ b/ballerina/http_service_endpoint.bal
@@ -23,6 +23,7 @@ public isolated class Listener {
 
     private int port;
     private InferredListenerConfiguration inferredConfig;
+    private Interceptor[] interceptors;
 
     # Gets invoked during module initialization to initialize the listener.
     #
@@ -39,6 +40,13 @@ public isolated class Listener {
             server: config.server,
             requestLimits: config.requestLimits
         };
+        self.interceptors = [new DefaultErrorInterceptor()];
+        Interceptor[]? interceptors = config.interceptors;
+        if interceptors is Interceptor[] {
+            foreach Interceptor interceptor in interceptors {
+                self.interceptors.push(interceptor);
+            }
+        }
         self.inferredConfig = inferredListenerConfig.cloneReadOnly();
         self.port = port;
         return externInitEndpoint(self, config);

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Allow records to be annotated with @http:Header](https://github.com/ballerina-platform/ballerina-standard-library/issues/2699)
 - [Add basic type support for header params in addition to `string`, `string[]`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2807)
 - [Allow HTTP caller to respond `error`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2832)
+- [Introduce `DefaultErrorInterceptor`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2669)
 
 ## [2.2.1] - 2022-03-02
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/BallerinaHTTPConnectorListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/BallerinaHTTPConnectorListener.java
@@ -56,12 +56,15 @@ public class BallerinaHTTPConnectorListener implements HttpConnectorListener {
     protected final List<HTTPInterceptorServicesRegistry> httpInterceptorServicesRegistries;
 
     protected final BMap endpointConfig;
+    protected final Object listenerLevelInterceptors;
 
     public BallerinaHTTPConnectorListener(HTTPServicesRegistry httpServicesRegistry,
-                        List<HTTPInterceptorServicesRegistry> httpInterceptorServicesRegistries, BMap endpointConfig) {
+                                          List<HTTPInterceptorServicesRegistry> httpInterceptorServicesRegistries,
+                                          BMap endpointConfig, Object interceptors) {
         this.httpInterceptorServicesRegistries = httpInterceptorServicesRegistries;
         this.httpServicesRegistry = httpServicesRegistry;
         this.endpointConfig = endpointConfig;
+        this.listenerLevelInterceptors = interceptors;
     }
 
     @Override
@@ -291,7 +294,7 @@ public class BallerinaHTTPConnectorListener implements HttpConnectorListener {
 
     private void setTargetServiceToInboundMsg(HttpCarbonMessage inboundMessage) {
         inboundMessage.setProperty(INTERCEPTOR_SERVICES_REGISTRIES, httpInterceptorServicesRegistries);
-        inboundMessage.setProperty(INTERCEPTORS, endpointConfig.getArrayValue(HttpConstants.ANN_INTERCEPTORS));
+        inboundMessage.setProperty(INTERCEPTORS, listenerLevelInterceptors);
         try {
             HttpService targetService = HttpDispatcher.findService(httpServicesRegistry, inboundMessage, true);
             inboundMessage.setProperty(HttpConstants.TARGET_SERVICE, targetService.getBalService());

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -384,6 +384,7 @@ public class HttpConstants {
     //Service Endpoint Config
     public static final BString ENDPOINT_CONFIG_HOST = StringUtils.fromString("host");
     public static final BString ENDPOINT_CONFIG_PORT = StringUtils.fromString("port");
+    public static final BString ENDPOINT_CONFIG_INTERCEPTORS = StringUtils.fromString("interceptors");
     public static final BString ENDPOINT_CONFIG_KEEP_ALIVE = StringUtils.fromString("keepAlive");
     public static final BString ENDPOINT_CONFIG_TIMEOUT = StringUtils.fromString("timeout");
     public static final String ENDPOINT_CONFIG_CHUNKING = "chunking";

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -132,7 +132,6 @@ import static io.ballerina.stdlib.http.api.HttpConstants.SECURESOCKET_CONFIG_PRO
 import static io.ballerina.stdlib.http.api.HttpConstants.SECURESOCKET_CONFIG_SESSION_TIMEOUT;
 import static io.ballerina.stdlib.http.api.HttpConstants.SECURESOCKET_CONFIG_TRUSTSTORE_FILE_PATH;
 import static io.ballerina.stdlib.http.api.HttpConstants.SECURESOCKET_CONFIG_TRUSTSTORE_PASSWORD;
-import static io.ballerina.stdlib.http.api.HttpConstants.SERVICE_ENDPOINT_CONFIG;
 import static io.ballerina.stdlib.http.transport.contract.Constants.ENCODING_GZIP;
 import static io.ballerina.stdlib.http.transport.contract.Constants.HTTP_1_1_VERSION;
 import static io.ballerina.stdlib.http.transport.contract.Constants.HTTP_2_0_VERSION;
@@ -1507,10 +1506,9 @@ public class HttpUtil {
     }
 
     public static void populateInterceptorServicesFromListener(BObject serviceEndpoint, Runtime runtime) {
-        BMap endpointConfig = (BMap) serviceEndpoint.getNativeData(SERVICE_ENDPOINT_CONFIG);
         Object[] interceptors = {};
         List<BObject> interceptorServices = new ArrayList<>();
-        BArray interceptorsArray = endpointConfig.getArrayValue(HttpConstants.ANN_INTERCEPTORS);
+        BArray interceptorsArray = serviceEndpoint.getArrayValue(HttpConstants.ENDPOINT_CONFIG_INTERCEPTORS);
 
         if (interceptorsArray != null) {
             interceptors = interceptorsArray.getValues();

--- a/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/connection/Respond.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/connection/Respond.java
@@ -197,7 +197,7 @@ public class Respond extends ConnectionAction {
 
             try {
                 InterceptorService service = HttpDispatcher.findInterceptorService(interceptorServicesRegistry,
-                                             inboundMessage);
+                                             inboundMessage, true);
                 if (service == null) {
                     throw new BallerinaConnectorException("no Interceptor Service found to handle the response");
                 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/endpoint/Start.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/endpoint/Start.java
@@ -66,7 +66,8 @@ public class Start extends AbstractHttpNativeFunction {
         BallerinaHTTPConnectorListener httpListener =
                 new BallerinaHTTPConnectorListener(getHttpServicesRegistry(serviceEndpoint),
                                                    getHttpInterceptorServicesRegistries(serviceEndpoint),
-                                                   (BMap) serviceEndpoint.getNativeData(SERVICE_ENDPOINT_CONFIG));
+                                                   (BMap) serviceEndpoint.getNativeData(SERVICE_ENDPOINT_CONFIG),
+                                                   serviceEndpoint.getNativeData(HttpConstants.INTERCEPTORS));
         serviceEndpoint.addNativeData(SERVER_CONNECTOR_FUTURE, serverConnectorFuture);
         HttpConnectorPortBindingListener portBindingListener = new HttpConnectorPortBindingListener();
         serverConnectorFuture.setHttpConnectorListener(httpListener);


### PR DESCRIPTION
## Purpose
Introducing `DefaultErrorInterceptor` which will handle all the unhandled errors, and return an error response.

Part of [`Proposal: Error Handling #2669`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2669)

Related to [`Move security error reporting to a default error interceptor #2823`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2823)

## Defintion

```ballerina
service class DefaultErrorInterceptor {
    *ResponseErrorInterceptor;

    remote function interceptResponseError(error err, http:Response alreadyBuiltErrorResponse) 
              returns http:Response {
        // Returning the already built response for simplicity. This has been built with proper 
        // status code and headers (for `ApplicationResponseError` types)
        // For any other custom responses the `err` object can be used with type check
        return alreadyBuiltErrorResponse;
    }
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] <s> Added tests </s>
- [ ] <s> Updated the spec </s>
