### PR TITLE
Correlate http2 source handler to the target channel thread pools

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -19,13 +19,13 @@ path = "../native/build/libs/http-native-2.4.0-SNAPSHOT.jar"
 groupId = "io.ballerina.stdlib"
 artifactId = "mime-native"
 version = "2.4.0"
-path = "./lib/mime-native-2.4.0-20220725-195700-6ca85ae.jar"
+path = "./lib/mime-native-2.4.0-20220727-002600-4748bde.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "constraint-native"
 version = "1.0.0"
-path = "./lib/constraint-native-1.0.0-20220725-150900-09f2f31.jar"
+path = "./lib/constraint-native-1.0.0-20220726-233800-e82b939.jar"
 
 [[platform.java11.dependency]]
 path = "./lib/netty-common-4.1.77.Final.jar"

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/DefaultHttpClientConnector.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/DefaultHttpClientConnector.java
@@ -183,7 +183,8 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
                                                    this.configHashCode);
             if (http2) {
                 // See whether an already upgraded HTTP/2 connection is available
-                Http2ClientChannel activeHttp2ClientChannel = http2ConnectionManager.borrowChannel(route);
+                Http2ClientChannel activeHttp2ClientChannel = http2ConnectionManager.borrowChannel(http2SourceHandler,
+                                                                                                   route);
 
                 if (activeHttp2ClientChannel != null) {
                     outboundMsgHolder.setHttp2ClientChannel(activeHttp2ClientChannel);
@@ -250,7 +251,8 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
 
                 private void prepareTargetChannelForHttp2() {
                     freshHttp2ClientChannel.setSocketIdleTimeout(socketIdleTimeout);
-                    connectionManager.getHttp2ConnectionManager().addHttp2ClientChannel(route, freshHttp2ClientChannel);
+                    connectionManager.getHttp2ConnectionManager().addHttp2ClientChannel(
+                            freshHttp2ClientChannel.getChannel().eventLoop(), route, freshHttp2ClientChannel);
                     freshHttp2ClientChannel.getConnection().remote().flowController().listener(
                             new ClientRemoteFlowControlListener(freshHttp2ClientChannel));
                     freshHttp2ClientChannel.addDataEventListener(

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/TargetHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/TargetHandler.java
@@ -191,8 +191,9 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
 
     private void handoverChannelToHttp2ConnectionManager() {
         Http2ClientChannel upgradedHttp2ClientChannel = targetChannel.getHttp2ClientChannel();
-        connectionManager.getHttp2ConnectionManager().addHttp2ClientChannel(targetChannel.getHttpRoute(),
-                                                                            upgradedHttp2ClientChannel);
+        connectionManager.getHttp2ConnectionManager()
+                .addHttp2ClientChannel(targetChannel.getChannel().eventLoop(), targetChannel.getHttpRoute(),
+                                       upgradedHttp2ClientChannel);
         upgradedHttp2ClientChannel.getConnection().remote().flowController().listener(
             new ClientRemoteFlowControlListener(upgradedHttp2ClientChannel));
     }
@@ -207,7 +208,8 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
     }
 
     private void releasePerRoutePoolLatchOnFailure() {
-        connectionManager.getHttp2ConnectionManager().releasePerRoutePoolLatch(targetChannel.getHttpRoute());
+        connectionManager.getHttp2ConnectionManager()
+                .releasePerRoutePoolLatch(targetChannel.getChannel().eventLoop(), targetChannel.getHttpRoute());
     }
 
     public void setHttpResponseFuture(HttpResponseFuture httpResponseFuture) {

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/http2/Http2ConnectionManager.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/http2/Http2ConnectionManager.java
@@ -94,10 +94,6 @@ public class Http2ConnectionManager {
      * @return PerRouteConnectionPool
      */
     private Http2ChannelPool getOrCreateEventLoopPool(EventLoop eventLoop) {
-        final Http2ChannelPool pool = h2ChannelPools.get(eventLoop);
-        if (pool != null) {
-            return pool;
-        }
         return h2ChannelPools.computeIfAbsent(eventLoop, e -> new Http2ChannelPool());
     }
 

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/TestExhaustedStreamIdForClient.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/TestExhaustedStreamIdForClient.java
@@ -100,7 +100,7 @@ public class TestExhaustedStreamIdForClient {
         assertEquals(firstResult, testValue, "Expected response not received");
 
         Http2ClientChannel http2ClientChannel = connectionManager.getHttp2ConnectionManager()
-            .borrowChannel(new HttpRoute(Constants.HTTP_SCHEME, LOCALHOST,
+            .borrowChannel(null, new HttpRoute(Constants.HTTP_SCHEME, LOCALHOST,
                                                HTTP_SERVER_PORT, 0));
 
         //Simulate the stream id to have reached its max value for the connection.

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/util/Http2Util.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/util/Http2Util.java
@@ -42,6 +42,7 @@ import static io.ballerina.stdlib.http.transport.contract.Constants.HTTPS_SCHEME
 import static io.ballerina.stdlib.http.transport.contract.Constants.HTTP_2_0;
 import static io.ballerina.stdlib.http.transport.contract.Constants.OPTIONAL;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 /**
  * Utilities required for HTTP/2 test cases.
@@ -118,8 +119,10 @@ public class Http2Util {
     }
 
     public static void assertResult(String response1, String response2, String response3, String response4) {
-        assertEquals(response1, response2, "Client uses the same pool, hence response 1 and 3 should be equal");
-        assertEquals(response3, response4, "Client uses the same pool, hence response 1 and 3 should be equal");
+        assertNotEquals(response1, response2,
+                        "Client uses two different pools, hence response 1 and 2 should not be equal");
+        assertNotEquals(response3, response4,
+                        "Client uses two different pools, hence response 3 and 4 should not be equal");
         assertEquals(response1, response3, "Client uses the same pool, hence response 1 and 3 should be equal");
         assertEquals(response2, response4, "Client uses the same pool, hence response 2 and 4 should be equal");
     }


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/3190
> With this change, 10 clients will create 10 channels. 10 current request of a single client will create only 1 connection. Initial channel creation is still synchronised.
<img width="706" alt="Screenshot 2022-08-03 at 17 33 54" src="https://user-images.githubusercontent.com/8381003/182603400-918383ed-1b7b-4d47-aebb-f7b40dd14586.png">


## Examples
```ballerina
import ballerina/http;
import ballerina/test;

final http:Client http2Client = check new("http://localhost:9122", { httpVersion: "2.0",
                                http2Settings: { http2PriorKnowledge: true } });
                                
service /backEndService on new http:Listener(9122, { httpVersion: "2.0" }) {

    resource function get http2ReplyText(http:Caller caller, http:Request req) returns error? {
        check caller->respond("Hello");
    }
}

service /testHttp2Service on new http:Listener(9123, { httpVersion: "2.0" }) {

    resource function get clientGet(http:Caller caller, http:Request req) returns error? {
        foreach int i in 0 ..< 10 {
            _ = start runTest(i);
        }
        check caller->respond("Hello");
    }
}

function runTest(int i) {
    string value = "";
    http:Response|error response1 = http2Client->get("/backEndService/http2ReplyText");
    if response1 is http:Response {
        var result = response1.getTextPayload();
        if result is string {
            value = result;
        } else {
            value = result.message();
        }
    }
}

@test:Config {}
public function testHttp2GetAction() returns error? {
    http:Client clientEP = check new("http://localhost:9123", { httpVersion: "2.0"});
    http:Response|error resp = clientEP->get("/testHttp2Service/clientGet");
    if resp is http:Response {
        assertTextPayload(resp.getTextPayload(), "Hello");
        assertHeaderValue(check resp.getHeader("content-type"), "text/plain");
    } else {
        test:assertFail(msg = "Found unexpected output: " +  resp.message());
    }
}
```

Output
```
PerRouteConnectionPool addChannel:1370934327
activeHttp2ClientChannel != null
activeHttp2ClientChannel != null
activeHttp2ClientChannel != null
activeHttp2ClientChannel != null
activeHttp2ClientChannel != null
activeHttp2ClientChannel != null
activeHttp2ClientChannel != null
activeHttp2ClientChannel != null
activeHttp2ClientChannel != null
```
## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
