### PR TITLE
Refactor auth-desugar respond with `DefaultErrorInterceptor`

### DIFF
--- a/ballerina/auth_desugar.bal
+++ b/ballerina/auth_desugar.bal
@@ -42,12 +42,12 @@ public isolated function authenticateResource(Service serviceRef, string methodN
     if header is string {
         Unauthorized|Forbidden? result = tryAuthenticate(<ListenerAuthConfig[]>authConfig, header);
         if result is Unauthorized {
-            sendResponse(create401Response());
+            panic error ListenerAuthnError("");
         } else if result is Forbidden {
-            sendResponse(create403Response());
+            panic error ListenerAuthzError("");
         }
     } else {
-        sendResponse(create401Response());
+        panic error ListenerAuthnError("");
     }
 }
 
@@ -224,29 +224,6 @@ isolated function getResourceAuthConfig(Service serviceRef, string methodName, s
     }
     HttpResourceConfig resourceConfig = <HttpResourceConfig>resourceAnnotation;
     return resourceConfig?.auth;
-}
-
-isolated function create401Response() returns Response {
-    Response response = new;
-    response.statusCode = 401;
-    return response;
-}
-
-isolated function create403Response() returns Response {
-    Response response = new;
-    response.statusCode = 403;
-    return response;
-}
-
-isolated function sendResponse(Response response) {
-    Caller caller = getCaller();
-    error? err = caller->respond(response);
-    if err is error {
-        log:printError("Failed to respond the 401/403 request.", 'error = err);
-    }
-    // This panic is added to break the execution of the implementation inside the resource function after there is
-    // an authn/authz failure and responded with 401/403 internally.
-    panic error DesugarAuthError("Already responded by auth-desugar.");
 }
 
 isolated function getAuthorizationHeader() returns string|HeaderNotFoundError = @java:Method {

--- a/ballerina/http_errors.bal
+++ b/ballerina/http_errors.bal
@@ -56,8 +56,11 @@ public type GenericListenerError distinct ListenerError;
 # Defines the auth error types that returned from listener.
 public type ListenerAuthError distinct ListenerError;
 
-# Defines the auth-desugar error types that returned from listener.
-type DesugarAuthError distinct ListenerAuthError;
+# Defines the authentication error types that returned from listener.
+type ListenerAuthnError distinct ListenerAuthError;
+
+# Defines the authorization error types that returned from listener.
+type ListenerAuthzError distinct ListenerAuthError;
 
 # Defines the client error types that returned while sending outbound request.
 public type OutboundRequestError distinct ClientError;

--- a/ballerina/http_errors.bal
+++ b/ballerina/http_errors.bal
@@ -57,10 +57,10 @@ public type GenericListenerError distinct ListenerError;
 public type ListenerAuthError distinct ListenerError;
 
 # Defines the authentication error types that returned from listener.
-type ListenerAuthnError distinct ListenerAuthError;
+public type ListenerAuthnError distinct ListenerAuthError;
 
 # Defines the authorization error types that returned from listener.
-type ListenerAuthzError distinct ListenerAuthError;
+public type ListenerAuthzError distinct ListenerAuthError;
 
 # Defines the client error types that returned while sending outbound request.
 public type OutboundRequestError distinct ClientError;

--- a/ballerina/http_interceptors.bal
+++ b/ballerina/http_interceptors.bal
@@ -48,6 +48,15 @@ service class DefaultErrorInterceptor {
         // Returning the already built response for simplicity. This has been built with proper 
         // status code and headers (for `ApplicationResponseError` types)
         // For any other custom responses the `err` object can be used with type check
+        if err is ListenerAuthnError {
+            Response response = new;
+            response.statusCode = 401;
+            return response;
+        } else if err is ListenerAuthzError {
+            Response response = new;
+            response.statusCode = 403;
+            return response;
+        }
         return alreadyBuiltErrorResponse;
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - [Append the scheme of the HTTP client URL based on the client configurations](https://github.com/ballerina-platform/ballerina-standard-library/issues/2816)
+- [Refactor auth-desugar respond with DefaultErrorInterceptor](https://github.com/ballerina-platform/ballerina-standard-library/issues/2823)
 
 ## [2.2.1] - 2022-03-02
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
@@ -131,11 +131,6 @@ public class HttpCallableUnitCallback implements Callback {
     @Override
     public void notifyFailure(BError error) { // handles panic and check_panic
         cleanupRequestMessage();
-        // This check is added to release the failure path since there is an authn/authz failure and responded
-        // with 401/403 internally.
-        if (error.getType().getName().equals(HttpErrorType.DESUGAR_AUTH_ERROR.getErrorName())) {
-            return;
-        }
         if (alreadyResponded(error)) {
             return;
         }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpErrorType.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpErrorType.java
@@ -62,8 +62,7 @@ public enum HttpErrorType {
     SSL_ERROR("SslError"),
     INVALID_CONTENT_LENGTH("InvalidContentLengthError"),
     HEADER_NOT_FOUND_ERROR("HeaderNotFoundError"),
-    CLIENT_ERROR("ClientError"),
-    DESUGAR_AUTH_ERROR("DesugarAuthError");
+    CLIENT_ERROR("ClientError");
 
     private final String errorName;
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpRequestInterceptorUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpRequestInterceptorUnitCallback.java
@@ -65,11 +65,6 @@ public class HttpRequestInterceptorUnitCallback implements Callback {
 
     @Override
     public void notifyFailure(BError error) { // handles panic and check_panic
-        // This check is added to release the failure path since there is an authn/authz failure and responded
-        // with 401/403 internally.
-        if (error.getType().getName().equals(HttpErrorType.DESUGAR_AUTH_ERROR.getErrorName())) {
-            return;
-        }
         if (alreadyResponded()) {
             return;
         }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpResponseInterceptorUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpResponseInterceptorUnitCallback.java
@@ -68,11 +68,6 @@ public class HttpResponseInterceptorUnitCallback implements Callback {
 
     @Override
     public void notifyFailure(BError error) { // handles panic and check_panic
-        // This check is added to release the failure path since there is an authn/authz failure and responded
-        // with 401/403 internally.
-        if (error.getType().getName().equals(HttpErrorType.DESUGAR_AUTH_ERROR.getErrorName())) {
-            return;
-        }
         invokeErrorInterceptors(error, false);
     }
 


### PR DESCRIPTION
## Purpose
This PR refactor the way of handling the 401/403 error responses with the introduction of `DefaultErrorInterceptor`. The errors are now pushed into the pipeline and can be overridden with a custom error interceptor.

Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/2823

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] ~Added tests~
- [ ] ~Updated the spec~
