### PR TITLE
Return `400-BadRequest` for query casting errors

### DIFF
--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -19,6 +19,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"}
 ]
+modules = [
+	{org = "ballerina", packageName = "auth", moduleName = "auth"}
+]
 
 [[package]]
 org = "ballerina"
@@ -40,6 +43,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
 ]
+modules = [
+	{org = "ballerina", packageName = "crypto", moduleName = "crypto"}
+]
 
 [[package]]
 org = "ballerina"
@@ -53,6 +59,9 @@ dependencies = [
 	{org = "ballerina", name = "os"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
+]
+modules = [
+	{org = "ballerina", packageName = "file", moduleName = "file"}
 ]
 
 [[package]]
@@ -91,11 +100,23 @@ org = "ballerina"
 name = "http_tests"
 version = "2.3.0"
 dependencies = [
+	{org = "ballerina", name = "auth"},
+	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "jwt"},
+	{org = "ballerina", name = "lang.boolean"},
+	{org = "ballerina", name = "lang.float"},
+	{org = "ballerina", name = "lang.int"},
 	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "lang.string"},
+	{org = "ballerina", name = "lang.xml"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mime"},
+	{org = "ballerina", name = "oauth2"},
+	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "url"}
 ]
@@ -112,12 +133,18 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
+modules = [
+	{org = "ballerina", packageName = "io", moduleName = "io"}
+]
 
 [[package]]
 org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
 scope = "testOnly"
+modules = [
+	{org = "ballerina", packageName = "jballerina.java", moduleName = "jballerina.java"}
+]
 
 [[package]]
 org = "ballerina"
@@ -133,6 +160,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
+]
+modules = [
+	{org = "ballerina", packageName = "jwt", moduleName = "jwt"}
 ]
 
 [[package]]
@@ -157,6 +187,18 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.boolean"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.boolean", moduleName = "lang.boolean"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.decimal"
 version = "0.0.0"
 scope = "testOnly"
@@ -166,11 +208,26 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.float"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.float", moduleName = "lang.float"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.int"
 version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.int", moduleName = "lang.int"}
 ]
 
 [[package]]
@@ -214,6 +271,18 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.xml"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.xml", moduleName = "lang.xml"}
+]
+
+[[package]]
+org = "ballerina"
 name = "log"
 version = "2.2.1"
 scope = "testOnly"
@@ -253,6 +322,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "time"}
 ]
+modules = [
+	{org = "ballerina", packageName = "oauth2", moduleName = "oauth2"}
+]
 
 [[package]]
 org = "ballerina"
@@ -279,6 +351,9 @@ version = "1.2.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "regex", moduleName = "regex"}
 ]
 
 [[package]]

--- a/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
@@ -118,8 +118,16 @@ function testNegativeStringQueryBindingCaseSensitivity() {
 function testNegativeIntQueryBindingCastingError() {
     http:Response|error response = queryBindingClient->get("/queryparamservice/?foo=WSO2&bar=go");
     if response is http:Response {
-        test:assertEquals(response.statusCode, 500);
+        test:assertEquals(response.statusCode, 400);
         assertTextPayload(response.getTextPayload(), "Error in casting query param : For input string: \"go\"");
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+
+    response = queryBindingClient->get("/queryparamservice/?foo=WSO2&bar=");
+    if response is http:Response {
+        test:assertEquals(response.statusCode, 400);
+        assertTextPayload(response.getTextPayload(), "Error in casting query param : For input string: \"\"");
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllQueryParams.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllQueryParams.java
@@ -108,6 +108,7 @@ public class AllQueryParams implements Parameter {
                 }
                 paramFeed[index] = true;
             } catch (Exception ex) {
+                httpCarbonMessage.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
                 throw new BallerinaConnectorException("Error in casting query param : " + ex.getMessage());
             }
         }


### PR DESCRIPTION
## Purpose

> $Subject

> Fixes [`Some integer query parameter values returns HTTP 500 Internal Server Error when 400 Bad Request expected instead #2814`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2814)

## Examples

```ballerina
import ballerina/http;

listener http:Listener serverEP = new(8080);

service / on serverEP {
    // id is mandatory
    resource function get foo(int id) returns http:Ok {
        return http:OK;
    }
}
```

**With the valid query parameter :**
```
curl -v 'http://localhost:8080/foo?id=1'
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /foo?id=1 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.79.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< content-length: 0
< server: ballerina
< date: Tue, 3 May 2022 11:29:34 +0530
< 
* Connection #0 to host localhost left intact
```

**Without the query parameter :**
```
curl -v "http://localhost:8080/foo"
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /foo HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.79.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 400 Bad Request
< content-type: text/plain
< content-length: 35
< server: ballerina
< date: Tue, 3 May 2022 11:32:22 +0530
< 
* Connection #0 to host localhost left intact
no query param value found for 'id'
```

**With the empty query parameter :**
```
curl -v 'http://localhost:8080/foo?id='
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /foo?id= HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.79.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 400 Bad Request
< content-type: text/plain
< content-length: 51
< server: ballerina
< date: Tue, 3 May 2022 11:29:48 +0530
< 
* Connection #0 to host localhost left intact
Error in casting query param : For input string: ""                                                                                     
```

**With the invalid query parameter :**
```
curl -v 'http://localhost:8080/foo?id=A'
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /foo?id=A HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.79.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 400 Bad Request
< content-type: text/plain
< content-length: 52
< server: ballerina
< date: Tue, 3 May 2022 11:29:54 +0530
< 
* Connection #0 to host localhost left intact
Error in casting query param : For input string: "A"
```

## Checklist
- [x] Linked to an issue
- [ ] <s> Updated the changelog </s>
- [x] Added tests
- [ ] <s> Updated the spec </s>
