### PR TITLE
Add `enum` data-binding support

### DIFF
--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -107,8 +107,12 @@ dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "jwt"},
+	{org = "ballerina", name = "lang.boolean"},
+	{org = "ballerina", name = "lang.float"},
+	{org = "ballerina", name = "lang.int"},
 	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "lang.string"},
+	{org = "ballerina", name = "lang.xml"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mime"},
 	{org = "ballerina", name = "oauth2"},
@@ -183,6 +187,18 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.boolean"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.boolean", moduleName = "lang.boolean"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.decimal"
 version = "0.0.0"
 scope = "testOnly"
@@ -192,11 +208,26 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.float"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.float", moduleName = "lang.float"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.int"
 version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.int", moduleName = "lang.int"}
 ]
 
 [[package]]
@@ -236,6 +267,18 @@ version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.xml"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.xml", moduleName = "lang.xml"}
 ]
 
 [[package]]

--- a/ballerina-tests/tests/service_dispatching_data_binding_anydata_test.bal
+++ b/ballerina-tests/tests/service_dispatching_data_binding_anydata_test.bal
@@ -18,6 +18,32 @@ import ballerina/lang.'string as strings;
 import ballerina/test;
 import ballerina/http;
 
+enum MenuType {
+    BREAK_FAST,
+    LUNCH,
+    DINNER
+}
+
+type MenuItem record {|
+    int _id;
+    string name;
+    string description;
+    decimal price;
+|};
+
+type Menu record {|
+    int _id;
+    MenuType 'type;
+    MenuItem[] items;
+|};
+
+type Restaurant record {|
+    string name;
+    string city;
+    string description;
+    Menu[] menus;
+|};
+
 type newXmlElement xml:Element;
 
 final http:Client anydataBindingClient = check new("http://localhost:" + generalPort.toString(), httpVersion = "1.1");
@@ -319,6 +345,15 @@ service /anydataB on generalListener {
 
     resource function post checkIntSigned32(@http:Payload int:Signed32 payload) returns int:Signed32 {
         return payload;
+    }
+
+    // enums
+    resource function post checkEnum(@http:Payload MenuType menuType) returns MenuType {
+        return menuType;
+    }
+
+    resource function post checkRecordWithEnum(@http:Payload Restaurant restaurant) returns Restaurant {
+        return restaurant;
     }
 }
 
@@ -943,4 +978,28 @@ function testDataBindingSubtypeIntSigned32() returns error? {
     int:Signed32 payload = 123;
     int:Signed32 response = check anydataBindingClient->post("/anydataB/checkIntSigned32", payload);
     test:assertEquals(response, payload);
+}
+
+@test:Config {}
+function testDataBindingEnum() returns error? {
+    MenuType response = check anydataBindingClient->post("/anydataB/checkEnum", "DINNER");
+    test:assertEquals(response, "DINNER");
+}
+
+@test:Config {}
+function testDataBindingRecordWithEnum() returns error? {
+    Restaurant restaurant = {
+        name : "name1",
+        city : "city1",
+        description : "description1",
+        menus : [
+            {
+                _id : 5,
+                'type : "LUNCH",
+                items : []
+            }
+        ]
+    };
+    Restaurant response = check anydataBindingClient->post("/anydataB/checkRecordWithEnum", restaurant);
+    test:assertEquals(response, restaurant);
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -101,16 +101,6 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testSample() {
-        Package currentPackage = loadPackage("sample_package");
-        PackageCompilation compilation = currentPackage.getCompilation();
-        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
-        long availableErrors = diagnosticResult.diagnostics().stream()
-                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR)).count();
-        Assert.assertEquals(availableErrors, 0);
-    }
-
-    @Test
     public void testInvalidMethodTypes() {
         Package currentPackage = loadPackage("sample_package_1");
         PackageCompilation compilation = currentPackage.getCompilation();

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -101,6 +101,16 @@ public class CompilerPluginTest {
     }
 
     @Test
+    public void testSample() {
+        Package currentPackage = loadPackage("sample_package");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        long availableErrors = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR)).count();
+        Assert.assertEquals(availableErrors, 0);
+    }
+
+    @Test
     public void testInvalidMethodTypes() {
         Package currentPackage = loadPackage("sample_package_1");
         PackageCompilation compilation = currentPackage.getCompilation();

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_4/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_4/service.bal
@@ -319,3 +319,48 @@ service http:Service on new http:Listener(9090) {
         return "done"; //error
     }
 }
+
+enum MenuType {
+    BREAK_FAST,
+    LUNCH,
+    DINNER
+}
+
+type Item record {|
+    int _id;
+    string name;
+    string description;
+    decimal price;
+|};
+
+type Menu record {|
+    int _id;
+    MenuType 'type;
+    Item[] items;
+|};
+
+type Restaurant record {|
+    string name;
+    string city;
+    string description;
+    Menu[] menus;
+|};
+
+service on new http:Listener(9091) {
+
+    resource function post menuType(@http:Payload MenuType menuType)
+            returns http:Accepted {
+        return http:ACCEPTED;
+    }
+
+    resource function post menu(@http:Payload Menu menu)
+            returns http:Created {
+        return http:CREATED;
+    }
+
+    resource function post restaurants(@http:Payload Restaurant restaurant)
+            returns http:Created {
+        return http:CREATED;
+    }
+}
+

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpCompilerPluginUtil.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpCompilerPluginUtil.java
@@ -127,7 +127,7 @@ public class HttpCompilerPluginUtil {
         }
         TypeDescKind kind = returnTypeSymbol.typeKind();
         if (isAnyDataType(kind) || kind == TypeDescKind.ERROR || kind == TypeDescKind.NIL ||
-                kind == TypeDescKind.ANYDATA) {
+                kind == TypeDescKind.ANYDATA || kind == TypeDescKind.SINGLETON) {
             return;
         }
         if (kind == TypeDescKind.INTERSECTION) {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
@@ -561,7 +561,7 @@ class HttpResourceValidator {
             }
             return isValidPayloadParamType(typeDescriptor, ctx, paramLocation, paramName);
         }
-        if (isAnyDataType(kind)) {
+        if (isAnyDataType(kind) || kind == TypeDescKind.SINGLETON) {
             return true;
         } else if (kind == TypeDescKind.ARRAY) {
             TypeSymbol arrTypeSymbol = ((ArrayTypeSymbol) typeDescriptor).memberTypeDescriptor();

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/builder/StringPayloadBuilder.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/builder/StringPayloadBuilder.java
@@ -54,7 +54,8 @@ public class StringPayloadBuilder extends AbstractPayloadBuilder {
     }
 
     private Object createValue(Type payloadType, boolean readonly, BString dataSource) {
-        if (payloadType.getTag() == TypeTags.STRING_TAG || payloadType.getTag() == TypeTags.CHAR_STRING_TAG) {
+        if (payloadType.getTag() == TypeTags.STRING_TAG || payloadType.getTag() == TypeTags.CHAR_STRING_TAG ||
+                payloadType.getTag() == TypeTags.FINITE_TYPE_TAG) {
             return dataSource;
         } else if (payloadType.getTag() == TypeTags.ARRAY_TAG) {
             return StringToByteArrayConverter.convert((ArrayType) payloadType, dataSource, readonly);


### PR DESCRIPTION
## Purpose

> $Subject

> Fixes : [`Records with enum objects are not supported as payload #2966`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2966)

## Examples

```ballerina
enum MenuType {
    BREAK_FAST,
    LUNCH,
    DINNER
}

type Item record {|
    int _id;
    string name;
    string description;
    decimal price;
|};

type Menu record {|
    int _id;
    MenuType 'type;
    Item[] items;
|};

type Restaurant record {|
    string name;
    string city;
    string description;
    Menu[] menus;
|};

service on new http:Listener(9091) {

    resource function post menuType(@http:Payload MenuType menuType)
            returns MenuType {
        return menuType;
    }

    resource function post menu(@http:Payload Menu menu)
            returns Menu {
        return menu;
    }

    resource function post restaurants(@http:Payload Restaurant restaurant)
            returns Restaurant  {
        return restaurant;
    }
}
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] <s>Updated the spec</s>
