### PR TITLE
Add `openApiDefinition` field to `@http:ServiceConfig` annotation

### DIFF
--- a/ballerina/http_annotation.bal
+++ b/ballerina/http_annotation.bal
@@ -24,6 +24,7 @@
 # + mediaTypeSubtypePrefix - Service specific media-type subtype prefix
 # + treatNilableAsOptional - Treat Nilable parameters as optional
 # + interceptors - An array of interceptor services
+# + openApiDefinition - The generated OpenAPI definition for the HTTP service. This is auto-generated at compile-time.
 public type HttpServiceConfig record {|
     string host = "b7a.default";
     CompressionConfig compression = {};
@@ -33,6 +34,7 @@ public type HttpServiceConfig record {|
     string mediaTypeSubtypePrefix?;
     boolean treatNilableAsOptional = true;
     Interceptor[] interceptors?;
+    readonly byte[] openApiDefinition = [];
 |};
 
 # Configurations for CORS support.

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -1364,6 +1364,7 @@ public type HttpServiceConfig record {|
     string mediaTypeSubtypePrefix?;
     boolean treatNilableAsOptional = true;
     Interceptor[] interceptors?;
+    readonly byte[] openApiDefinition = [];
 |};
 
 @http:ServiceConfig {

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -1375,6 +1375,9 @@ service on testListener {
 }
 ```
 
+The `openApiDefinition` field in http:ServiceConfig annotation serves a unique purpose. It will be automatically 
+populated at compile-time with OpenAPI definition of the particular http:Service.
+
 ### 4.2. Resource configuration
 The resource configuration responsible for shaping the resource function. Most of the behaviours are provided from 
 the language itself such as path, HTTP verb as a part of resource function. Some other configs such as CORS, 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.3.0-SNAPSHOT
-ballerinaLangVersion=2201.1.0-rc1.1
+ballerinaLangVersion=2201.1.0-rc1.4
 ballerinaTomlParserVersion=1.2.2
 commonsLang3Version=3.8.1
 nettyVersion=4.1.71.Final


### PR DESCRIPTION
## Purpose
> $subject

In the initial design we planned to add the `openApiDefinition` to the `@openapi:ServiceInfo` annotation. But following concern arises when we use that approach:
- If the developer has not specified any open-api related functionality, if we are to add `@openapi:ServiceInfo` using code-modifier then we have to add the `ballerina/openapi` import statement as well.

Since, `openApiDefinition` field is used by ballerina HTTP package itself we could add that particular field to the `@http:ServiceConfig` annotation itself. 

Related to [#2472](https://github.com/ballerina-platform/ballerina-standard-library/issues/2472)

## Examples
N/A

## Checklist
- [X] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [x] Updated the spec
