### PR TITLE
Add `Links` as header when the return type is a closed record

### DIFF
--- a/ballerina/http_connection.bal
+++ b/ballerina/http_connection.bal
@@ -148,11 +148,11 @@ public isolated client class Caller {
                 response = createStatusCodeResponse(errResponse);
             } else {
                 Accepted acceptedResponse = {};
-                response = createStatusCodeResponse(acceptedResponse);
+                response = createStatusCodeResponse(acceptedResponse, links = links);
             }
         } else if message is StatusCodeResponse {
             if message is SuccessStatusCodeResponse {
-                response = createStatusCodeResponse(message, returnMediaType, setETag);
+                response = createStatusCodeResponse(message, returnMediaType, setETag, links);
                 cacheCompatibleType = true;
             } else {
                 response = createStatusCodeResponse(message, returnMediaType);
@@ -165,7 +165,7 @@ public isolated client class Caller {
                 response.setHeader(CONTENT_TYPE, returnMediaType);
             }
         } else {
-            setPayload(message, response, returnMediaType, setETag);
+            setPayload(message, response, returnMediaType, setETag, links);
             if returnMediaType is string {
                 response.setHeader(CONTENT_TYPE, returnMediaType);
             }
@@ -182,7 +182,6 @@ public isolated client class Caller {
                 response.setLastModified();
             }
         }
-        addLinkHeader(response, links);
         return nativeRespond(self, response);
     }
 
@@ -203,7 +202,7 @@ public isolated client class Caller {
     }
 }
 
-isolated function createStatusCodeResponse(StatusCodeResponse message, string? returnMediaType = (), boolean setETag = false)
+isolated function createStatusCodeResponse(StatusCodeResponse message, string? returnMediaType = (), boolean setETag = false, map<Link>? links = ())
     returns Response {
     Response response = new;
     response.statusCode = message.status.code;
@@ -233,7 +232,7 @@ isolated function createStatusCodeResponse(StatusCodeResponse message, string? r
         }
     }
     string? mediaType = retrieveMediaType(message, returnMediaType);
-    setPayload(message?.body, response, mediaType, setETag);
+    setPayload(message?.body, response, mediaType, setETag, links);
     // Update content-type header according to the priority. (Highest to lowest)
     // 1. MediaType field in response record
     // 2. Payload annotation mediaType value
@@ -292,7 +291,28 @@ isolated function arrayToString(string[] arr) returns string {
     return arrayString.substring(1, arrayString.length() - 1);
 }
 
-isolated function setPayload(anydata payload, Response response, string? mediaType = (), boolean setETag = false) {
+isolated function addLinksToPayload(anydata message, map<Link>? links) returns [boolean, anydata] {
+    if links !is () {
+        if message is map<anydata> && !message.hasKey("_links") {
+            error? err = trap addLinksToJsonPayload(message, links);
+            if err !is error {
+                return [true, message];
+            }
+        }
+    }
+    return [false, message];
+}
+
+isolated function addLinksToJsonPayload(map<anydata> message, map<Link> links) {
+    message["_links"] = links.toJson();
+}
+
+isolated function setPayload(anydata message, Response response, string? mediaType = (), boolean setETag = false, map<Link>? links = ()) {
+    [boolean, anydata] [isLinksAddedToPayload, payload] = addLinksToPayload(message, links);
+    if !isLinksAddedToPayload {
+        addLinkHeader(response, links);
+    }
+
     if payload is () {
         return;
     }

--- a/ballerina/http_connection.bal
+++ b/ballerina/http_connection.bal
@@ -292,7 +292,7 @@ isolated function arrayToString(string[] arr) returns string {
 }
 
 isolated function addLinksToPayload(anydata message, map<Link>? links) returns [boolean, anydata] {
-    if links !is () {
+    if links is map<Link> {
         if message is map<anydata> && !message.hasKey("_links") {
             error? err = trap addLinksToJsonPayload(message, links);
             if err !is error {

--- a/ballerina/http_connection.bal
+++ b/ballerina/http_connection.bal
@@ -292,7 +292,7 @@ isolated function arrayToString(string[] arr) returns string {
 }
 
 isolated function addLinksToPayload(anydata message, map<Link>? links) returns [boolean, anydata] {
-    if links is map<Link> {
+    if links !is () {
         if message is map<anydata> && !message.hasKey("_links") {
             error? err = trap addLinksToJsonPayload(message, links);
             if err !is error {

--- a/docs/proposals/introducing-initial-support-for-hateoas.md
+++ b/docs/proposals/introducing-initial-support-for-hateoas.md
@@ -188,15 +188,15 @@ public type Location record {|
     string address;
 |};
 
-public type Locations record {|
+public type Locations record {
     Location[] locations;
-|};
+};
 ```
 ```ballerina
-public type Locations record {|
+public type Locations record {
     *http:Links;
     Location[] locations;
-|};
+};
 ```
 > **Note**: Following is the definition of http:Link
 ```ballerina
@@ -257,6 +257,8 @@ For the non-json payloads the links will be added as `Link` header. Sample `Link
 ```
 link: </snowpeak/locations/{id}/rooms>; rel="room"; methods="\"GET\""
 ```
+> **Note**: The links will not be added either in payload or in header if the resource returns a `http:Response`.
+
 > **Note**: If the links are already added by the user either in the payload or as `Link` header, then the response 
 > will not be overwritten by the links generated from `linkedTo` configuration
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -1759,7 +1759,8 @@ public type Link record {
 ```
 
 This `Links` is generated from the `linkedTo` field in the `ResourceConfig` annotation, and added either to the 
-payload or as a `Link` header depends on the payload type.
+payload or as a `Link` header depends on the payload type. This `Links` will not be added when a `http:Response` is 
+returned.
 
 #### 7.2.1 LinkedTo record
 The `LinkedTo` record is defined as follows :
@@ -1828,25 +1829,25 @@ service on new http:Listener(port) {
 ```
 
 #### 7.2.2 Links in the response
-The static `Links` generated from the `linkedTo` field will be injected to the payload when the payload media-type is 
-JSON, and it is not `readonly`. Suppose the user returns the below record type, the runtime will inject the `Links` 
+The static `Links` generated from the `linkedTo` field will be injected to the json payload when it is not 
+a closed record and not `readonly`. Suppose the user returns the below record type, the runtime will inject the `Links` 
 record as in the latter. So the response should be considered as a record with `Links` field.
 
 ```ballerina
-public type 'Order record {|
+public type 'Order record {
     string item_name;
     string id;
     string quantity;
-|};
+};
 ```
 
 ```ballerina
-public type 'Order record {|
+public type 'Order record {
     *http:Links;
     string item_name;
     string id;
     string quantity;
-|};
+};
 ```
 
 Following is an example of `Links` in payload :

--- a/examples/snowpeak/README.md
+++ b/examples/snowpeak/README.md
@@ -280,11 +280,11 @@ type Location record {|
    string address;
 |};
 # Represents a collection of locations
-public type Locations record {|
+public type Locations record {
    *http:Links;
    # collection of locations
    Location[] locations;
-|};
+};
 ```
 
 Location has three fields: name, id and address. Each field is documented along with the Location record. Documentation is very important because it helps readers of the code to understand the code better and at the same time it helps API users understand the API as this documentation is mapped into OpenAPI documentation as descriptions. Many developers tend to think of documentation as a second class thing but it is not.

--- a/examples/snowpeak/service/modules/representations/representations.bal
+++ b/examples/snowpeak/service/modules/representations/representations.bal
@@ -26,10 +26,10 @@ public type Location record {|
     string address;
 |};
 # Represents a collection of locations
-public type Locations record {|
+public type Locations record {
     # collection of locations
     Location[] locations;
-|};
+};
 
 public enum RoomCategory {
     DELUXE,
@@ -66,10 +66,10 @@ public type Room record {|
     int count;
 |};
 # Represents a collection of resort rooms
-public type Rooms record {|
+public type Rooms record {
     # Array of rooms
     Room[] rooms;
-|};
+};
 
 # Represents rooms be reserved
 public type ReserveRoom record {|

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -520,11 +520,6 @@ public class HttpConstants {
     public static final BString LINK_HREF = StringUtils.fromString("href");
     public static final BString LINK_METHODS = StringUtils.fromString("methods");
     public static final BString LINK_TYPES = StringUtils.fromString("types");
-    public static final BString LINKS = StringUtils.fromString("_links");
-
-    //StatusCodeResponse field named
-    public static final BString STATUS = StringUtils.fromString("status");
-    public static final BString BODY = StringUtils.fromString("body");
 
     //WebSocket Related constants for WebSocket upgrade
     public static final String NATIVE_DATA_WEBSOCKET_CONNECTION_MANAGER = "NATIVE_DATA_WEBSOCKET_CONNECTION_MANAGER";

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpResource.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpResource.java
@@ -17,7 +17,9 @@
 */
 package io.ballerina.stdlib.http.api;
 
+import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
+import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.RemoteMethodType;
 import io.ballerina.runtime.api.types.ResourceMethodType;
@@ -42,6 +44,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.ballerina.stdlib.http.api.HttpConstants.ANN_NAME_RESOURCE_CONFIG;
+import static io.ballerina.stdlib.http.api.HttpConstants.LINK;
 import static io.ballerina.stdlib.http.api.HttpConstants.SINGLE_SLASH;
 import static io.ballerina.stdlib.http.api.HttpUtil.checkConfigAnnotationAvailability;
 import static io.ballerina.stdlib.http.api.HttpUtil.getParameterTypes;
@@ -66,10 +69,12 @@ public class HttpResource implements Resource {
     private static final BString HTTP_RESOURCE_CONFIG =
             StringUtils.fromString(ModuleUtils.getHttpPackageIdentifier() + ":" + ANN_NAME_RESOURCE_CONFIG);
     private static final String RETURN_ANNOT_PREFIX = "$returns$";
+    private static final MapType LINK_MAP_TYPE = TypeCreator.createMapType(TypeCreator.createRecordType(
+            LINK, ModuleUtils.getHttpPackage(), 0, false, 0));
 
     private String resourceLinkName;
     private List<LinkedResourceInfo> linkedResources = new ArrayList<>();
-    private BMap<BString, Object> links = ValueCreator.createMapValue();
+    private BMap<BString, Object> links = ValueCreator.createMapValue(LINK_MAP_TYPE);
     private List<BString> linkedRelations = new ArrayList<>();
     private MethodType balResource;
     private List<String> methods;


### PR DESCRIPTION
## Purpose

> $Subject
> Fixes : [`Fix adding links to close records #3212`](https://github.com/ballerina-platform/ballerina-standard-library/issues/3212)

## Examples

```ballerina
import ballerina/http;

type Order record {|
    string id;
    json 'order;
    decimal cost;
|};

type PaymentSlip record {|
    string id;
    decimal amount;
|};

service /restbucks on new http:Listener(9090) {

    @http:ResourceConfig {
        name: "order",
        linkedTo: [
            {name: "orders", relation: "update"},
            {name: "payment", relation: "payment"}
        ]
    }
    resource function post 'order(@http:Payload json 'order) returns Order {
        return {id: "001", 'order: 'order, cost: 49.30};
    }

    @http:ResourceConfig {
        name: "orders",
        linkedTo: [
            {name: "orders", relation: "update"},
            {name: "payment", relation: "payment"}
        ]
    }
    resource function put orders/[string id]() returns http:Ok {
        return http:OK;
    }

    @http:ResourceConfig {
        name: "payment"
    }
    resource function put payment/[string id](@http:Payload json payment)
           returns @http:Payload{mediaType: "application/restbucks.payment+json"} http:Accepted {
        PaymentSlip paymentSlip = { id: "1234", amount: 50.00};
        return { body: paymentSlip };
    }
}
```

```console
curl -v http://localhost:9090/restbucks/order -d '{"name":"latte", "quantity":2}' -H "Content-Type: application/json" 
```

```console
*   Trying 127.0.0.1:9090...
* Connected to localhost (127.0.0.1) port 9090 (#0)
> POST /restbucks/order HTTP/1.1
> Host: localhost:9090
> User-Agent: curl/7.79.1
> Accept: */*
> Content-Type: application/json
> Content-Length: 30
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 201 Created
< Link: </restbucks/orders/{id}>; rel="update"; methods=""PUT"", </restbucks/payment/{id}>; rel="payment"; methods=""PUT""; types=""application/restbucks.payment+json""
< content-type: application/json
< content-length: 66
< server: ballerina
< date: Thu, 4 Aug 2022 15:18:16 +0530
< 
* Connection #0 to host localhost left intact
{"id":"001", "order":{"name":"latte", "quantity":2}, "cost":49.30}
```

```console
curl -v http://localhost:9090/restbucks/payment/001 -d '{"amount":50.00}' -H "Content-Type: application/json" -X PUT
```

```console
*   Trying 127.0.0.1:9090...
* Connected to localhost (127.0.0.1) port 9090 (#0)
> PUT /restbucks/payment/001 HTTP/1.1
> Host: localhost:9090
> User-Agent: curl/7.79.1
> Accept: */*
> Content-Type: application/json
> Content-Length: 16
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 202 Accepted
< Link: </restbucks/order>; rel="order"; methods=""POST""
< content-type: application/restbucks.payment+json
< content-length: 29
< server: ballerina
< date: Thu, 4 Aug 2022 15:23:09 +0530
< 
* Connection #0 to host localhost left intact
{"id":"1234", "amount":50.00}
```

## Checklist
- [x] Linked to an issue
- [ ] <s>Updated the changelog</s>
- [x] Added tests
- [x] Updated the spec
