### PR TITLE
Fix `User-Agent` header inconsistency

### DIFF
--- a/ballerina-tests/tests/service_dispatching_header_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_header_param_binding_test.bal
@@ -411,7 +411,8 @@ function testHeaderObjectBinding() {
     response = headerBindingClient->get("/headerparamservice/q4", headers2);
     if response is http:Response {
         json expected = { val1: "foo header not found", val2: "Http header does not exist", val3: false,
-                                val4: ["Http header does not exist"],  val5: ["bar", "connection", "host", "X-Type"]};
+                                val4: ["Http header does not exist"],
+                                val5: ["bar", "connection", "host", "user-agent", "X-Type"]};
         assertJsonPayloadtoJsonString(response.getJsonPayload(), expected);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());

--- a/ballerina-tests/tests/service_dispatching_header_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_header_param_binding_test.bal
@@ -273,6 +273,16 @@ service /headerRecord on HeaderBindingEP {
         }
         return { header1 : j1, header2 : j2, header3 : j3, header4 : j4};
     }
+
+    resource function post userAgentWithPayload(@http:Payload string payloadVal,
+            @http:Header {name: "user-agent"} string? userAgent) returns json {
+        return {"hello": userAgent};
+    }
+
+    resource function get userAgentWithRequest(http:Request req,
+            @http:Header {name: "user-agent"} string? userAgent) returns json {
+        return {"hello": userAgent};
+    }
 }
 
 @test:Config {}
@@ -693,4 +703,14 @@ function testHeaderParamsCastingError() returns error? {
         {"daid" : ["3.4", "5.6", "hello", "8"]});
     test:assertEquals(response.statusCode, 400);
     assertTextPayload(response.getTextPayload(), "header binding failed for parameter: 'daid'");
+}
+
+@test:Config {}
+function userAgentHeaderBindingTest() returns error? {
+    json response = check headerBindingClient->post("/headerRecord/userAgentWithPayload", "world",
+        {"user-agent": "slbeta3"});
+    assertJsonValue(response, "hello", "slbeta3");
+
+    response = check headerBindingClient->get("/headerRecord/userAgentWithRequest", {"user-agent": "slbeta4"});
+    assertJsonValue(response, "hello", "slbeta4");
 }

--- a/ballerina-tests/tests/service_dispatching_header_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_header_param_binding_test.bal
@@ -401,7 +401,7 @@ function testHeaderObjectBinding() {
     http:Response|error response = headerBindingClient->get("/headerparamservice/q4", headers);
     if response is http:Response {
         json expected = { val1: "World", val2: "Write", val3: true, val4: ["All", "Ballerina"],
-                                val5: ["bar", "baz", "connection", "daz", "Foo", "host", "X-Type"]};
+                                val5: ["bar", "baz", "connection", "daz", "Foo", "host", "user-agent", "X-Type"]};
         assertJsonPayloadtoJsonString(response.getJsonPayload(), expected);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - [Update default response status as HTTP 201 for POST resources](https://github.com/ballerina-platform/ballerina-standard-library/issues/2469)
 
+
+### Fixed
+- [User-Agent header is set to a default value or empty in http post request](https://github.com/ballerina-platform/ballerina-standard-library/issues/3283)
+
 ## [2.3.0] - 2022-05-30
 
 ### Added

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -730,9 +730,6 @@ public class HttpUtil {
             BString agent = fromString(
                     inboundRequestMsg.getHeader(HttpHeaderNames.USER_AGENT.toString()));
             inboundRequestObj.set(HttpConstants.REQUEST_USER_AGENT_FIELD, agent);
-            if (inboundRequestMsg.isAccessedInNonInterceptorService()) {
-                inboundRequestMsg.removeHeader(HttpHeaderNames.USER_AGENT.toString());
-            }
         }
     }
 


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/3283
> `User-Agent` header is removed and populated to http:Request to provide high level support as it is important attribute. But with the introduction of header binding, `User-Agent` header should be accessible from signature itself without accessing `http:Request`. The PR will fix the issue by not removing particular header after the value being populated to `http:Request`

## Examples
```ballerina
import ballerina/http;
import ballerina/log;

type MyRecord record {|
    string id;
    string name;
|};

service / on new http:Listener(9090) {

    resource function post hello(@http:Payload MyRecord payloadVal, @http:Header {name: "user-agent"} string? userAgent = ())
            returns json {

        log:printInfo("Received header value: " + (userAgent ?: ""));
        return {"hello": "world"};
    }
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
