### PR TITLE
Allow type references as query param types

### DIFF
--- a/ballerina-tests/tests/http2_to_http1_client_fallback_test.bal
+++ b/ballerina-tests/tests/http2_to_http1_client_fallback_test.bal
@@ -58,7 +58,10 @@ public function testClientFallbackFromH2ToH1() returns error? {
 public function testSslClientFallbackFromH2ToH1() returns error? {
     string payload = check fallbackSslClient->get("/helloWorldWithSSL");
     test:assertEquals(payload, version_1_1, msg = "Found unexpected output");
+}
 
-    payload = check fallbackSslClient->get("/helloWorldWithSSL");
+@test:Config {dependsOn:[testSslClientFallbackFromH2ToH1]}
+public function testSslClientFallbackFromH2ToH1Subsequent() returns error? {
+    string payload = check fallbackSslClient->get("/helloWorldWithSSL");
     test:assertEquals(payload, version_1_1, msg = "Found unexpected output");
 }

--- a/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
@@ -24,6 +24,9 @@ final http:Client queryBindingClient = check new("http://localhost:" + queryPara
 // This is user-defined type
 public type Count int;
 public type TypeJson json;
+public type Name string;
+public type FirstName Name;
+public type FullName FirstName;
 
 service /queryparamservice on QueryBindingEP {
 
@@ -105,6 +108,10 @@ service /queryparamservice on QueryBindingEP {
 
     resource function get petsMap(map<TypeJson> count) returns json {
         return count;
+    }
+    
+    resource function get nestedTypeRef(FullName name) returns string {
+        return name;
     }
 }
 
@@ -357,6 +364,9 @@ function testTypeReferenceQueryParamBinding() returns error? {
 
     response = check queryBindingClient->get("/queryparamservice/petsArr?count=30,20,10");
     assertTextPayload(response.getTextPayload(), "30");
+    
+    response = check queryBindingClient->get("/queryparamservice/nestedTypeRef?name=wso2");
+    assertTextPayload(response.getTextPayload(), "wso2");
 }
 
 @test:Config {}

--- a/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
@@ -21,6 +21,10 @@ import ballerina/url;
 listener http:Listener QueryBindingEP = new(queryParamBindingTest, httpVersion = http:HTTP_1_1);
 final http:Client queryBindingClient = check new("http://localhost:" + queryParamBindingTest.toString(), httpVersion = http:HTTP_1_1);
 
+// This is user-defined type
+public type Count int;
+public type TypeJson json;
+
 service /queryparamservice on QueryBindingEP {
 
     resource function get .(string foo, http:Caller caller, int bar, http:Request req) returns error? {
@@ -34,19 +38,19 @@ service /queryparamservice on QueryBindingEP {
         check caller->respond(responseJson);
     }
 
-    resource function get q2(int[] id, string[] PersoN, float[] val, boolean[] isPresent, 
+    resource function get q2(int[] id, string[] PersoN, float[] val, boolean[] isPresent,
             http:Caller caller, decimal[] dc) returns error? {
         json responseJson = { iValue: id, sValue: PersoN, fValue: val, bValue: isPresent, dValue: dc };
         check caller->respond(responseJson);
     }
 
-    resource function get q3(http:Caller caller, int? id, string? PersoN, float? val, 
+    resource function get q3(http:Caller caller, int? id, string? PersoN, float? val,
             boolean? isPresent, decimal? dc) returns error? {
         json responseJson = { iValue: id, sValue: PersoN, fValue: val, bValue: isPresent, dValue: dc };
         check caller->respond(responseJson);
     }
 
-    resource function get q4(int[]? id, string[]? PersoN, float[]? val, boolean[]? isPresent, 
+    resource function get q4(int[]? id, string[]? PersoN, float[]? val, boolean[]? isPresent,
             http:Caller caller, decimal[]? dc) returns error? {
         json responseJson = { iValue: id, sValue: PersoN, fValue: val, bValue: isPresent, dValue: dc };
         check caller->respond(responseJson);
@@ -82,6 +86,25 @@ service /queryparamservice on QueryBindingEP {
 
     resource function get q10(string? x\-Type) returns string {
         return x\-Type ?: "default";
+    }
+
+    resource function get pets(Count count) returns http:Ok {
+        http:Ok ok = {body: count};
+        return ok;
+    }
+
+    resource function get petsUnion(Count? count) returns http:Ok {
+        http:Ok ok = {body: "nil"};
+        return ok;
+    }
+
+    resource function get petsArr(Count[] count) returns http:Ok {
+        http:Ok ok = {body: count[0]};
+        return ok;
+    }
+
+    resource function get petsMap(map<TypeJson> count) returns json {
+        return count;
     }
 }
 
@@ -322,4 +345,24 @@ function testOptionalRepeatingQueryParamBinding() {
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }
+}
+
+@test:Config {}
+function testTypeReferenceQueryParamBinding() returns error? {
+    http:Response response = check queryBindingClient->get("/queryparamservice/pets?count=10");
+    assertTextPayload(response.getTextPayload(), "10");
+
+    response = check queryBindingClient->get("/queryparamservice/petsUnion?");
+    assertTextPayload(response.getTextPayload(), "nil");
+
+    response = check queryBindingClient->get("/queryparamservice/petsArr?count=30,20,10");
+    assertTextPayload(response.getTextPayload(), "30");
+}
+
+@test:Config {}
+function testTypeReferenceConstrainedMapQueryParamBinding() returns error? {
+    map<json> jsonObj = { name : "test", value : "json" };
+    string jsonEncoded = check url:encode(jsonObj.toJsonString(), "UTF-8");
+    http:Response response = check queryBindingClient->get("/queryparamservice/petsMap?count=" + jsonEncoded);
+    assertJsonPayloadtoJsonString(response.getJsonPayload(), jsonObj);
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/service.bal
@@ -24,6 +24,9 @@ type Caller record {|
 // This is user-defined type
 public type Count int;
 public type TypeJson json;
+public type Name string;
+public type FirstName Name;
+public type FullName FirstName;
 
 service http:Service on new http:Listener(9090) {
 
@@ -123,6 +126,11 @@ service http:Service on new http:Listener(9090) {
     }
 
     resource function get petsMap(map<TypeJson> count) returns http:Ok {
+        http:Ok ok = {body: ()};
+        return ok;
+    }
+
+    resource function get nestedTypeRef(FullName names) returns http:Ok {
         http:Ok ok = {body: ()};
         return ok;
     }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/service.bal
@@ -21,6 +21,10 @@ type Caller record {|
     int id;
 |};
 
+// This is user-defined type
+public type Count int;
+public type TypeJson json;
+
 service http:Service on new http:Listener(9090) {
 
     resource function get callerInfo1(string a, int[] b, float? c, decimal[]? d) returns string {
@@ -101,5 +105,25 @@ service http:Service on new http:Listener(9090) {
 
     resource function get callerErr10(json[] d, xml e) returns string {
             return "done";
+    }
+
+    resource function get pets(Count count) returns http:Ok {
+        http:Ok ok = {body: ()};
+        return ok;
+    }
+
+    resource function get petsUnion(Count? count) returns http:Ok {
+        http:Ok ok = {body: ()};
+        return ok;
+    }
+
+    resource function get petsArr(Count[] count) returns http:Ok {
+        http:Ok ok = {body: ()};
+        return ok;
+    }
+
+    resource function get petsMap(map<TypeJson> count) returns http:Ok {
+        http:Ok ok = {body: ()};
+        return ok;
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllQueryParams.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllQueryParams.java
@@ -25,6 +25,7 @@ import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.JsonUtils;
 import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.utils.TypeUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
@@ -91,7 +92,8 @@ public class AllQueryParams implements Parameter {
                 BArray queryValueArr = (BArray) queryValue;
                 Type paramType = queryParam.getType();
                 if (paramType.getTag() == ARRAY_TAG) {
-                    int elementTypeTag = ((ArrayType) paramType).getElementType().getTag();
+                    Type elementType = ((ArrayType) paramType).getElementType();
+                    int elementTypeTag = TypeUtils.getReferredType(elementType).getTag();
                     BArray paramArray = ParamUtils.castParamArray(elementTypeTag, queryValueArr.getStringArray());
                     if (queryParam.isReadonly()) {
                         paramArray.freezeDirect();


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/3064

## Examples
```ballerina
public type Name string;
public type FirstName Name;
public type FullName FirstName;

service /queryparamservice on QueryBindingEP {
    resource function get nestedTypeRef(FullName name) returns string {
        return name;
    }
}
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
