### PR TITLE
Fix stacklessConnectionClosed exception while calling backend with well known certs

### DIFF
--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -26,7 +26,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.4.0"
+version = "3.3.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "constraint"},

--- a/ballerina-tests/tests/ssl_wellknown_cert_test.bal
+++ b/ballerina-tests/tests/ssl_wellknown_cert_test.bal
@@ -1,0 +1,74 @@
+// Copyright (c) 2022 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/test;
+
+final http:Client callCountryTestClient = check new("http://localhost:" + http2GeneralPort.toString());
+
+public type Country record {
+    string name;
+};
+
+service on generalHTTP2Listener {
+
+    resource function get country/[int callingCode]() returns string|error {
+        http:Client restCountriesEp = check new ("https://restcountries.com");
+        Country[] countries = check restCountriesEp->get("/v2/callingcode/" + callingCode.toString());
+        if countries.length() == 0 {
+            return "Invalid Calling Code";
+        }
+        return countries[0].name;
+    }
+
+    resource function get countryLocal/[int callingCode]() returns string|error {
+        http:Client restCountriesEp = check new ("https://localhost:" + http2SslGeneralPort.toString(), http2SslClientConf1);
+        string country = check restCountriesEp->get("/restcountries/v2/callingcode/" + callingCode.toString());
+        return country;
+    }
+}
+
+service /restcountries/v2 on generalHTTPS2Listener {
+
+    resource function get callingcode/[int callingCode]() returns string {
+        return "American Samoa";
+    }
+}
+
+@test:Config {}
+function testWellknownCertBackendWithinService() returns error? {
+    string response = check callCountryTestClient->get("/country/1");
+    test:assertEquals(response, "American Samoa", msg = "Found unexpected output");
+
+    response = check callCountryTestClient->get("/country/1");
+    test:assertEquals(response, "American Samoa", msg = "Found unexpected output");
+}
+
+@test:Config {}
+function testWellknownCertBackendWithinLocalService() returns error? {
+    string response = check callCountryTestClient->get("/countryLocal/1");
+    test:assertEquals(response, "American Samoa", msg = "Found unexpected output");
+
+    response = check callCountryTestClient->get("/countryLocal/1");
+    test:assertEquals(response, "American Samoa", msg = "Found unexpected output");
+}
+
+@test:Config {}
+function testWellknownCertBackendWithinFunction() returns error? {
+    http:Client restCountriesEp = check new ("https://restcountries.com");
+    Country[] countries = check restCountriesEp->get("/v2/callingcode/1");
+    test:assertEquals(countries[0].name, "American Samoa", msg = "Found unexpected output");
+}

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Reduce Listener default timeout to 60s and Client default timeout to 30s](https://github.com/ballerina-platform/ballerina-standard-library/issues/3278)
 - [API Docs Updated](https://github.com/ballerina-platform/ballerina-standard-library/issues/3463)
 
+### Fixed
+- [Fix stacklessConnectionClosed exception while calling backend with well known certs](https://github.com/ballerina-platform/ballerina-standard-library/issues/3507)
+
 ## [2.4.0] - 2022-09-08
 
 ### Added


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/3507
> It was found that SSL engine application protocol is chosen as HTTP1.1. When H2 channel goes through the H1 flow, before executing the request, the channel is registered to the respective Source handler after de-registering from the initial event loop which bounded during the channel creating. During the de-registration channel move to connected state to closed state resulting io.netty.channel.StacklessClosedChannelException.

Hence as the solution, this de-registration is avoided for h2 channels

## Examples

```ballerina
import ballerina/http;

public type Country record {
    string name;
};

service / on new http:Listener(8080) {

    resource function get country() returns string|error {
        http:Client restCountriesEp = check new ("https://restcountries.com");
        Country[] countries = check restCountriesEp->get("/v2/callingcode/1");
        return countries[0].name;
    }
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
