### PR TITLE
Fix compiler error for links with method as reference object

### DIFF
--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_25/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_25/service.bal
@@ -33,8 +33,8 @@ service on new http:Listener(9090) {
     @http:ResourceConfig {
         name: "Resource1",
         linkedTo: [
-            {name: "resource1", method: "POST"},
-            {name: "resource3", method: "get", relation: "get"},
+            {name: "resource1", method: http:POST},
+            {name: "resource3", method: http:GET, relation: "get"},
             {name: "resource3", method: "post", relation: "add"}
         ]
     }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
@@ -205,6 +205,7 @@ class HttpResourceValidator {
         String name = null;
         String method = null;
         String relation = SELF;
+        boolean nameRefMethodAvailable = false;
         for (Node fieldNode : ((MappingConstructorExpressionNode) node).fields()) {
             if (!(fieldNode instanceof SpecificFieldNode)) {
                 continue;
@@ -216,7 +217,12 @@ class HttpResourceValidator {
             }
             Node linkedToFieldValue = linkedToFieldValueExpression.get();
             if (linkedToFieldValue instanceof NameReferenceNode) {
-                break;
+                if (!linkedToFieldName.equals(METHOD)) {
+                    break;
+                } else {
+                    nameRefMethodAvailable = true;
+                    continue;
+                }
             }
             switch (linkedToFieldName) {
                 case NAME:
@@ -236,7 +242,7 @@ class HttpResourceValidator {
                 reportInvalidLinkRelation(ctx, node.location(), relation);
                 return;
             }
-            linkedResources.put(relation, new LinkedToResource(name, method, node));
+            linkedResources.put(relation, new LinkedToResource(name, method, node, nameRefMethodAvailable));
         }
     }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpServiceValidator.java
@@ -115,7 +115,9 @@ public class HttpServiceValidator implements AnalysisTask<SyntaxNodeAnalysisCont
         if (!linksMetaData.hasNameReferenceObjects()) {
             for (Map<String, LinkedToResource> linkedToResourceMap : linksMetaData.getLinkedToResourceMaps()) {
                 for (LinkedToResource linkedToResource : linkedToResourceMap.values()) {
-                    checkLinkedResourceExistence(syntaxNodeAnalysisContext, linksMetaData, linkedToResource);
+                    if (!linkedToResource.hasNameRefMethodAvailable()) {
+                        checkLinkedResourceExistence(syntaxNodeAnalysisContext, linksMetaData, linkedToResource);
+                    }
                 }
             }
         }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/LinkedToResource.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/LinkedToResource.java
@@ -30,11 +30,13 @@ public class LinkedToResource {
     private final String name;
     private final String method;
     private Node node;
+    boolean nameRefMethodAvailable;
 
-    public LinkedToResource(String name, String method, Node node) {
+    public LinkedToResource(String name, String method, Node node, boolean nameRefMethodAvailable) {
         this.name = name;
         this.method = method;
         this.node = node;
+        this.nameRefMethodAvailable = nameRefMethodAvailable;
     }
 
     public String getName() {
@@ -47,5 +49,9 @@ public class LinkedToResource {
 
     public Node getNode() {
         return node;
+    }
+
+    public boolean hasNameRefMethodAvailable() {
+        return this.nameRefMethodAvailable;
     }
 }


### PR DESCRIPTION
## Purpose

> $Subject

> Fixes [`Compiler plugin validation for Links with enum method fails #3000`](https://github.com/ballerina-platform/ballerina-standard-library/issues/3000)

## Examples

```ballerina
import ballerina/http;

service on new http:Listener(9090) {

   @http:ResourceConfig {
     name: "Resource1"
   }
   resource function get path1() returns string {
     return "Path1";
   }

   @http:ResourceConfig {
     name: "Resource1"
   }
   resource function post path1() returns string {
     return "Path1";
   }

   @http:ResourceConfig {
     linkedTo: [
      // This is valid with method as string literal
      { name: "Resource1", relation: "Relation1", method: "GET"},
      // This is also valid with method as reference object
      { name: "Resource1", relation: "Relation2", method: http:GET}
    ]
   }
   resource function get path2 () returns string {
     return "Path2";
   }
}
```

## Checklist
- [x] Linked to an issue
- [ ] <s>Updated the changelog</s>
- [x] Added tests
- [ ] <s>Updated the spec</s>
