### PR TITLE
[2201.1.x] Allow central publish action to publish to multiple environments

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -2,6 +2,15 @@ name: Publish to the Ballerina central
 
 on:
   workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        description: Select environment
+        required: true
+        options:
+          - CENTRAL
+          - DEV CENTRAL
+          - STAGE CENTRAL
 
 jobs:
   publish-release:
@@ -30,11 +39,39 @@ jobs:
           format: 'table'
           timeout: '10m0s'
           exit-code: '1'
-      - name: Publish artifact
+
+      - name: Ballerina Central Push
+        if: ${{ github.event.inputs.environment == 'CENTRAL' }}
         env:
+          BALLERINA_DEV_CENTRAL: false
+          BALLERINA_STAGE_CENTRAL: false
           BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
           packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
           ./gradlew clean build -PpublishToCentral=true
+
+      - name: Ballerina Central Dev Push
+        if: ${{ github.event.inputs.environment == 'DEV CENTRAL' }}
+        env:
+            BALLERINA_DEV_CENTRAL: true
+            BALLERINA_STAGE_CENTRAL: false
+            BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}
+            packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+            packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+            ./gradlew clean build -PpublishToCentral=true
+
+      - name: Ballerina Central Stage Push
+        if: ${{ github.event.inputs.environment == 'STAGE CENTRAL' }}
+        env:
+            BALLERINA_DEV_CENTRAL: false
+            BALLERINA_STAGE_CENTRAL: true
+            BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+            packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+            packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+            ./gradlew clean build -PpublishToCentral=true

--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -62,6 +62,7 @@ jobs:
             packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
             GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
+            sed -i 's/version=\(.*\)-SNAPSHOT/version=\1/g' gradle.properties
             ./gradlew clean build -PpublishToCentral=true
 
       - name: Ballerina Central Stage Push
@@ -74,4 +75,5 @@ jobs:
             packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
             GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
+            sed -i 's/version=\(.*\)-SNAPSHOT/version=\1/g' gradle.properties
             ./gradlew clean build -PpublishToCentral=true


### PR DESCRIPTION
## Purpose

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
