### PR TITLE
Add quoted string array param support to `parseHeader()`

### DIFF
--- a/ballerina-tests/Ballerina.toml
+++ b/ballerina-tests/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http_tests"
-version = "2.3.0"
+version = "2.3.1"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/http-native-2.3.0.jar"
+path = "../native/build/libs/http-native-2.3.1-SNAPSHOT.jar"

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -67,7 +67,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.3.0"
+version = "2.3.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -98,7 +98,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_tests"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "crypto"},
@@ -329,7 +329,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.4"
+version = "1.0.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina-tests/tests/parse_header.bal
+++ b/ballerina-tests/tests/parse_header.bal
@@ -150,6 +150,33 @@ function testLinkHeader() {
     }
 }
 
+//Test function with link header with simple array value
+@test:Config {}
+function testLinkHeaderWithSimpleArrayValue() returns error? {
+    string linkHeader = "</>; rel=\"self\"; methods=\"\"GET\", \"POST\"\", </users>; rel=\"add\"; methods=\"\"POST\"\"";
+    var result = check http:parseHeader(linkHeader);
+    test:assertEquals(result[0].value, "</>");
+    test:assertEquals(result[0].params["rel"], "\"self\"");
+    test:assertEquals(result[0].params["methods"], "\"\"GET\", \"POST\"\"");
+    test:assertEquals(result[1].value, "</users>");
+    test:assertEquals(result[1].params["rel"], "\"add\"");
+    test:assertEquals(result[1].params["methods"], "\"\"POST\"\"");
+}
+
+//Test function with link header with complex array value
+@test:Config {}
+function testLinkHeaderWithComplexArrayValue() returns error? {
+    string linkHeader = "</>; rel=\"sample\"; example=\"\"foo\", -1.23, true, [\"charlie\", \"bennet\"], {\"cat\": \"thor\"}, false\", " +
+                        "</users>; rel=\"add\"; methods=\"\"POST\"\"";
+    var result = check http:parseHeader(linkHeader);
+    test:assertEquals(result[0].value, "</>");
+    test:assertEquals(result[0].params["rel"], "\"sample\"");
+    test:assertEquals(result[0].params["example"], "\"\"foo\", -1.23, true, [\"charlie\", \"bennet\"], {\"cat\": \"thor\"}, false\"");
+    test:assertEquals(result[1].value, "</users>");
+    test:assertEquals(result[1].params["rel"], "\"add\"");
+    test:assertEquals(result[1].params["methods"], "\"\"POST\"\"");
+}
+
 //Test function with empty value
 @test:Config {}
 function testEmptyValue() {

--- a/ballerina-tests/tests/parse_header.bal
+++ b/ballerina-tests/tests/parse_header.bal
@@ -177,6 +177,16 @@ function testLinkHeaderWithComplexArrayValue() returns error? {
     test:assertEquals(result[1].params["methods"], "\"\"POST\"\"");
 }
 
+//Test function with negative array value in link header
+@test:Config {}
+function testLinkHeaderWithNegativeArrayValue() returns error? {
+    string linkHeader = "</>; rel=\"self\"; methods=\"\"GET\", \"PO";
+    var result = check http:parseHeader(linkHeader);
+    test:assertEquals(result[0].value, "</>");
+    test:assertEquals(result[0].params["rel"], "\"self\"");
+    test:assertEquals(result[0].params["methods"], "\"\"GET\", \"PO");
+}
+
 //Test function with empty value
 @test:Config {}
 function testEmptyValue() {

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -10,7 +10,7 @@ license = ["Apache-2.0"]
 distribution = "2201.1.0"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/http-native-2.3.0.jar"
+path = "../native/build/libs/http-native-2.3.1-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
 path = "./lib/mime-native-2.3.0.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.3.0.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.3.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -66,7 +66,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -257,7 +257,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ParseHeader.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ParseHeader.java
@@ -34,7 +34,6 @@ import static io.ballerina.stdlib.http.api.HttpConstants.HEADER_VALUE_FIELD;
 import static io.ballerina.stdlib.http.api.HttpConstants.HEADER_VALUE_PARAM_FIELD;
 import static io.ballerina.stdlib.http.api.HttpConstants.HEADER_VALUE_RECORD;
 import static io.ballerina.stdlib.http.api.HttpErrorType.GENERIC_CLIENT_ERROR;
-import static io.ballerina.stdlib.mime.util.MimeConstants.COMMA;
 import static io.ballerina.stdlib.mime.util.MimeConstants.FAILED_TO_PARSE;
 import static io.ballerina.stdlib.mime.util.MimeConstants.SEMICOLON;
 
@@ -48,10 +47,11 @@ public class ParseHeader {
     private static final RecordType RECORD_TYPE = TypeCreator.createRecordType(
             HEADER_VALUE_RECORD, ModuleUtils.getHttpPackage(), 0, false, 0);
     private static final ArrayType ARRAY_TYPE = TypeCreator.createArrayType(RECORD_TYPE);
+    private static final String COMMA_OUT_OF_QUOTATIONS = "(,)(?=(?:[^\"]|\"[^\"]*\")*$)";
 
     public static Object parseHeader(BString headerValue) {
         try {
-            String[] headerValues = headerValue.getValue().split(COMMA);
+            String[] headerValues = headerValue.getValue().split(COMMA_OUT_OF_QUOTATIONS);
             BArray recordArray = ValueCreator.createArrayValue(ARRAY_TYPE);
             for (int i = 0; i < headerValues.length; i++) {
                 String value = headerValues[i].trim();


### PR DESCRIPTION
## Purpose

> $Subject

> Fixes [`Add quoted string array param support to parseHeader() method #2962`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2962)

## Example

```ballerina
import ballerina/io;
import ballerina/http;

public function main() {
    string header = "</>; rel=\"self\"; methods=\"\"GET\", \"POST\"\", " + 
                    "</users>; rel=\"add\"; methods=\"\"POST\"\"";
    io:println(http:parseHeader(header));
}
```

Output : 
```json
[
   {
      "value":"</>",
      "params":{
         "rel":"\"self\"",
         "methods":"\"\"GET\", \"POST\"\""
      }
   },
   {
      "value":"</users>",
      "params":{
         "rel":"\"add\"",
         "methods":"\"\"POST\"\""
      }
   }
]
```

## Checklist
- [x] Linked to an issue
- [ ] <s> Updated the changelog </s>
- [x] Added tests
- [ ] <s> Updated the spec </s>
