### PR TITLE
Immediately stop the respective listener when a panic occurs inside a resource

### DIFF
--- a/ballerina-tests/tests/http_listener_method_service_test.bal
+++ b/ballerina-tests/tests/http_listener_method_service_test.bal
@@ -144,7 +144,7 @@ function testImmediateStopMethod() returns error? {
 
 @test:Config {dependsOn:[testImmediateStopMethod]}
 function testInvokingStoppedImmediateService() returns error? {
-    final http:Client backendImmediateStopTestClient = check new("http://localhost:" + listenerMethodTestPort2.toString(), 
+    final http:Client backendImmediateStopTestClient = check new("http://localhost:" + listenerMethodTestPort2.toString(),
         httpVersion = http:HTTP_1_1, http1Settings = { keepAlive: http:KEEPALIVE_NEVER });
     http:Response|error response = backendImmediateStopTestClient->get("/mock1");
     if response is error {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/BallerinaHTTPConnectorListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/BallerinaHTTPConnectorListener.java
@@ -276,9 +276,8 @@ public class BallerinaHTTPConnectorListener implements HttpConnectorListener {
                 extractPropertiesAndStartResourceExecution(inboundMessage, httpResource);
             }
         } catch (BallerinaConnectorException ex) {
-            HttpCallableUnitCallback callback = new HttpCallableUnitCallback(inboundMessage,
-                                                                             httpServicesRegistry.getRuntime(),
-                                                                             httpResource, immediateStopFuture);
+            HttpCallableUnitCallback callback = new HttpCallableUnitCallback(
+                    inboundMessage, httpServicesRegistry.getRuntime(), httpResource, immediateStopFuture);
             callback.invokeErrorInterceptors(HttpUtil.createError(ex), false);
         }
     }
@@ -316,6 +315,5 @@ public class BallerinaHTTPConnectorListener implements HttpConnectorListener {
 
     public void setImmediateStopNotifier(ImmediateStopFuture immediateStopFuture) {
         this.immediateStopFuture = immediateStopFuture;
-
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
@@ -60,7 +60,7 @@ public class HttpCallableUnitCallback implements Callback {
         this.immediateStopFuture = immediateStopFuture;
     }
 
-    public HttpCallableUnitCallback(HttpCarbonMessage requestMessage, Runtime runtime) {
+    HttpCallableUnitCallback(HttpCarbonMessage requestMessage, Runtime runtime) {
         this.requestMessage = requestMessage;
         this.runtime = runtime;
         this.returnMediaType = null;

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallbackPanic.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallbackPanic.java
@@ -22,6 +22,11 @@ import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
 
 import java.util.Objects;
 
+/**
+ * {@code HttpCallbackPanic} is the responsible for acting on notifications received from a resource panic.
+ *
+ * @since 2022.2.0
+ */
 public class HttpCallbackPanic extends HttpCallbackReturn {
     private final ImmediateStopFuture immediateStopFuture;
 
@@ -34,8 +39,7 @@ public class HttpCallbackPanic extends HttpCallbackReturn {
     public void notifySuccess(Object result) {
         super.notifySuccess(result);
         if (Objects.nonNull(this.immediateStopFuture)) {
-            this.immediateStopFuture.Stop();
-            System.exit(0);
+            this.immediateStopFuture.stop();
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallbackPanic.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallbackPanic.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.ballerina.stdlib.http.api;
+
+import io.ballerina.runtime.api.values.BError;
+import io.ballerina.stdlib.http.transport.contract.ImmediateStopFuture;
+import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
+
+import java.util.Objects;
+
+public class HttpCallbackPanic extends HttpCallbackReturn {
+    private final ImmediateStopFuture immediateStopFuture;
+
+    public HttpCallbackPanic(HttpCarbonMessage requestMessage, ImmediateStopFuture immediateStopFuture) {
+        super(requestMessage);
+        this.immediateStopFuture = immediateStopFuture;
+    }
+
+    @Override
+    public void notifySuccess(Object result) {
+        super.notifySuccess(result);
+        if (Objects.nonNull(this.immediateStopFuture)) {
+            this.immediateStopFuture.Stop();
+            System.exit(0);
+        }
+    }
+
+    @Override
+    public void notifyFailure(BError result) {
+        HttpCallbackUtils.sendFailureResponse(result, requestMessage);
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallbackReturn.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallbackReturn.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.ballerina.stdlib.http.api;
+
+import io.ballerina.runtime.api.async.Callback;
+import io.ballerina.runtime.api.values.BError;
+import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
+
+public class HttpCallbackReturn implements Callback {
+    HttpCarbonMessage requestMessage;
+
+    public HttpCallbackReturn(HttpCarbonMessage requestMessage) {
+        this.requestMessage = requestMessage;
+    }
+
+    @Override
+    public void notifySuccess(Object result) {
+        HttpCallbackUtils.stopObserverContext(requestMessage);
+        HttpCallbackUtils.printStacktraceIfError(result);
+    }
+
+    @Override
+    public void notifyFailure(BError result) {
+        HttpCallbackUtils.sendFailureResponse(result, requestMessage);
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallbackReturn.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallbackReturn.java
@@ -20,8 +20,13 @@ import io.ballerina.runtime.api.async.Callback;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
 
+/**
+ * {@code HttpCallbackReturn} is the responsible for acting on notifications received from a resource return.
+ *
+ * @since 2022.2.0
+ */
 public class HttpCallbackReturn implements Callback {
-    HttpCarbonMessage requestMessage;
+    protected final HttpCarbonMessage requestMessage;
 
     public HttpCallbackReturn(HttpCarbonMessage requestMessage) {
         this.requestMessage = requestMessage;

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallbackUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallbackUtils.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.ballerina.stdlib.http.api;
+
+import io.ballerina.runtime.api.values.BError;
+import io.ballerina.runtime.observability.ObserveUtils;
+import io.ballerina.runtime.observability.ObserverContext;
+import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
+
+import static io.ballerina.stdlib.http.api.HttpConstants.OBSERVABILITY_CONTEXT_PROPERTY;
+
+public class HttpCallbackUtils {
+
+    protected static void stopObserverContext(HttpCarbonMessage requestMessage) {
+        if (ObserveUtils.isObservabilityEnabled()) {
+            ObserverContext observerContext = (ObserverContext) requestMessage
+                    .getProperty(OBSERVABILITY_CONTEXT_PROPERTY);
+            if (observerContext.isManuallyClosed()) {
+                ObserveUtils.stopObservationWithContext(observerContext);
+            }
+        }
+    }
+
+    protected static void printStacktraceIfError(Object result) {
+        if (result instanceof BError) {
+            ((BError) result).printStackTrace();
+        }
+    }
+
+    protected static void sendFailureResponse(BError error, HttpCarbonMessage requestMessage) {
+        stopObserverContext(requestMessage);
+        HttpUtil.handleFailure(requestMessage, error, true);
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallbackUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallbackUtils.java
@@ -23,6 +23,11 @@ import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
 
 import static io.ballerina.stdlib.http.api.HttpConstants.OBSERVABILITY_CONTEXT_PROPERTY;
 
+/**
+ * {@code HttpCallbackUtils} holds the utility functions related to Http callbacks.
+ *
+ * @since 2022.2.0
+ */
 public class HttpCallbackUtils {
 
     protected static void stopObserverContext(HttpCarbonMessage requestMessage) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -369,6 +369,7 @@ public class HttpConstants {
     public static final String REQUEST_INTERCEPTOR_INDEX = "REQUEST_INTERCEPTOR_INDEX";
     public static final String RESPONSE_INTERCEPTOR_INDEX = "RESPONSE_INTERCEPTOR_INDEX";
     public static final String INTERCEPTOR_SERVICE_ERROR = "INTERCEPTOR_SERVICE_ERROR";
+    public static final String INTERCEPTOR_SERVICE_PANIC_ERROR = "INTERCEPTOR_SERVICE_PANIC_ERROR";
     public static final String WAIT_FOR_FULL_REQUEST = "WAIT_FOR_FULL_REQUEST";
     public static final String HTTP_NORMAL = "Normal";
     public static final String REQUEST_INTERCEPTOR = "RequestInterceptor";
@@ -394,6 +395,7 @@ public class HttpConstants {
     public static final String ENDPOINT_CONFIG_CHUNKING = "chunking";
     public static final BString ENDPOINT_CONFIG_VERSION = StringUtils.fromString("httpVersion");
     public static final String ENDPOINT_REQUEST_LIMITS = "requestLimits";
+    public static final BString ENDPOINT_CONFIG_GRACEFUL_STOP_TIMEOUT = StringUtils.fromString("gracefulStopTimeout");
 
     public static final BString MAX_URI_LENGTH = StringUtils.fromString("maxUriLength");
     public static final BString MAX_STATUS_LINE_LENGTH = StringUtils.fromString("maxStatusLineLength");

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/endpoint/Start.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/endpoint/Start.java
@@ -30,6 +30,7 @@ import io.ballerina.stdlib.http.api.HttpErrorType;
 import io.ballerina.stdlib.http.api.HttpUtil;
 import io.ballerina.stdlib.http.transport.contract.ServerConnector;
 import io.ballerina.stdlib.http.transport.contract.ServerConnectorFuture;
+import io.ballerina.stdlib.http.transport.contractimpl.listener.HTTPImmediateStopFuture;
 
 import static io.ballerina.stdlib.http.api.HttpConstants.SERVER_CONNECTOR_FUTURE;
 import static io.ballerina.stdlib.http.api.HttpConstants.SERVICE_ENDPOINT_CONFIG;
@@ -72,6 +73,7 @@ public class Start extends AbstractHttpNativeFunction {
         HttpConnectorPortBindingListener portBindingListener = new HttpConnectorPortBindingListener();
         serverConnectorFuture.setHttpConnectorListener(httpListener);
         serverConnectorFuture.setPortBindingEventListener(portBindingListener);
+        httpListener.setImmediateStopNotifier(new HTTPImmediateStopFuture(serverConnector));
 
         try {
             serverConnectorFuture.sync();

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contract/ImmediateStopFuture.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contract/ImmediateStopFuture.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package io.ballerina.stdlib.http.transport.contract;
+
+/**
+ *  Nofify immediate stop to the server connector.
+ */
+public interface ImmediateStopFuture {
+    /**
+     * Stop the server connector immediately.
+     */
+    void Stop();
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contract/ImmediateStopFuture.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contract/ImmediateStopFuture.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -20,11 +20,14 @@
 package io.ballerina.stdlib.http.transport.contract;
 
 /**
- *  Nofify immediate stop to the server connector.
+ *  Notifies the immediate stop to the server connector.
+ *
+ *  @since 2022.2.0
  */
 public interface ImmediateStopFuture {
+
     /**
      * Stop the server connector immediately.
      */
-    void Stop();
+    void stop();
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/HTTPImmediateStopFuture.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/HTTPImmediateStopFuture.java
@@ -1,0 +1,18 @@
+package io.ballerina.stdlib.http.transport.contractimpl.listener;
+
+import io.ballerina.stdlib.http.transport.contract.ImmediateStopFuture;
+import io.ballerina.stdlib.http.transport.contract.ServerConnector;
+
+public class HTTPImmediateStopFuture implements ImmediateStopFuture {
+
+    ServerConnector httpServerConnector;
+
+    public HTTPImmediateStopFuture(ServerConnector httpServerConnector) {
+        this.httpServerConnector = httpServerConnector;
+    }
+
+    @Override
+    public void Stop() {
+        this.httpServerConnector.immediateStop();
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/HTTPImmediateStopFuture.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/HTTPImmediateStopFuture.java
@@ -1,18 +1,42 @@
+/*
+ *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
 package io.ballerina.stdlib.http.transport.contractimpl.listener;
 
 import io.ballerina.stdlib.http.transport.contract.ImmediateStopFuture;
 import io.ballerina.stdlib.http.transport.contract.ServerConnector;
 
+/**
+ * {@code HTTPImmediateStopFuture} is the responsible for stopping the listener immediately.
+ *
+ * @since 2022.2.0
+ */
 public class HTTPImmediateStopFuture implements ImmediateStopFuture {
 
-    ServerConnector httpServerConnector;
+    private ServerConnector httpServerConnector;
 
     public HTTPImmediateStopFuture(ServerConnector httpServerConnector) {
         this.httpServerConnector = httpServerConnector;
     }
 
     @Override
-    public void Stop() {
+    public void stop() {
         this.httpServerConnector.immediateStop();
     }
 }


### PR DESCRIPTION
## Purpose
$subject and fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/2714

## Examples
```ballerina
service / on new http:Listener(8900) {
    resource function get greeting() returns string {
        panic error("test panic");
    }
}
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
