### PR TITLE
Use server pipeline channel to perform immediate stop

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/HttpServerChannelInitializer.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/HttpServerChannelInitializer.java
@@ -31,6 +31,7 @@ import io.ballerina.stdlib.http.transport.contractimpl.listener.http2.Http2ToHtt
 import io.ballerina.stdlib.http.transport.contractimpl.listener.http2.Http2WithPriorKnowledgeHandler;
 import io.ballerina.stdlib.http.transport.contractimpl.sender.CertificateValidationHandler;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
@@ -107,14 +108,15 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
     private long pipeliningLimit;
     private EventExecutorGroup pipeliningGroup;
     private boolean webSocketCompressionEnabled;
-    private ChannelPipeline serverPipeline;
+    private Channel pipelineChannel;
 
     @Override
     public void initChannel(SocketChannel ch) throws Exception {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Initializing source channel pipeline");
         }
-        serverPipeline = ch.pipeline();
+        ChannelPipeline serverPipeline = ch.pipeline();
+        pipelineChannel = serverPipeline.channel();
 
         if (http2Enabled) {
             if (sslHandlerFactory != null) {
@@ -392,8 +394,8 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
         this.webSocketCompressionEnabled = webSocketCompressionEnabled;
     }
 
-    public ChannelPipeline getServerPipeline() {
-        return serverPipeline;
+    public Channel getPipelineChannel() {
+        return pipelineChannel;
     }
 
     /**

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/ServerConnectorBootstrap.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/ServerConnectorBootstrap.java
@@ -245,7 +245,7 @@ public class ServerConnectorBootstrap {
 
         @Override
         public void immediateStop() {
-            httpServerChannelInitializer.getServerPipeline().close().addListener(future -> {
+            httpServerChannelInitializer.getPipelineChannel().close().addListener(future -> {
                 if (future.isSuccess()) {
                     if (log.isDebugEnabled()) {
                         log.debug("HTTP listener on host {} and port {} has immediately stopped", getHost(), getPort());


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/3228
Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/1794

## Examples
https://livebook.manning.com/book/netty-in-action/chapter-6/157
https://netty.io/4.0/api/io/netty/channel/ChannelPipeline.html

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
