### PR TITLE
Change `Link` header array value format

### DIFF
--- a/ballerina-tests/tests/hateoas_tests.bal
+++ b/ballerina-tests/tests/hateoas_tests.bal
@@ -241,29 +241,29 @@ function testHateoasLinkHeaderWithClosedRecord() returns error? {
             value: "</restBucks/orders/{id}>", 
             params: {
                 rel: "\"update\"", 
-                methods: "\"\"PUT\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                methods: "\"PUT\"",
+                types: "\"application/vnd.restBucks+json\""}
         },
         { 
             value: "</restBucks/orders/{id}>", 
             params: {
                 rel: "\"status\"", 
-                methods: "\"\"GET\",\"POST\",\"PUT\",\"PATCH\",\"DELETE\",\"OPTIONS\",\"HEAD\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                methods: "\"GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD\"",
+                types: "\"application/vnd.restBucks+json\""}
         },
         { 
             value: "</restBucks/orders/{id}>", 
             params: {
                 rel: "\"cancel\"", 
-                methods: "\"\"DELETE\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                methods: "\"DELETE\"",
+                types: "\"application/vnd.restBucks+json\""}
         },
         { 
             value: "</restBucks/payment/{id}>", 
             params: {
                 rel: "\"payment\"", 
-                methods: "\"\"PUT\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                methods: "\"PUT\"",
+                types: "\"application/vnd.restBucks+json\""}
         }
     ];
     test:assertEquals(parsedLinkHeader, expectedLinkHeader);
@@ -280,29 +280,29 @@ function testHateoasLinkHeaderWithReadOnlyPayload() returns error? {
             value: "</restBucks/orders/{id}>", 
             params: {
                 rel: "\"self\"", 
-                methods: "\"\"GET\",\"POST\",\"PUT\",\"PATCH\",\"DELETE\",\"OPTIONS\",\"HEAD\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                methods: "\"GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD\"",
+                types: "\"application/vnd.restBucks+json\""}
         },
         { 
             value: "</restBucks/orders/{id}>", 
             params: {
                 rel: "\"update\"", 
-                methods: "\"\"PUT\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                methods: "\"PUT\"",
+                types: "\"application/vnd.restBucks+json\""}
         },
         { 
             value: "</restBucks/orders/{id}>", 
             params: {
                 rel: "\"cancel\"", 
-                methods: "\"\"DELETE\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                methods: "\"DELETE\"",
+                types: "\"application/vnd.restBucks+json\""}
         },
         { 
             value: "</restBucks/payment/{id}>", 
             params: {
                 rel: "\"payment\"", 
-                methods: "\"\"PUT\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                methods: "\"PUT\"",
+                types: "\"application/vnd.restBucks+json\""}
         }
     ];
     test:assertEquals(parsedLinkHeader, expectedLinkHeader);
@@ -351,8 +351,8 @@ function testHateoasLinkHeaderWithoutBody() returns error? {
             value: "</restBucks/orders/{id}>", 
             params: {
                 rel: "\"self\"", 
-                methods: "\"\"DELETE\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                methods: "\"DELETE\"",
+                types: "\"application/vnd.restBucks+json\""}
         }
     ];
     test:assertEquals(parsedLinkHeader, expectedLinkHeader);
@@ -389,15 +389,15 @@ function testHateoasLinkHeaderWithClosedRecordInBody() returns error? {
             value: "</restBucks/payment/{id}>", 
             params: {
                 rel: "\"self\"", 
-                methods: "\"\"PUT\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                methods: "\"PUT\"",
+                types: "\"application/vnd.restBucks+json\""}
         },
         { 
             value: "</restBucks/orders/{id}>", 
             params: {
                 rel: "\"status\"", 
-                methods: "\"\"GET\",\"POST\",\"PUT\",\"PATCH\",\"DELETE\",\"OPTIONS\",\"HEAD\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                methods: "\"GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD\"",
+                types: "\"application/vnd.restBucks+json\""}
         }
     ];
     test:assertEquals(parsedLinkHeader, expectedLinkHeader);

--- a/ballerina-tests/tests/http2_hateoas_tests.bal
+++ b/ballerina-tests/tests/http2_hateoas_tests.bal
@@ -130,7 +130,7 @@ function testHttp2HateoasLinks1() returns error? {
 
 @test:Config {}
 function testHttp2HateoasLinkHeaderWithClosedRecord() returns error? {
-    http:Response res = check jsonClientEP->post("/order?closed=true", mockOrder);
+    http:Response res = check http2JsonClientEP->post("/order?closed=true", mockOrder);
     test:assertTrue(res.hasHeader("Link"));
     string linkHeader = check res.getHeader("Link");
     http:HeaderValue[] parsedLinkHeader = check http:parseHeader(linkHeader);
@@ -139,29 +139,29 @@ function testHttp2HateoasLinkHeaderWithClosedRecord() returns error? {
             value: "</restBucks/orders/{id}>", 
             params: {
                 rel: "\"update\"", 
-                methods: "\"\"PUT\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                methods: "\"PUT\"",
+                types: "\"application/vnd.restBucks+json\""}
         },
         { 
             value: "</restBucks/orders/{id}>", 
             params: {
-                rel: "\"status\"", 
-                methods: "\"\"GET\",\"POST\",\"PUT\",\"PATCH\",\"DELETE\",\"OPTIONS\",\"HEAD\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                rel: "\"status\"",
+                methods: "\"GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD\"",
+                types: "\"application/vnd.restBucks+json\""}
         },
         { 
             value: "</restBucks/orders/{id}>", 
             params: {
-                rel: "\"cancel\"", 
-                methods: "\"\"DELETE\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                rel: "\"cancel\"",
+                methods: "\"DELETE\"",
+                types: "\"application/vnd.restBucks+json\""}
         },
         { 
             value: "</restBucks/payment/{id}>", 
             params: {
-                rel: "\"payment\"", 
-                methods: "\"\"PUT\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                rel: "\"payment\"",
+                methods: "\"PUT\"",
+                types: "\"application/vnd.restBucks+json\""}
         }
     ];
     test:assertEquals(parsedLinkHeader, expectedLinkHeader);
@@ -177,30 +177,30 @@ function testHttp2HateoasLinkHeaderWithReadOnlyPayload() returns error? {
         { 
             value: "</restBucks/orders/{id}>", 
             params: {
-                rel: "\"self\"", 
-                methods: "\"\"GET\",\"POST\",\"PUT\",\"PATCH\",\"DELETE\",\"OPTIONS\",\"HEAD\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                rel: "\"self\"",
+                methods: "\"GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD\"",
+                types: "\"application/vnd.restBucks+json\""}
         },
         { 
             value: "</restBucks/orders/{id}>", 
             params: {
-                rel: "\"update\"", 
-                methods: "\"\"PUT\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                rel: "\"update\"",
+                methods: "\"PUT\"",
+                types: "\"application/vnd.restBucks+json\""}
         },
         { 
             value: "</restBucks/orders/{id}>", 
             params: {
-                rel: "\"cancel\"", 
-                methods: "\"\"DELETE\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                rel: "\"cancel\"",
+                methods: "\"DELETE\"",
+                types: "\"application/vnd.restBucks+json\""}
         },
         { 
             value: "</restBucks/payment/{id}>", 
             params: {
-                rel: "\"payment\"", 
-                methods: "\"\"PUT\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                rel: "\"payment\"",
+                methods: "\"PUT\"",
+                types: "\"application/vnd.restBucks+json\""}
         }
     ];
     test:assertEquals(parsedLinkHeader, expectedLinkHeader);
@@ -249,9 +249,9 @@ function testHttp2HateoasLinkHeaderWithoutBody() returns error? {
         { 
             value: "</restBucks/orders/{id}>", 
             params: {
-                rel: "\"self\"", 
-                methods: "\"\"DELETE\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                rel: "\"self\"",
+                methods: "\"DELETE\"",
+                types: "\"application/vnd.restBucks+json\""}
         }
     ];
     test:assertEquals(parsedLinkHeader, expectedLinkHeader);
@@ -279,7 +279,7 @@ function testHttp2HateoasLinksInBody() returns error? {
 
 @test:Config {}
 function testHttp2HateoasLinkHeaderWithClosedRecordInBody() returns error? {
-    http:Response res = check jsonClientEP->put("/payment/001?closed=true", mockPayment);
+    http:Response res = check http2JsonClientEP->put("/payment/001?closed=true", mockPayment);
     test:assertTrue(res.hasHeader("Link"));
     string linkHeader = check res.getHeader("Link");
     http:HeaderValue[] parsedLinkHeader = check http:parseHeader(linkHeader);
@@ -287,16 +287,16 @@ function testHttp2HateoasLinkHeaderWithClosedRecordInBody() returns error? {
         { 
             value: "</restBucks/payment/{id}>", 
             params: {
-                rel: "\"self\"", 
-                methods: "\"\"PUT\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                rel: "\"self\"",
+                methods: "\"PUT\"",
+                types: "\"application/vnd.restBucks+json\""}
         },
         { 
             value: "</restBucks/orders/{id}>", 
             params: {
-                rel: "\"status\"", 
-                methods: "\"\"GET\",\"POST\",\"PUT\",\"PATCH\",\"DELETE\",\"OPTIONS\",\"HEAD\"\"",
-                types: "\"\"application/vnd.restBucks+json\"\""}
+                rel: "\"status\"",
+                methods: "\"GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD\"",
+                types: "\"application/vnd.restBucks+json\""}
         }
     ];
     test:assertEquals(parsedLinkHeader, expectedLinkHeader);

--- a/ballerina/http_connection.bal
+++ b/ballerina/http_connection.bal
@@ -268,7 +268,7 @@ isolated function addLinkHeader(Response response, map<Link>? links) {
 isolated function createLinkHeaderValue(map<Link>? links) returns string? {
     if links != () {
         string[] linkValues = from var [rel, link] in links.entries() select createLink(rel, link);
-        return string:'join(", ", ...linkValues);
+        return arrayToString(linkValues);
     }
     return;
 }
@@ -287,8 +287,7 @@ isolated function createLink(string rel, Link link) returns string {
 }
 
 isolated function arrayToString(string[] arr) returns string {
-    string arrayString = arr.toString();
-    return arrayString.substring(1, arrayString.length() - 1);
+    return string:'join(", ", ...arr);
 }
 
 isolated function addLinksToPayload(anydata message, map<Link>? links) returns [boolean, anydata] {


### PR DESCRIPTION
## Purpose

Change the `Link` header array values such as `methods` and `types` to token formats.

## Examples

Previous `Link` Header :

```console
Link: </restbucks/orders/{id}>; rel="update"; methods=""GET","POST","PUT","PATCH","DELETE","OPTIONS","HEAD"", 
</restbucks/payment/{id}>; rel="payment"; methods=""PUT""; types=""application/restbucks.payment+json""
```

After this change :

```console
Link: </restbucks/orders/{id}>; rel="update"; methods="GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD", 
</restbucks/payment/{id}>; rel="payment"; methods="PUT"; types="application/restbucks.payment+json"
```

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
