### PR TITLE
Allow HTTP caller to respond `StatusCodeResponse`

### DIFF
--- a/ballerina-tests/tests/http_caller_respond_test.bal
+++ b/ballerina-tests/tests/http_caller_respond_test.bal
@@ -1,0 +1,78 @@
+// Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/test;
+
+final http:Client callerRespondTestClientEP = check new("http://localhost:" + callerRespondTestPort.toString());
+
+listener http:Listener callerRespondTestServerEP = new(callerRespondTestPort);
+
+service / on callerRespondTestServerEP {
+
+    resource function get accepted(http:Caller caller) returns error? {
+        check caller->respond(http:ACCEPTED);
+    }
+
+    resource function post status(http:Caller caller, http:Request req) returns error? {
+        http:StatusCodeResponse res;
+        string|error header = req.getHeader("x-header");
+        json|error payload = req.getJsonPayload();
+        if header is error {
+            res = <http:NotFound> {body: {message: "header not found"}};
+        } else if payload is error {
+            res = <http:BadRequest> {body: {message: "payload type is not supported"}};
+        } else {
+            res = <http:Ok> {body: {message: "hello world"}};
+        }
+        check caller->respond(res);
+    } 
+}
+
+@test:Config{}
+function testCallerRespondAccepted() returns error? {
+    http:Response res = check callerRespondTestClientEP->get("/accepted");
+    test:assertEquals(res.statusCode, 202);
+}
+
+@test:Config{}
+function testCallerRespondNotFound() returns error? {
+    http:Request req = new;
+    req.setJsonPayload({message: "hello world"});
+    http:Response res = check callerRespondTestClientEP->post("/status", req);
+    test:assertEquals(res.statusCode, 404);
+    assertJsonPayload(res.getJsonPayload(), {message: "header not found"});
+}
+
+@test:Config{}
+function testCallerRespondBadRequest() returns error? {
+    http:Request req = new;
+    req.setHeader("x-header", "x-value");
+    req.setXmlPayload(xml `<message> hello world </message>`);
+    http:Response res = check callerRespondTestClientEP->post("/status", req);
+    test:assertEquals(res.statusCode, 400);
+    assertJsonPayload(res.getJsonPayload(), {message: "payload type is not supported"});
+}
+
+@test:Config{}
+function testCallerRespondOk() returns error? {
+    http:Request req = new;
+    req.setHeader("x-header", "x-value");
+    req.setJsonPayload({message: "hello world"});
+    http:Response res = check callerRespondTestClientEP->post("/status", req);
+    test:assertEquals(res.statusCode, 200);
+    assertJsonPayload(res.getJsonPayload(), {message: "hello world"});
+}

--- a/ballerina-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/tests/test_service_ports.bal
@@ -176,6 +176,7 @@ const int responseInterceptorNegativeTestPort1 = 9621;
 const int responseInterceptorCallerRespondErrorTestPort = 9622;
 const int requestInterceptorCallerRespondErrorTestPort = 9623;
 const int clientSchemeTestHttpsListenerTestPort = 9624;
+const int callerRespondTestPort = 9625;
 
 //HTTP2
 const int serverPushTestPort1 = 9701;

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -50,8 +50,9 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
+	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "os"},
@@ -256,7 +257,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/http_annotation.bal
+++ b/ballerina/http_annotation.bal
@@ -88,7 +88,7 @@ public annotation HttpPayload Payload on parameter, return;
 # + respondType - Specifies the type of response
 public type HttpCallerInfo record {|
     // TODO : allow error type once the limitation in typedesc is resolved
-    typedesc<ResponseMessage|Error> respondType?;
+    typedesc<ResponseMessage|StatusCodeResponse|Error> respondType?;
 |};
 
 # The annotation which is used to configure the type of the response.

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Allow records to be annotated with @http:Header](https://github.com/ballerina-platform/ballerina-standard-library/issues/2699)
 - [Add basic type support for header params in addition to `string`, `string[]`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2807)
 - [Allow HTTP caller to respond `error`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2832)
+- [Allow HTTP caller to respond `StatusCodeResponse`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2853)
 - [Introduce `DefaultErrorInterceptor`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2669)
 - [Support `anydata` in service data binding](https://github.com/ballerina-platform/ballerina-standard-library/issues/2530)
 - [Add common constants for HTTP status-code responses](https://github.com/ballerina-platform/ballerina-standard-library/issues/1540)

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -284,7 +284,7 @@ public class CompilerPluginTest {
         Package currentPackage = loadPackage("sample_package_10");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
-        Assert.assertEquals(diagnosticResult.errorCount(), 9);
+        Assert.assertEquals(diagnosticResult.errorCount(), 11);
         assertError(diagnosticResult, 0, "incompatible respond method argument type : expected " +
                 "'int' according to the 'http:CallerInfo' annotation", HTTP_114);
         assertError(diagnosticResult, 1, "incompatible respond method argument type : expected " +
@@ -302,6 +302,10 @@ public class CompilerPluginTest {
                 "'Person' according to the 'http:CallerInfo' annotation", HTTP_114);
         assertError(diagnosticResult, 8, "incompatible respond method argument type : expected " +
                 "'http:Error' according to the 'http:CallerInfo' annotation", HTTP_114);
+        assertError(diagnosticResult, 9, "incompatible respond method argument type : expected " +
+                "'http:Ok' according to the 'http:CallerInfo' annotation", HTTP_114); 
+        assertError(diagnosticResult, 10, "incompatible respond method argument type : expected " +
+                "'http:StatusCodeResponse' according to the 'http:CallerInfo' annotation", HTTP_114);       
     }
 
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_10/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_10/service.bal
@@ -27,6 +27,8 @@ type AA record {|
 
 type NewError http:Error;
 
+type StatusResponse http:Ok|http:BadRequest;
+
 service http:Service on new http:Listener(9090) {
     resource function get callerInfo1(int xyz, @http:CallerInfo {respondType: string} http:Caller abc) {
         checkpanic abc->respond("done");
@@ -126,7 +128,28 @@ service http:Service on new http:Listener(9090) {
         check abc->respond(error("hello world")); // error
     }
 
-    resource function get greeting(@http:CallerInfo{respondType: NewError} http:Caller caller) returns error? {
+    resource function get callerInfo22(@http:CallerInfo{respondType: NewError} http:Caller caller) returns error? {
         check caller->respond(<NewError> error("New Error"));
+    }
+
+    resource function get callerInfo23(@http:CallerInfo{respondType: http:Ok} http:Caller caller) returns error? {
+        check caller->respond(http:OK);
+    }
+
+    resource function get callerInfo24(@http:CallerInfo{respondType: http:Ok} http:Caller caller) returns error? {
+        check caller->respond(http:NOT_FOUND); // error
+    }
+
+    resource function get callerInfo25(@http:CallerInfo{respondType: http:StatusCodeResponse} http:Caller caller) returns error? {
+        check caller->respond(http:NOT_FOUND);
+    }
+
+    resource function get callerInfo26(@http:CallerInfo{respondType: http:StatusCodeResponse} http:Caller caller) returns error? {
+        check caller->respond("hello wold"); // error
+    }
+
+    resource function get callerInfo27(@http:CallerInfo{respondType: StatusResponse} http:Caller caller) returns error? {
+        http:BadRequest res = {body: {message: "Bad Request"}};
+        check caller->respond(res);
     }
 }

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -396,8 +396,8 @@ Based on the payload types respective header value is added as the `Content-type
 | int, float, decimal, boolean                                          | application/json         |
 | map\<json\>, table<map\<json\>>, map\<json\>[], table<map\<json\>>)[] | application/json         |
 
-In addition to the above types, caller `respond()` method can accept `error` type. In this case, an error response is 
-returned to the client with the error message.
+In addition to the above types, caller `respond()` method can accept `StatusCodeResponse` or `error` type. In case of 
+`error`, an error response is returned to the client with the error message.
 
 The HTTP compiler extension checks the argument of the `respond()` method if the matching payload type is passed as
 denoted in the CallerInfo annotation. At the moment, in terms of responding error, CallerInfo annotation can only support 


### PR DESCRIPTION
## Purpose

> $Subject

> Fixes [`Add support to respond StatusCodeResponse type using http:Caller #2853`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2853)

## Examples

```ballerina
import ballerina/http;

service on new http:Listener(9090) {

   resource function get accepted(@http:CallerInfo{respondType: http:Accepted} http:Caller caller) 
         returns error? {
       check caller->respond(http:ACCEPTED);
   }

   resource function post status(@http:CallerInfo{respondType: http:StatusCodeResponse} http:Caller caller,
         http:Request req) returns error? {
       http:StatusCodeResponse res;
       string|error header = req.getHeader("x-header");
       json|error payload = req.getJsonPayload();
       if header is error {
           res = <http:NotFound> {body: {message: "header not found"}};
       } else if payload is error {
           res = <http:BadRequest> {body: {message: "payload type is not supported"}};
       } else {
           res = <http:Ok> {body: {message: "hello world"}};
       }
       check caller->respond(res);
   } 
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
