### PR TITLE
Synchronize the initial target channel borrowing

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/AbstractHTTPAction.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/AbstractHTTPAction.java
@@ -66,7 +66,6 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Objects;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.BALLERINA_VERSION;
 import static io.ballerina.stdlib.http.api.HttpConstants.ANN_CONFIG_ATTR_COMPRESSION;
@@ -266,13 +265,11 @@ public abstract class AbstractHTTPAction {
         //Make the request associate with this response consumable again so that it can be reused.
         checkDirtiness(dataContext, outboundRequestMsg);
 
-        if (Objects.nonNull(dataContext.getEnvironment().getStrandLocal(HttpConstants.MAIN_STRAND))) {
-            Object sourceHandler = outboundRequestMsg.getProperty(HttpConstants.SRC_HANDLER);
-            if (sourceHandler == null) {
+        Object sourceHandler = outboundRequestMsg.getProperty(HttpConstants.SRC_HANDLER);
+        if (sourceHandler == null) {
 
-                outboundRequestMsg.setProperty(HttpConstants.SRC_HANDLER,
-                        dataContext.getEnvironment().getStrandLocal(HttpConstants.SRC_HANDLER));
-            }
+            outboundRequestMsg.setProperty(HttpConstants.SRC_HANDLER,
+                    dataContext.getEnvironment().getStrandLocal(HttpConstants.SRC_HANDLER));
         }
 
         Object poolableByteBufferFactory = outboundRequestMsg.getProperty(HttpConstants.POOLED_BYTE_BUFFER_FACTORY);

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/DefaultHttpClientConnector.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/DefaultHttpClientConnector.java
@@ -58,6 +58,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.NoSuchElementException;
+import java.util.concurrent.CountDownLatch;
 
 import static io.ballerina.stdlib.http.transport.contract.Constants.REMOTE_SERVER_CLOSED_BEFORE_INITIATING_OUTBOUND_REQUEST;
 
@@ -80,6 +81,8 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
     private EventLoopGroup clientEventGroup;
     private BootstrapConfiguration bootstrapConfig;
     private int configHashCode;
+    private CountDownLatch countDownLatch = new CountDownLatch(1);
+    private boolean firstCall = true;
 
     public DefaultHttpClientConnector(ConnectionManager connectionManager, SenderConfiguration senderConfiguration,
                                       BootstrapConfiguration bootstrapConfig, EventLoopGroup clientEventGroup,
@@ -182,11 +185,13 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
             final HttpRoute route = getTargetRoute(senderConfiguration.getScheme(), httpOutboundRequest,
                                                    this.configHashCode);
             if (isHttp2) {
+                waitTillInProgress();
                 // See whether an already upgraded HTTP/2 connection is available
                 Http2ClientChannel activeHttp2ClientChannel = http2ConnectionManager.borrowChannel(http2SourceHandler,
                                                                                                    route);
 
                 if (activeHttp2ClientChannel != null) {
+                    countDownLatch.countDown();
                     outboundMsgHolder.setHttp2ClientChannel(activeHttp2ClientChannel);
                     setHttp2ForwardedExtension(outboundMsgHolder);
                     new RequestWriteStarter(outboundMsgHolder, activeHttp2ClientChannel).startWritingContent();
@@ -254,6 +259,7 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
                     connectionManager.getHttp2ConnectionManager().
                             addHttp2ClientChannel(freshHttp2ClientChannel.getChannel().eventLoop(), route,
                                                   freshHttp2ClientChannel);
+                    countDownLatch.countDown();
                     freshHttp2ClientChannel.getConnection().remote().flowController().listener(
                             new ClientRemoteFlowControlListener(freshHttp2ClientChannel));
                     freshHttp2ClientChannel.addDataEventListener(
@@ -312,6 +318,18 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
             return notifyListenerAndGetErrorResponseFuture(failedCause);
         }
         return httpResponseFuture;
+    }
+
+    private synchronized void waitTillInProgress() {
+        try {
+            if (firstCall) {
+                firstCall = false;
+            } else {
+                countDownLatch.await();
+            }
+        } catch (InterruptedException e) {
+            LOG.warn("Interrupted before initiating the target channel");
+        }
     }
 
     private void setHttp2ForwardedExtension(OutboundMsgHolder outboundMsgHolder) {

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/http2/EventLoopPool.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/http2/EventLoopPool.java
@@ -63,8 +63,8 @@ class EventLoopPool {
         Http2ClientChannel fetchTargetChannel() {
             if (!http2ClientChannels.isEmpty()) {
                 Http2ClientChannel http2ClientChannel = http2ClientChannels.peek();
-                Channel channel = http2ClientChannel.getChannel();
-                if (!channel.isActive()) {  // if channel is not active, forget it and fetch next one
+                Channel channel = http2ClientChannel.getChannel().parent();
+                if (channel != null && !channel.isActive()) {  // if channel is not active, forget it and fetch next one
                     http2ClientChannels.remove(http2ClientChannel);
                     return fetchTargetChannel();
                 }


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/494

## Approach
 - Allow the first thread to initiate the target channel and add to the PerRouteConnectionPool
 - Allow other strands also to have pass properties. Outbound calls which done in workers do not have related Source handler info. 

## Examples
```ballerina
final http:Client http2Client = check new("http://localhost:9122", { httpVersion: "2.0",
                                http2Settings: { http2PriorKnowledge: true } });
                                
service /backEndService on new http:Listener(9122, { httpVersion: "2.0" }) {

    resource function get http2ReplyText(http:Caller caller, http:Request req) returns error? {
        check caller->respond("Hello");
    }
}

service /testHttp2Service on new http:Listener(9123, { httpVersion: "2.0" }) {

    resource function get clientGet(http:Caller caller, http:Request req) returns error? {
        foreach int i in 0 ..< 10 {
            _ = start runTest(i);
        }
        check caller->respond("Hello");
    }
}

function runTest(int i) {
    string value = "";
    http:Response|error response1 = http2Client->get("/backEndService/http2ReplyText");
    if response1 is http:Response {
        var result = response1.getTextPayload();
        if result is string {
            value = result;
        } else {
            value = result.message();
        }
    }
}

@test:Config {}
public function testHttp2GetAction() returns error? {
    http:Client clientEP = check new("http://localhost:9123", { httpVersion: "2.0"});
    http:Response|error resp = clientEP->get("/testHttp2Service/clientGet");
    if resp is http:Response {
        assertTextPayload(resp.getTextPayload(), "Hello");
        assertHeaderValue(check resp.getHeader("content-type"), "text/plain");
    } else {
        test:assertFail(msg = "Found unexpected output: " +  resp.message());
    }
}
```

## Server log output
Single channel has been reused in 10 calls
```
PerRouteConnectionPool fetchTargetChannel: channels empty
PerRouteConnectionPool addChannel:364868789
activeHttp2ClientChannel != null
activeHttp2ClientChannel != null
activeHttp2ClientChannel != null
activeHttp2ClientChannel != null
activeHttp2ClientChannel != null
activeHttp2ClientChannel != null
activeHttp2ClientChannel != null
activeHttp2ClientChannel != null
activeHttp2ClientChannel != null
```

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
