### PR TITLE
Hide subtypes of http:Client and move CB supportive method to the http:Client class

### DIFF
--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -19,6 +19,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"}
 ]
+modules = [
+	{org = "ballerina", packageName = "auth", moduleName = "auth"}
+]
 
 [[package]]
 org = "ballerina"
@@ -40,6 +43,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
 ]
+modules = [
+	{org = "ballerina", packageName = "crypto", moduleName = "crypto"}
+]
 
 [[package]]
 org = "ballerina"
@@ -53,6 +59,9 @@ dependencies = [
 	{org = "ballerina", name = "os"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
+]
+modules = [
+	{org = "ballerina", packageName = "file", moduleName = "file"}
 ]
 
 [[package]]
@@ -91,11 +100,23 @@ org = "ballerina"
 name = "http_tests"
 version = "2.3.0"
 dependencies = [
+	{org = "ballerina", name = "auth"},
+	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "jwt"},
+	{org = "ballerina", name = "lang.boolean"},
+	{org = "ballerina", name = "lang.float"},
+	{org = "ballerina", name = "lang.int"},
 	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "lang.string"},
+	{org = "ballerina", name = "lang.xml"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mime"},
+	{org = "ballerina", name = "oauth2"},
+	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "url"}
 ]
@@ -112,12 +133,18 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
+modules = [
+	{org = "ballerina", packageName = "io", moduleName = "io"}
+]
 
 [[package]]
 org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
 scope = "testOnly"
+modules = [
+	{org = "ballerina", packageName = "jballerina.java", moduleName = "jballerina.java"}
+]
 
 [[package]]
 org = "ballerina"
@@ -133,6 +160,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
+]
+modules = [
+	{org = "ballerina", packageName = "jwt", moduleName = "jwt"}
 ]
 
 [[package]]
@@ -157,6 +187,18 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.boolean"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.boolean", moduleName = "lang.boolean"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.decimal"
 version = "0.0.0"
 scope = "testOnly"
@@ -166,11 +208,26 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.float"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.float", moduleName = "lang.float"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.int"
 version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.int", moduleName = "lang.int"}
 ]
 
 [[package]]
@@ -214,6 +271,18 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.xml"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.xml", moduleName = "lang.xml"}
+]
+
+[[package]]
+org = "ballerina"
 name = "log"
 version = "2.2.1"
 scope = "testOnly"
@@ -253,6 +322,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "time"}
 ]
+modules = [
+	{org = "ballerina", packageName = "oauth2", moduleName = "oauth2"}
+]
 
 [[package]]
 org = "ballerina"
@@ -279,6 +351,9 @@ version = "1.2.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "regex", moduleName = "regex"}
 ]
 
 [[package]]

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -19,9 +19,6 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"}
 ]
-modules = [
-	{org = "ballerina", packageName = "auth", moduleName = "auth"}
-]
 
 [[package]]
 org = "ballerina"
@@ -43,9 +40,6 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
 ]
-modules = [
-	{org = "ballerina", packageName = "crypto", moduleName = "crypto"}
-]
 
 [[package]]
 org = "ballerina"
@@ -59,9 +53,6 @@ dependencies = [
 	{org = "ballerina", name = "os"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
-]
-modules = [
-	{org = "ballerina", packageName = "file", moduleName = "file"}
 ]
 
 [[package]]
@@ -100,23 +91,11 @@ org = "ballerina"
 name = "http_tests"
 version = "2.3.0"
 dependencies = [
-	{org = "ballerina", name = "auth"},
-	{org = "ballerina", name = "crypto"},
-	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
-	{org = "ballerina", name = "io"},
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "jwt"},
-	{org = "ballerina", name = "lang.boolean"},
-	{org = "ballerina", name = "lang.float"},
-	{org = "ballerina", name = "lang.int"},
 	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "lang.string"},
-	{org = "ballerina", name = "lang.xml"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mime"},
-	{org = "ballerina", name = "oauth2"},
-	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "url"}
 ]
@@ -133,18 +112,12 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
-modules = [
-	{org = "ballerina", packageName = "io", moduleName = "io"}
-]
 
 [[package]]
 org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
 scope = "testOnly"
-modules = [
-	{org = "ballerina", packageName = "jballerina.java", moduleName = "jballerina.java"}
-]
 
 [[package]]
 org = "ballerina"
@@ -160,9 +133,6 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
-]
-modules = [
-	{org = "ballerina", packageName = "jwt", moduleName = "jwt"}
 ]
 
 [[package]]
@@ -187,18 +157,6 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
-name = "lang.boolean"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.boolean", moduleName = "lang.boolean"}
-]
-
-[[package]]
-org = "ballerina"
 name = "lang.decimal"
 version = "0.0.0"
 scope = "testOnly"
@@ -208,26 +166,11 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
-name = "lang.float"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.float", moduleName = "lang.float"}
-]
-
-[[package]]
-org = "ballerina"
 name = "lang.int"
 version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.int", moduleName = "lang.int"}
 ]
 
 [[package]]
@@ -271,18 +214,6 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
-name = "lang.xml"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.xml", moduleName = "lang.xml"}
-]
-
-[[package]]
-org = "ballerina"
 name = "log"
 version = "2.2.1"
 scope = "testOnly"
@@ -322,9 +253,6 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "time"}
 ]
-modules = [
-	{org = "ballerina", packageName = "oauth2", moduleName = "oauth2"}
-]
 
 [[package]]
 org = "ballerina"
@@ -351,9 +279,6 @@ version = "1.2.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "regex", moduleName = "regex"}
 ]
 
 [[package]]

--- a/ballerina-tests/tests/resiliency_http_circuit_breaker_illegal_method_test.bal
+++ b/ballerina-tests/tests/resiliency_http_circuit_breaker_illegal_method_test.bal
@@ -1,0 +1,47 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+import ballerina/http;
+
+final http:Client backendClientNegative = check new("http://localhost:8086");
+
+@test:Config {}
+function testInvokingCBRelatedMethodOnNonCBClients() {
+    error? err = trap backendClientNegative.circuitBreakerForceClose();
+    if err is error {
+        test:assertEquals(err.message(), "illegal method invocation. 'circuitBreakerForceClose()' is allowed for " +
+            "clients which have configured with circuit breaker configurations", msg = "Found unexpected output");
+    } else {
+        test:assertFail(msg = "Found unexpected output type");
+    }
+
+    err = trap backendClientNegative.circuitBreakerForceOpen();
+    if err is error {
+        test:assertEquals(err.message(), "illegal method invocation. 'circuitBreakerForceOpen()' is allowed for " +
+            "clients which have configured with circuit breaker configurations", msg = "Found unexpected output");
+    } else {
+        test:assertFail(msg = "Found unexpected output type");
+    }
+
+    http:CircuitState|error state = trap backendClientNegative.getCircuitBreakerCurrentState();
+    if state is error {
+        test:assertEquals(state.message(), "illegal method invocation. 'getCircuitBreakerCurrentState()' is allowed " +
+            "for clients which have configured with circuit breaker configurations", msg = "Found unexpected output");
+    } else {
+        test:assertFail(msg = "Found unexpected output type");
+    }
+}

--- a/ballerina-tests/tests/resiliency_http_circuit_breaker_test_2.bal
+++ b/ballerina-tests/tests/resiliency_http_circuit_breaker_test_2.bal
@@ -52,9 +52,9 @@ service /cb on circuitBreakerEP01 {
     resource function 'default forceopen(http:Caller caller, http:Request request) {
         int counter = retrieveAndIncrementCounter();
         if (counter % 3 == 0) {
-            healthyClientEP.forceClose();
+            healthyClientEP.circuitBreakerForceClose();
         } else if (counter % 3 == 1) {
-            healthyClientEP.forceOpen();
+            healthyClientEP.circuitBreakerForceOpen();
         }
 
         http:Response|error backendRes = healthyClientEP->forward("/healthy", request);
@@ -64,9 +64,9 @@ service /cb on circuitBreakerEP01 {
     resource function get forceopen(http:Caller caller, http:Request request) {
         int counter = retrieveAndIncrementCounter();
         if (counter % 3 == 0) {
-            healthyClientEP.forceClose();
+            healthyClientEP.circuitBreakerForceClose();
         } else if (counter % 3 == 1) {
-            healthyClientEP.forceOpen();
+            healthyClientEP.circuitBreakerForceOpen();
         }
 
         http:Response|error backendRes = healthyClientEP->get("/healthy");
@@ -76,9 +76,9 @@ service /cb on circuitBreakerEP01 {
     resource function head forceopen(http:Caller caller, http:Request request) {
         int counter = retrieveAndIncrementCounter();
         if (counter % 3 == 0) {
-            healthyClientEP.forceClose();
+            healthyClientEP.circuitBreakerForceClose();
         } else if (counter % 3 == 1) {
-            healthyClientEP.forceOpen();
+            healthyClientEP.circuitBreakerForceOpen();
         }
         http:Response|error backendRes = healthyClientEP->head("/healthy");
         if backendRes is http:Response {
@@ -100,9 +100,9 @@ service /cb on circuitBreakerEP01 {
     resource function options forceopen(http:Caller caller, http:Request request) {
         int counter = retrieveAndIncrementCounter();
         if (counter % 3 == 0) {
-            healthyClientEP.forceClose();
+            healthyClientEP.circuitBreakerForceClose();
         } else if (counter % 3 == 1) {
-            healthyClientEP.forceOpen();
+            healthyClientEP.circuitBreakerForceOpen();
         }
         http:Response|error backendRes = healthyClientEP->options("/healthy");
         if backendRes is http:Response {
@@ -124,9 +124,9 @@ service /cb on circuitBreakerEP01 {
     resource function put forceopen(http:Caller caller, http:Request request) {
         int counter = retrieveAndIncrementCounter();
         if (counter % 3 == 0) {
-            healthyClientEP.forceClose();
+            healthyClientEP.circuitBreakerForceClose();
         } else if (counter % 3 == 1) {
-            healthyClientEP.forceOpen();
+            healthyClientEP.circuitBreakerForceOpen();
         }
 
         http:Response|error backendRes = healthyClientEP->put("/healthy", request);
@@ -136,9 +136,9 @@ service /cb on circuitBreakerEP01 {
     resource function patch forceopen(http:Caller caller, http:Request request) {
         int counter = retrieveAndIncrementCounter();
         if (counter % 3 == 0) {
-            healthyClientEP.forceClose();
+            healthyClientEP.circuitBreakerForceClose();
         } else if (counter % 3 == 1) {
-            healthyClientEP.forceOpen();
+            healthyClientEP.circuitBreakerForceOpen();
         }
 
         http:Response|error backendRes = healthyClientEP->patch("/healthy", request);
@@ -148,9 +148,9 @@ service /cb on circuitBreakerEP01 {
     resource function delete forceopen(http:Caller caller, http:Request request) {
         int counter = retrieveAndIncrementCounter();
         if (counter % 3 == 0) {
-            healthyClientEP.forceClose();
+            healthyClientEP.circuitBreakerForceClose();
         } else if (counter % 3 == 1) {
-            healthyClientEP.forceOpen();
+            healthyClientEP.circuitBreakerForceOpen();
         }
 
         http:Response|error backendRes = healthyClientEP->delete("/healthy", request);

--- a/ballerina-tests/tests/resiliency_http_circuit_breaker_test_2.bal
+++ b/ballerina-tests/tests/resiliency_http_circuit_breaker_test_2.bal
@@ -50,12 +50,11 @@ final http:Client healthyClientEP = checkpanic new("http://localhost:8087", conf
 service /cb on circuitBreakerEP01 {
 
     resource function 'default forceopen(http:Caller caller, http:Request request) {
-        http:CircuitBreakerClient cbClient = <http:CircuitBreakerClient>healthyClientEP.httpClient;
         int counter = retrieveAndIncrementCounter();
         if (counter % 3 == 0) {
-            cbClient.forceClose();
+            healthyClientEP.forceClose();
         } else if (counter % 3 == 1) {
-            cbClient.forceOpen();
+            healthyClientEP.forceOpen();
         }
 
         http:Response|error backendRes = healthyClientEP->forward("/healthy", request);
@@ -63,12 +62,11 @@ service /cb on circuitBreakerEP01 {
     }
 
     resource function get forceopen(http:Caller caller, http:Request request) {
-        http:CircuitBreakerClient cbClient = <http:CircuitBreakerClient>healthyClientEP.httpClient;
         int counter = retrieveAndIncrementCounter();
         if (counter % 3 == 0) {
-            cbClient.forceClose();
+            healthyClientEP.forceClose();
         } else if (counter % 3 == 1) {
-            cbClient.forceOpen();
+            healthyClientEP.forceOpen();
         }
 
         http:Response|error backendRes = healthyClientEP->get("/healthy");
@@ -76,12 +74,11 @@ service /cb on circuitBreakerEP01 {
     }
 
     resource function head forceopen(http:Caller caller, http:Request request) {
-        http:CircuitBreakerClient cbClient = <http:CircuitBreakerClient>healthyClientEP.httpClient;
         int counter = retrieveAndIncrementCounter();
         if (counter % 3 == 0) {
-            cbClient.forceClose();
+            healthyClientEP.forceClose();
         } else if (counter % 3 == 1) {
-            cbClient.forceOpen();
+            healthyClientEP.forceOpen();
         }
         http:Response|error backendRes = healthyClientEP->head("/healthy");
         if backendRes is http:Response {
@@ -101,12 +98,11 @@ service /cb on circuitBreakerEP01 {
     }
 
     resource function options forceopen(http:Caller caller, http:Request request) {
-        http:CircuitBreakerClient cbClient = <http:CircuitBreakerClient>healthyClientEP.httpClient;
         int counter = retrieveAndIncrementCounter();
         if (counter % 3 == 0) {
-            cbClient.forceClose();
+            healthyClientEP.forceClose();
         } else if (counter % 3 == 1) {
-            cbClient.forceOpen();
+            healthyClientEP.forceOpen();
         }
         http:Response|error backendRes = healthyClientEP->options("/healthy");
         if backendRes is http:Response {
@@ -126,12 +122,11 @@ service /cb on circuitBreakerEP01 {
     }
 
     resource function put forceopen(http:Caller caller, http:Request request) {
-        http:CircuitBreakerClient cbClient = <http:CircuitBreakerClient>healthyClientEP.httpClient;
         int counter = retrieveAndIncrementCounter();
         if (counter % 3 == 0) {
-            cbClient.forceClose();
+            healthyClientEP.forceClose();
         } else if (counter % 3 == 1) {
-            cbClient.forceOpen();
+            healthyClientEP.forceOpen();
         }
 
         http:Response|error backendRes = healthyClientEP->put("/healthy", request);
@@ -139,12 +134,11 @@ service /cb on circuitBreakerEP01 {
     }
 
     resource function patch forceopen(http:Caller caller, http:Request request) {
-        http:CircuitBreakerClient cbClient = <http:CircuitBreakerClient>healthyClientEP.httpClient;
         int counter = retrieveAndIncrementCounter();
         if (counter % 3 == 0) {
-            cbClient.forceClose();
+            healthyClientEP.forceClose();
         } else if (counter % 3 == 1) {
-            cbClient.forceOpen();
+            healthyClientEP.forceOpen();
         }
 
         http:Response|error backendRes = healthyClientEP->patch("/healthy", request);
@@ -152,12 +146,11 @@ service /cb on circuitBreakerEP01 {
     }
 
     resource function delete forceopen(http:Caller caller, http:Request request) {
-        http:CircuitBreakerClient cbClient = <http:CircuitBreakerClient>healthyClientEP.httpClient;
         int counter = retrieveAndIncrementCounter();
         if (counter % 3 == 0) {
-            cbClient.forceClose();
+            healthyClientEP.forceClose();
         } else if (counter % 3 == 1) {
-            cbClient.forceOpen();
+            healthyClientEP.forceOpen();
         }
 
         http:Response|error backendRes = healthyClientEP->delete("/healthy", request);

--- a/ballerina-tests/tests/resiliency_http_circuit_breaker_test_3.bal
+++ b/ballerina-tests/tests/resiliency_http_circuit_breaker_test_3.bal
@@ -43,7 +43,6 @@ final http:Client unhealthyClientEP = check new("http://localhost:8088", conf02)
 service /cb on circuitBreakerEP02 {
 
     isolated resource function 'default forceclose(http:Caller caller, http:Request request) {
-        http:CircuitBreakerClient cbClient = <http:CircuitBreakerClient>unhealthyClientEP.httpClient;
         lock {
             forceCloseStateCount = forceCloseStateCount + 1;
         }
@@ -54,7 +53,7 @@ service /cb on circuitBreakerEP02 {
         }
         if (count == 4) {
             runtime:sleep(5);
-            cbClient.forceClose();
+            unhealthyClientEP.forceClose();
         }
         http:Response|error backendRes = unhealthyClientEP->forward("/unhealthy", request);
         if backendRes is http:Response {

--- a/ballerina-tests/tests/resiliency_http_circuit_breaker_test_3.bal
+++ b/ballerina-tests/tests/resiliency_http_circuit_breaker_test_3.bal
@@ -53,7 +53,7 @@ service /cb on circuitBreakerEP02 {
         }
         if (count == 4) {
             runtime:sleep(5);
-            unhealthyClientEP.forceClose();
+            unhealthyClientEP.circuitBreakerForceClose();
         }
         http:Response|error backendRes = unhealthyClientEP->forward("/unhealthy", request);
         if backendRes is http:Response {

--- a/ballerina-tests/tests/resiliency_http_circuit_breaker_test_4.bal
+++ b/ballerina-tests/tests/resiliency_http_circuit_breaker_test_4.bal
@@ -40,9 +40,8 @@ final http:Client simpleClientEP = check new("http://localhost:8089", conf03);
 service /cb on circuitBreakerEP03 {
 
     resource function 'default getstate(http:Caller caller, http:Request request) {
-        http:CircuitBreakerClient cbClient = <http:CircuitBreakerClient>simpleClientEP.httpClient;
         http:Response|error backendRes = simpleClientEP->forward("/simple", request);
-        http:CircuitState currentState = cbClient.getCurrentState();
+        http:CircuitState currentState = simpleClientEP.getCurrentState();
         if backendRes is http:Response {
             if (!(currentState == http:CB_CLOSED_STATE)) {
                 backendRes.setPayload("Circuit Breaker is not in correct state state");

--- a/ballerina-tests/tests/resiliency_http_circuit_breaker_test_4.bal
+++ b/ballerina-tests/tests/resiliency_http_circuit_breaker_test_4.bal
@@ -41,7 +41,7 @@ service /cb on circuitBreakerEP03 {
 
     resource function 'default getstate(http:Caller caller, http:Request request) {
         http:Response|error backendRes = simpleClientEP->forward("/simple", request);
-        http:CircuitState currentState = simpleClientEP.getCurrentState();
+        http:CircuitState currentState = simpleClientEP.getCircuitBreakerCurrentState();
         if backendRes is http:Response {
             if (!(currentState == http:CB_CLOSED_STATE)) {
                 backendRes.setPayload("Circuit Breaker is not in correct state state");

--- a/ballerina/caching_http_caching_client.bal
+++ b/ballerina/caching_http_caching_client.bal
@@ -23,7 +23,7 @@ import ballerina/time;
 # + httpClient - The underlying `HttpActions` instance which will be making the actual network calls
 # + cache - The cache storage for the HTTP responses
 # + cacheConfig - Configurations for the underlying cache storage and for controlling the HTTP caching behaviour
-public client isolated class HttpCachingClient {
+client isolated class HttpCachingClient {
 
     private final HttpClient httpClient;
     private final HttpCache cache;

--- a/ballerina/cookie_http_client.bal
+++ b/ballerina/cookie_http_client.bal
@@ -27,7 +27,7 @@ type CookieInferredConfig record {|
 # + cookieConfig - Configurations associated with the cookies
 # + httpClient - HTTP client for outbound HTTP requests
 # + cookieStore - Stores the cookies of the client
-public client isolated class CookieClient {
+client isolated class CookieClient {
 
     private final string url;
     private final CookieInferredConfig & readonly cookieConfig;

--- a/ballerina/http_client.bal
+++ b/ballerina/http_client.bal
@@ -18,7 +18,7 @@ import ballerina/jballerina.java;
 
 # Lies inside every type of client in the chain holding the native client connector. More complex and specific
 # endpoint types are created by wrapping this generic HTTP actions implementation internally.
-public client isolated class HttpClient {
+client isolated class HttpClient {
 
     # Gets invoked to initialize the native `client`. During the initialization, the configurations are provided through the
     # `config`. The `HttpClient` lies inside every type of client in the chain holding the native client connector.

--- a/ballerina/http_commons.bal
+++ b/ballerina/http_commons.bal
@@ -185,7 +185,7 @@ isolated function populateHeaders(Request request, map<string|string[]>? headers
 # + httpClient - HTTP client which uses to call the relevant functions
 # + verb - HTTP verb used for submit method
 # + return - The response for the request or an `http:ClientError` if failed to establish communication with the upstream server
-public isolated function invokeEndpoint (string path, Request outRequest, HttpOperation requestAction, HttpClient httpClient,
+isolated function invokeEndpoint (string path, Request outRequest, HttpOperation requestAction, HttpClient httpClient,
         string verb = "") returns  HttpResponse|ClientError {
 
     if HTTP_GET == requestAction {

--- a/ballerina/http_secure_client.bal
+++ b/ballerina/http_secure_client.bal
@@ -18,7 +18,7 @@
 # schemes configured in the HTTP client endpoint to secure the HTTP requests.
 #
 # + httpClient - The underlying `HttpActions` instance, which will make the actual network calls
-public client isolated class HttpSecureClient {
+client isolated class HttpSecureClient {
 
     private final HttpClient httpClient;
     private final ClientAuthHandler clientAuthHandler;

--- a/ballerina/redirect_http_client.bal
+++ b/ballerina/redirect_http_client.bal
@@ -40,7 +40,7 @@ type RedirectInferredConfig record {|
 # + redirectConfig - Configurations associated with redirect
 # + httpClient - HTTP client for outbound HTTP requests
 # + currentRedirectCount - Current redirect count of the HTTP client
-public client isolated class RedirectClient {
+client isolated class RedirectClient {
 
     final string url;
     private final RedirectInferredConfig config;

--- a/ballerina/resiliency_http_circuit_breaker.bal
+++ b/ballerina/resiliency_http_circuit_breaker.bal
@@ -118,13 +118,13 @@ public type CircuitBreakerInferredConfig record {|
 # + httpClient - The underlying `HttpActions` instance which will be making the actual network calls
 # + circuitHealth - The circuit health monitor
 # + currentCircuitState - The current state the circuit is in
-public client isolated class CircuitBreakerClient {
+client isolated class CircuitBreakerClient {
 
     private string url;
     private final CircuitBreakerInferredConfig & readonly circuitBreakerInferredConfig;
     private final CircuitHealth circuitHealth;
     private CircuitState currentCircuitState = CB_CLOSED_STATE;
-    public final HttpClient httpClient;
+    final HttpClient httpClient;
 
     # A Circuit Breaker implementation which can be used to gracefully handle network failures.
     #
@@ -375,7 +375,7 @@ public client isolated class CircuitBreakerClient {
 
     # Force the circuit into a closed state in which it will allow requests regardless of the error percentage
     # until the failure threshold exceeds.
-    public isolated function forceClose() {
+    isolated function forceClose() {
         log:printInfo("Circuit forcefully switched to CLOSE state.");
         self.setCurrentState(CB_CLOSED_STATE);
         lock {
@@ -385,7 +385,7 @@ public client isolated class CircuitBreakerClient {
 
     # Force the circuit into a open state in which it will suspend all requests
     # until `resetTime` interval exceeds.
-    public isolated function forceOpen() {
+    isolated function forceOpen() {
         lock {
             self.currentCircuitState = CB_OPEN_STATE;
             self.circuitHealth.lastForcedOpenTime = time:utcNow();
@@ -395,7 +395,7 @@ public client isolated class CircuitBreakerClient {
     # Provides the `http:CircuitState` of the circuit breaker.
     #
     # + return - The current `http:CircuitState` of the circuit breaker
-    public isolated function getCurrentState() returns CircuitState {
+    isolated function getCurrentState() returns CircuitState {
         lock {
             return self.currentCircuitState;
         }

--- a/ballerina/resiliency_http_retry_client.bal
+++ b/ballerina/resiliency_http_retry_client.bal
@@ -38,7 +38,7 @@ type RetryInferredConfig record {|
 # + retryInferredConfig - Derived set of configurations associated with retry
 # + httpClient - Chain of different HTTP clients which provides the capability for initiating contact with a remote
 #                HTTP service in resilient manner.
-public client isolated class RetryClient {
+client isolated class RetryClient {
 
     final RetryInferredConfig & readonly retryInferredConfig;
     final HttpClient httpClient;

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - [Append the scheme of the HTTP client URL based on the client configurations](https://github.com/ballerina-platform/ballerina-standard-library/issues/2816)
 - [Refactor auth-desugar respond with DefaultErrorInterceptor](https://github.com/ballerina-platform/ballerina-standard-library/issues/2823)
+- [Hide subtypes of http:Client](https://github.com/ballerina-platform/ballerina-standard-library/issues/504)
 
 ## [2.2.1] - 2022-03-02
 


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/504

## Approach
When checking the implementation, it was found that http:HttpClient was visible for circuit breaker to execute 3 methods. 
1. [forceClose()](https://github.com/ballerina-platform/module-ballerina-http/blob/v2.2.1/ballerina/resiliency_http_circuit_breaker.bal#L378)
2. [forceOpen()](https://github.com/ballerina-platform/module-ballerina-http/blob/v2.2.1/ballerina/resiliency_http_circuit_breaker.bal#L388)
3. [getCurrentState()](https://github.com/ballerina-platform/module-ballerina-http/blob/v2.2.1/ballerina/resiliency_http_circuit_breaker.bal#L398)

So moved them to http:Client(check test cases) and hid all the subtypes of http:Client
Hence only the following clients will be public,

##### Public client classes

- http:Client
- http:LoadBalanceClient
- http:FailoverClient



## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
