### PR TITLE
Return casting error in header binding as `400-BadRequest`

### DIFF
--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -19,6 +19,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"}
 ]
+modules = [
+	{org = "ballerina", packageName = "auth", moduleName = "auth"}
+]
 
 [[package]]
 org = "ballerina"
@@ -40,6 +43,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
 ]
+modules = [
+	{org = "ballerina", packageName = "crypto", moduleName = "crypto"}
+]
 
 [[package]]
 org = "ballerina"
@@ -53,6 +59,9 @@ dependencies = [
 	{org = "ballerina", name = "os"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
+]
+modules = [
+	{org = "ballerina", packageName = "file", moduleName = "file"}
 ]
 
 [[package]]
@@ -91,11 +100,25 @@ org = "ballerina"
 name = "http_tests"
 version = "2.3.0"
 dependencies = [
+	{org = "ballerina", name = "auth"},
+	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "jwt"},
+	{org = "ballerina", name = "lang.boolean"},
+	{org = "ballerina", name = "lang.float"},
+	{org = "ballerina", name = "lang.int"},
+	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "lang.xml"},
+	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mime"},
-	{org = "ballerina", name = "test"}
+	{org = "ballerina", name = "oauth2"},
+	{org = "ballerina", name = "regex"},
+	{org = "ballerina", name = "test"},
+	{org = "ballerina", name = "url"}
 ]
 modules = [
 	{org = "ballerina", packageName = "http_tests", moduleName = "http_tests"}
@@ -110,12 +133,18 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
+modules = [
+	{org = "ballerina", packageName = "io", moduleName = "io"}
+]
 
 [[package]]
 org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
 scope = "testOnly"
+modules = [
+	{org = "ballerina", packageName = "jballerina.java", moduleName = "jballerina.java"}
+]
 
 [[package]]
 org = "ballerina"
@@ -131,6 +160,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
+]
+modules = [
+	{org = "ballerina", packageName = "jwt", moduleName = "jwt"}
 ]
 
 [[package]]
@@ -155,6 +187,18 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.boolean"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.boolean", moduleName = "lang.boolean"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.decimal"
 version = "0.0.0"
 scope = "testOnly"
@@ -164,11 +208,26 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.float"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.float", moduleName = "lang.float"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.int"
 version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.int", moduleName = "lang.int"}
 ]
 
 [[package]]
@@ -184,6 +243,9 @@ version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
 ]
 
 [[package]]
@@ -230,6 +292,9 @@ dependencies = [
 	{org = "ballerina", name = "lang.value"},
 	{org = "ballerina", name = "observe"}
 ]
+modules = [
+	{org = "ballerina", packageName = "log", moduleName = "log"}
+]
 
 [[package]]
 org = "ballerina"
@@ -257,6 +322,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "time"}
 ]
+modules = [
+	{org = "ballerina", packageName = "oauth2", moduleName = "oauth2"}
+]
 
 [[package]]
 org = "ballerina"
@@ -283,6 +351,9 @@ version = "1.2.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "regex", moduleName = "regex"}
 ]
 
 [[package]]
@@ -323,6 +394,9 @@ version = "2.2.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "url", moduleName = "url"}
 ]
 
 

--- a/ballerina-tests/tests/service_dispatching_header_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_header_param_binding_test.bal
@@ -661,3 +661,36 @@ function testReadonlyHeaderParams() returns error? {
     assertJsonValue(response, "header3", { status : "non-readonly", value : "nil float" });
     assertJsonValue(response, "header4", { status : "readonly", value : [2.8d, 3.4d] });
 }
+
+@test:Config {}
+function testHeaderParamsCastingError() returns error? {
+    http:Response response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
+        {"iid" : "hello"});
+    test:assertEquals(response.statusCode, 400);
+    assertTrueTextPayload(response.getTextPayload(), "header binding failed: java.lang.NumberFormatException");
+
+    response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
+        {"fid" : "hello"});
+    test:assertEquals(response.statusCode, 400);
+    assertTrueTextPayload(response.getTextPayload(), "header binding failed: java.lang.NumberFormatException");
+
+    response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
+        {"did" : "hello"});
+    test:assertEquals(response.statusCode, 400);
+    assertTrueTextPayload(response.getTextPayload(), "header binding failed: java.lang.NumberFormatException");
+
+    response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
+        {"iaid" : ["3", "5", "8", "hello"]});
+    test:assertEquals(response.statusCode, 400);
+    assertTrueTextPayload(response.getTextPayload(), "header binding failed: java.lang.NumberFormatException");
+
+    response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
+        {"faid" : ["3.445", "hello", "5.667", "8.206"]});
+    test:assertEquals(response.statusCode, 400);
+    assertTrueTextPayload(response.getTextPayload(), "header binding failed: java.lang.NumberFormatException");
+
+    response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
+        {"daid" : ["3.4", "5.6", "hello", "8"]});
+    test:assertEquals(response.statusCode, 400);
+    assertTrueTextPayload(response.getTextPayload(), "header binding failed: java.lang.NumberFormatException");
+}

--- a/ballerina-tests/tests/service_dispatching_header_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_header_param_binding_test.bal
@@ -667,30 +667,30 @@ function testHeaderParamsCastingError() returns error? {
     http:Response response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
         {"iid" : "hello"});
     test:assertEquals(response.statusCode, 400);
-    assertTrueTextPayload(response.getTextPayload(), "header binding failed");
+    assertTextPayload(response.getTextPayload(), "header binding failed for parameter: iid");
 
     response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
         {"fid" : "hello"});
     test:assertEquals(response.statusCode, 400);
-    assertTrueTextPayload(response.getTextPayload(), "header binding failed");
+    assertTextPayload(response.getTextPayload(), "header binding failed for parameter: fid");
 
     response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
         {"did" : "hello"});
     test:assertEquals(response.statusCode, 400);
-    assertTrueTextPayload(response.getTextPayload(), "header binding failed");
+    assertTextPayload(response.getTextPayload(), "header binding failed for parameter: did");
 
     response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
         {"iaid" : ["3", "5", "8", "hello"]});
     test:assertEquals(response.statusCode, 400);
-    assertTrueTextPayload(response.getTextPayload(), "header binding failed");
+    assertTextPayload(response.getTextPayload(), "header binding failed for parameter: iaid");
 
     response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
         {"faid" : ["3.445", "hello", "5.667", "8.206"]});
     test:assertEquals(response.statusCode, 400);
-    assertTrueTextPayload(response.getTextPayload(), "header binding failed");
+    assertTextPayload(response.getTextPayload(), "header binding failed for parameter: faid");
 
     response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
         {"daid" : ["3.4", "5.6", "hello", "8"]});
     test:assertEquals(response.statusCode, 400);
-    assertTrueTextPayload(response.getTextPayload(), "header binding failed");
+    assertTextPayload(response.getTextPayload(), "header binding failed for parameter: daid");
 }

--- a/ballerina-tests/tests/service_dispatching_header_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_header_param_binding_test.bal
@@ -667,30 +667,30 @@ function testHeaderParamsCastingError() returns error? {
     http:Response response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
         {"iid" : "hello"});
     test:assertEquals(response.statusCode, 400);
-    assertTrueTextPayload(response.getTextPayload(), "header binding failed: java.lang.NumberFormatException");
+    assertTrueTextPayload(response.getTextPayload(), "header binding failed");
 
     response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
         {"fid" : "hello"});
     test:assertEquals(response.statusCode, 400);
-    assertTrueTextPayload(response.getTextPayload(), "header binding failed: java.lang.NumberFormatException");
+    assertTrueTextPayload(response.getTextPayload(), "header binding failed");
 
     response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
         {"did" : "hello"});
     test:assertEquals(response.statusCode, 400);
-    assertTrueTextPayload(response.getTextPayload(), "header binding failed: java.lang.NumberFormatException");
+    assertTrueTextPayload(response.getTextPayload(), "header binding failed");
 
     response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
         {"iaid" : ["3", "5", "8", "hello"]});
     test:assertEquals(response.statusCode, 400);
-    assertTrueTextPayload(response.getTextPayload(), "header binding failed: java.lang.NumberFormatException");
+    assertTrueTextPayload(response.getTextPayload(), "header binding failed");
 
     response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
         {"faid" : ["3.445", "hello", "5.667", "8.206"]});
     test:assertEquals(response.statusCode, 400);
-    assertTrueTextPayload(response.getTextPayload(), "header binding failed: java.lang.NumberFormatException");
+    assertTrueTextPayload(response.getTextPayload(), "header binding failed");
 
     response = check headerBindingClient->get("/headerRecord/ofOtherNilableHeaders", 
         {"daid" : ["3.4", "5.6", "hello", "8"]});
     test:assertEquals(response.statusCode, 400);
-    assertTrueTextPayload(response.getTextPayload(), "header binding failed: java.lang.NumberFormatException");
+    assertTrueTextPayload(response.getTextPayload(), "header binding failed");
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllHeaderParams.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllHeaderParams.java
@@ -118,9 +118,9 @@ public class AllHeaderParams implements Parameter {
                 } else {
                     paramFeed[index++] = castParam(typeTag, headerValues.get(0));
                 }
-            } catch (Exception exp) {
+            } catch (NumberFormatException e) {
                 httpCarbonMessage.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
-                throw new BallerinaConnectorException("header binding failed: " + exp.getMessage());
+                throw new BallerinaConnectorException("header binding failed for parameter: " + token);
             }
             paramFeed[index] = true;
         }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllHeaderParams.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllHeaderParams.java
@@ -107,15 +107,20 @@ public class AllHeaderParams implements Parameter {
                 }
             }
             int typeTag = headerParam.getType().getTag();
-            if (typeTag == ARRAY_TAG) {
-                int elementTypeTag = ((ArrayType) headerParam.getType()).getElementType().getTag();
-                BArray bArray = castParamArray(elementTypeTag, headerValues.toArray(new String[0]));
-                if (headerParam.isReadonly()) {
-                    bArray.freezeDirect();
+            try {
+                if (typeTag == ARRAY_TAG) {
+                    int elementTypeTag = ((ArrayType) headerParam.getType()).getElementType().getTag();
+                    BArray bArray = castParamArray(elementTypeTag, headerValues.toArray(new String[0]));
+                    if (headerParam.isReadonly()) {
+                        bArray.freezeDirect();
+                    }
+                    paramFeed[index++] = bArray;
+                } else {
+                    paramFeed[index++] = castParam(typeTag, headerValues.get(0));
                 }
-                paramFeed[index++] = bArray;
-            } else {
-                paramFeed[index++] = castParam(typeTag, headerValues.get(0));
+            } catch (Exception exp) {
+                httpCarbonMessage.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
+                throw new BallerinaConnectorException("header binding failed: " + exp);
             }
             paramFeed[index] = true;
         }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllHeaderParams.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllHeaderParams.java
@@ -120,7 +120,7 @@ public class AllHeaderParams implements Parameter {
                 }
             } catch (Exception exp) {
                 httpCarbonMessage.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
-                throw new BallerinaConnectorException("header binding failed: " + exp);
+                throw new BallerinaConnectorException("header binding failed: " + exp.getMessage());
             }
             paramFeed[index] = true;
         }


### PR DESCRIPTION
## Purpose

> $Subject

> Fixes [`Casting errors in header binding are returned as InternalServerError without proper error message #2888`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2888)

## Examples

```ballerina
import ballerina/http;

service / on new http:Listener(9090) {
  resource function get hello(@http:Header int x\-id) returns string {
    return "HelloWorld";
  }
}
```

```
curl -v http://localhost:9090/hello -H "x-id: bye"
```

```
*   Trying 127.0.0.1:9090...
* Connected to localhost (127.0.0.1) port 9090 (#0)
> GET /hello HTTP/1.1
> Host: localhost:9090
> User-Agent: curl/7.79.1
> Accept: */*
> x-id: bye
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 400 Bad Request
< content-type: text/plain
< content-length: 41
< server: ballerina
< date: Mon, 9 May 2022 17:04:57 +0530
< 
* Connection #0 to host localhost left intact
header binding failed for parameter: x-id
```

## Checklist
- [x] Linked to an issue
- [ ] <s>Updated the changelog</s>
- [x] Added tests
- [ ] <s>Updated the spec</s>
