### PR TITLE
Add union type support for client data binding

### DIFF
--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -19,6 +19,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"}
 ]
+modules = [
+	{org = "ballerina", packageName = "auth", moduleName = "auth"}
+]
 
 [[package]]
 org = "ballerina"
@@ -40,6 +43,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
 ]
+modules = [
+	{org = "ballerina", packageName = "crypto", moduleName = "crypto"}
+]
 
 [[package]]
 org = "ballerina"
@@ -53,6 +59,9 @@ dependencies = [
 	{org = "ballerina", name = "os"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
+]
+modules = [
+	{org = "ballerina", packageName = "file", moduleName = "file"}
 ]
 
 [[package]]
@@ -91,11 +100,23 @@ org = "ballerina"
 name = "http_tests"
 version = "2.3.0"
 dependencies = [
+	{org = "ballerina", name = "auth"},
+	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "jwt"},
+	{org = "ballerina", name = "lang.boolean"},
+	{org = "ballerina", name = "lang.float"},
+	{org = "ballerina", name = "lang.int"},
 	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "lang.string"},
+	{org = "ballerina", name = "lang.xml"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mime"},
+	{org = "ballerina", name = "oauth2"},
+	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "url"}
 ]
@@ -112,12 +133,18 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
+modules = [
+	{org = "ballerina", packageName = "io", moduleName = "io"}
+]
 
 [[package]]
 org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
 scope = "testOnly"
+modules = [
+	{org = "ballerina", packageName = "jballerina.java", moduleName = "jballerina.java"}
+]
 
 [[package]]
 org = "ballerina"
@@ -133,6 +160,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
+]
+modules = [
+	{org = "ballerina", packageName = "jwt", moduleName = "jwt"}
 ]
 
 [[package]]
@@ -157,6 +187,18 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.boolean"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.boolean", moduleName = "lang.boolean"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.decimal"
 version = "0.0.0"
 scope = "testOnly"
@@ -166,11 +208,26 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.float"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.float", moduleName = "lang.float"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.int"
 version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.int", moduleName = "lang.int"}
 ]
 
 [[package]]
@@ -214,6 +271,18 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.xml"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.xml", moduleName = "lang.xml"}
+]
+
+[[package]]
+org = "ballerina"
 name = "log"
 version = "2.2.1"
 scope = "testOnly"
@@ -253,6 +322,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "time"}
 ]
+modules = [
+	{org = "ballerina", packageName = "oauth2", moduleName = "oauth2"}
+]
 
 [[package]]
 org = "ballerina"
@@ -279,6 +351,9 @@ version = "1.2.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "regex", moduleName = "regex"}
 ]
 
 [[package]]

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -92,10 +92,12 @@ name = "http_tests"
 version = "2.3.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "lang.string"},
-	{org = "ballerina", name = "lang.xml"},
+	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mime"},
-	{org = "ballerina", name = "test"}
+	{org = "ballerina", name = "test"},
+	{org = "ballerina", name = "url"}
 ]
 modules = [
 	{org = "ballerina", packageName = "http_tests", moduleName = "http_tests"}
@@ -185,6 +187,9 @@ scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
+modules = [
+	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
+]
 
 [[package]]
 org = "ballerina"
@@ -209,18 +214,6 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
-name = "lang.xml"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.xml", moduleName = "lang.xml"}
-]
-
-[[package]]
-org = "ballerina"
 name = "log"
 version = "2.2.1"
 scope = "testOnly"
@@ -229,6 +222,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"},
 	{org = "ballerina", name = "observe"}
+]
+modules = [
+	{org = "ballerina", packageName = "log", moduleName = "log"}
 ]
 
 [[package]]
@@ -323,6 +319,9 @@ version = "2.2.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "url", moduleName = "url"}
 ]
 
 

--- a/ballerina-tests/tests/http_client_data_binding_anydata.bal
+++ b/ballerina-tests/tests/http_client_data_binding_anydata.bal
@@ -673,6 +673,46 @@ function testUnionOfDatabindingForRecordWithPersonNStock() returns error? {
 }
 
 @test:Config {}
+function testUnionOfDatabindingForMoreTypesWithString() returns error? {
+    xml|json|string|byte[] response = check clientDBBackendClient->get("/anydataTest/stringType");
+    if response is string {
+        test:assertEquals(response, "hello", msg = "Found unexpected output");
+    } else {
+        test:assertFail(msg = "Found unexpected output type");
+    }
+}
+
+@test:Config {}
+function testUnionOfDatabindingForMoreTypesWithJson() returns error? {
+    xml|json|string|byte[] response = check clientDBBackendClient->get("/anydataTest/jsonType");
+    if response is json {
+        assertJsonPayload(response, {name:"hello", id:20});
+    } else {
+        test:assertFail(msg = "Found unexpected output type");
+    }
+}
+
+@test:Config {}
+function testUnionOfDatabindingForMoreTypesWithXml() returns error? {
+    xml|json|string|byte[] response = check clientDBBackendClient->get("/anydataTest/xmlType");
+    if response is xml {
+        assertXmlPayload(response, xml `<name>WSO2</name>`);
+    } else {
+        test:assertFail(msg = "Found unexpected output type");
+    }
+}
+
+@test:Config {}
+function testUnionOfDatabindingForMoreTypesWithByteArr() returns error? {
+    xml|json|string|byte[] response = check clientDBBackendClient->get("/anydataTest/byteArrType");
+    if response is byte[] {
+        test:assertEquals(check strings:fromBytes(response), "WSO2", msg = "Found unexpected output");
+    } else {
+        test:assertFail(msg = "Found unexpected output type");
+    }
+}
+
+@test:Config {}
 function testNilableUnionOfDatabindingForXml() returns error? {
     xml|string? response = check clientDBBackendClient->get("/anydataTest/getNoContentXml");
     test:assertTrue(response is (), msg = "Found unexpected output");

--- a/ballerina-tests/tests/http_client_data_binding_anydata.bal
+++ b/ballerina-tests/tests/http_client_data_binding_anydata.bal
@@ -231,7 +231,28 @@ service /anydataTest on clientDBBackendListener {
     }
 
     resource function get getFormData() returns http:Ok|error {
-        return { body : "first%20Name=WS%20O2&tea%24%2Am=Bal%40Dance", mediaType : "x-www-form-urlencoded" };
+        return { body : "first%20Name=WS%20O2&tea%24%2Am=Bal%40Dance", mediaType : "application/x-www-form-urlencoded" };
+    }
+
+    // nilable union
+    resource function get getNoContentXml() returns http:Created {
+        return { mediaType : "application/xml" };
+    }
+
+    resource function get getNoContentString() returns http:Created {
+        return { mediaType : "text/plain" };
+    }
+
+    resource function get getNoContentUrlEncoded() returns http:Created {
+        return { mediaType : "application/x-www-form-urlencoded" };
+    }
+
+    resource function get getNoContentBlob() returns http:Created {
+        return { mediaType : "application/octet-stream" };
+    }
+
+    resource function get getNoContentJson() returns http:Created {
+        return { mediaType : "application/json" };
     }
 }
 
@@ -649,4 +670,46 @@ function testUnionOfDatabindingForRecordWithPersonNStock() returns error? {
     } else {
         test:assertFail(msg = "Found unexpected output type");
     }
+}
+
+@test:Config {}
+function testNilableUnionOfDatabindingForXml() returns error? {
+    xml|string? response = check clientDBBackendClient->get("/anydataTest/getNoContentXml");
+    test:assertTrue(response is (), msg = "Found unexpected output");
+}
+
+@test:Config {}
+function testNilableUnionOfDatabindingForString() returns error? {
+    xml|string? response = check clientDBBackendClient->get("/anydataTest/getNoContentString");
+    test:assertTrue(response is (), msg = "Found unexpected output");
+}
+
+@test:Config {}
+function testNilableUnionOfDatabindingForByteArr() returns error? {
+    xml|byte[]? response = check clientDBBackendClient->get("/anydataTest/getNoContentString");
+    test:assertTrue(response is (), msg = "Found unexpected output");
+}
+
+@test:Config {}
+function testNilableUnionOfDatabindingForMapFormData() returns error? {
+    xml|map<string>? response = check clientDBBackendClient->get("/anydataTest/getNoContentUrlEncoded");
+    test:assertTrue(response is (), msg = "Found unexpected output");
+}
+
+@test:Config {}
+function testNilableUnionOfDatabindingForStringFormData() returns error? {
+    xml|string? response = check clientDBBackendClient->get("/anydataTest/getNoContentUrlEncoded");
+    test:assertTrue(response is (), msg = "Found unexpected output");
+}
+
+@test:Config {}
+function testNilableUnionOfDatabindingForOctetBlob() returns error? {
+    xml|byte[]? response = check clientDBBackendClient->get("/anydataTest/getNoContentBlob");
+    test:assertTrue(response is (), msg = "Found unexpected output");
+}
+
+@test:Config {}
+function testNilableUnionOfDatabindingForJson() returns error? {
+    xml|json? response = check clientDBBackendClient->get("/anydataTest/getNoContentJson");
+    test:assertTrue(response is (), msg = "Found unexpected output");
 }

--- a/changelog.md
+++ b/changelog.md
@@ -16,7 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Introduce `DefaultErrorInterceptor`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2669)
 - [Support `anydata` in service data binding](https://github.com/ballerina-platform/ballerina-standard-library/issues/2530)
 - [Support `anydata` in client data binding](https://github.com/ballerina-platform/ballerina-standard-library/issues/2036)
-- [Add union type support data binding](https://github.com/ballerina-platform/ballerina-standard-library/issues/2701)
+- [Add union type support service data binding](https://github.com/ballerina-platform/ballerina-standard-library/issues/2701)
+- [Add union type support client data binding](https://github.com/ballerina-platform/ballerina-standard-library/issues/2883)
 - [Add common constants for HTTP status-code responses](https://github.com/ballerina-platform/ballerina-standard-library/issues/1540)
 - [Add code-actions to generate interceptor method template](https://github.com/ballerina-platform/ballerina-standard-library/issues/2664)
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -581,20 +581,26 @@ resource execution.
 The error which may occur during the process will be returned to the caller with the response 
 status code of 400 BAD REQUEST. The successful binding will proceed the resource execution with the built payload.
 
+```ballerina
+resource function post hello(@http:Payload json payload) { 
+    
+}
+```
+
 Additionally, the payload parameter type can be a union of `anydata`. Based on the media type, the potential binding
 type is decided. For example, if the union is defined as `json|xml` and the media type is related to `json`,
 the deserialization and the binding will proceed according to the type `json`. But if the media type is related to `xml`
 the process will happen according to the type `xml`.
 If the given types of the union are not compatible with the media type, an error is returned.
 
-If any of the type is union with `()`(i.e `string?`), then in the absence of the payload, `()` will be assigned as 
-the value without being responded by a `BAD REQUEST` response.
-
 ```ballerina
-resource function post hello(@http:Payload json payload) { 
+resource function post hello(@http:Payload json|xml payload) { 
     
 }
+
 ```
+If any of the type is union with `()`(i.e `string?`), then in the absence of the payload, `()` will be assigned as 
+the value without being responded by a `BAD REQUEST` response.
 
 Internally the complete payload is built, therefore the application should have sufficient memory to support the 
 process. Payload binding is not recommended if the service behaves as a proxy/pass-through where request payload is 
@@ -1334,6 +1340,13 @@ type is decided. For example, if the union is defined as `json|xml` and the medi
 the deserialization and the binding will proceed according to the type `json`. But if the media type is related to `xml`
 the process will happen according to the type `xml`.
 If the given types of the union are not compatible with the media type, an error is returned.
+
+```ballerina
+json|xml payload = check httpClient->get("/data");
+```
+
+If the type is union with `()`(i.e `string?`), then in the absence of the payload, `()` will be assigned as
+the value without being responded by a `BAD REQUEST` response.
 
 ## 3. Request routing
 Ballerina dispatching logic is implemented to uniquely identify a resource based on the request URI and Method.

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -582,8 +582,9 @@ The error which may occur during the process will be returned to the caller with
 status code of 400 BAD REQUEST. The successful binding will proceed the resource execution with the built payload.
 
 Additionally, the payload parameter type can be a union of `anydata`. Based on the media type, the potential binding
-type is decided. For example, if the union is defined as `json|xml` and the media type is related to `json`, 
-the deserialization and the binding will proceed according to type `json`. 
+type is decided. For example, if the union is defined as `json|xml` and the media type is related to `json`,
+the deserialization and the binding will proceed according to the type `json`. But if the media type is related to `xml`
+the process will happen according to the type `xml`.
 If the given types of the union are not compatible with the media type, an error is returned.
 
 If any of the type is union with `()`(i.e `string?`), then in the absence of the payload, `()` will be assigned as 
@@ -1297,6 +1298,14 @@ In case of using var as return type, user can pass the typedesc to the targetTyp
 http:Client httpClient = check new ("https://person.free.beeceptor.com");
 var payload = check httpClient->get("/data", targetType = json);
 ```
+
+If any of the type is union with `()`(i.e `string?`), then in the absence of the payload, `()` will be assigned as
+the value without being responded by a `BAD REQUEST` response.
+
+```ballerina
+string? payload = check httpClient->get("/data");
+```
+
 When the user expects client data binding to happen, the HTTP error responses (4XX, 5XX) will be categorized as an 
 error (http:ClientRequestError, http:RemoteServerError) of the client remote operation. These error types contain 
 payload, headers and status code inside the error detail.
@@ -1319,6 +1328,12 @@ if (result is http:RemoteServerError) {
     map<string[]> headers = result.detail().headers;
 }
 ```
+
+Additionally, the client action return type can be a union of `anydata`. Based on the media type, the potential binding
+type is decided. For example, if the union is defined as `json|xml` and the media type is related to `json`,
+the deserialization and the binding will proceed according to the type `json`. But if the media type is related to `xml`
+the process will happen according to the type `xml`.
+If the given types of the union are not compatible with the media type, an error is returned.
 
 ## 3. Request routing
 Ballerina dispatching logic is implemented to uniquely identify a resource based on the request URI and Method.

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/builder/AbstractPayloadBuilder.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/builder/AbstractPayloadBuilder.java
@@ -20,6 +20,7 @@ package io.ballerina.stdlib.http.api.service.signature.builder;
 
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.types.TypedescType;
 import io.ballerina.runtime.api.types.UnionType;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BTypedesc;
@@ -87,7 +88,7 @@ public abstract class AbstractPayloadBuilder {
         }
     }
 
-    public boolean isSubtypeOfAllowedType(Type payloadType, int targetTypeTag) {
+    public static boolean isSubtypeOfAllowedType(Type payloadType, int targetTypeTag) {
         if (payloadType.getTag() == targetTypeTag) {
             return true;
         } else if (payloadType.getTag() == TypeTags.UNION_TAG) {
@@ -98,7 +99,13 @@ public abstract class AbstractPayloadBuilder {
         return false;
     }
 
-    public boolean typeIncludedInUnion(BTypedesc unionType, BTypedesc targetType) {
-        return isSubtypeOfAllowedType(unionType.getDescribingType(), targetType.getDescribingType().getTag());
+    public static boolean typeIncludedInUnion(BTypedesc unionType, BTypedesc targetType) {
+        int targetTypeTag = ((TypedescType) targetType.getDescribingType()).getConstraint().getTag();
+        Type unionTypeDescribingType = unionType.getDescribingType();
+        if (unionTypeDescribingType.getTag() == TypeTags.UNION_TAG) {
+            List<Type> memberTypes = ((UnionType) unionTypeDescribingType).getMemberTypes();
+            return memberTypes.stream().anyMatch(memberType -> memberType.getTag() == targetTypeTag);
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## Purpose
The client action return type can be a union of `anydata`. Based on the media type, the potential binding
type is decided. For example, if the union is defined as `json|xml` and the media type is related to `json`,
the deserialization and the binding will proceed according to the type `json`. But if the media type is related to `xml`
the process will happen according to the type `xml`.
If the given types of the union are not compatible with the media type, an error is returned.

If any of the type is union with `()`(i.e `string?`), then in the absence of the payload, `()` will be assigned as 
the value without being responded by a `BAD REQUEST` response.

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/2883

## Examples
```ballerina
xml|json response = check clientDBBackendClient->get("/anydataTest/jsonType");
string|xml person = check clientDBBackendClient->get("/anydataTest/getFormData");
Person|Stock response = check clientDBBackendClient->get("/anydataTest/recordType");
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
