### PR TITLE
Fix dispatching logic issue due to double slash in basePath

### DIFF
--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -26,7 +26,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.4.0"
+version = "3.3.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "constraint"},

--- a/ballerina-tests/tests/http_url_double_slash.bal
+++ b/ballerina-tests/tests/http_url_double_slash.bal
@@ -47,6 +47,13 @@ service "//url" on httpUrlListenerEP1  {
     }
 }
 
+service / on httpUrlListenerEP1 {
+
+    resource function get foo() returns http:Ok {
+        return {body:{name:"foo"}};
+    }
+}
+
 //Test for handling double slashes
 @test:Config {}
 function testUrlDoubleSlash() returns error? {
@@ -140,4 +147,10 @@ function testResourcePath404Negative() returns error? {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }
     return;
+}
+
+@test:Config{}
+public function testClientWithDoubleURLs() returns error? {
+    json response = check httpUrlClient->get("/foo");
+    test:assertEquals(response, {name:"foo"});
 }

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Reduce Listener default timeout to 60s and Client default timeout to 30s](https://github.com/ballerina-platform/ballerina-standard-library/issues/3278)
 - [API Docs Updated](https://github.com/ballerina-platform/ballerina-standard-library/issues/3463)
 
+### Fixed
+- [Fix dispatching logic issue due to double slash in basePath](https://github.com/ballerina-platform/ballerina-standard-library/issues/3543)
+
 ## [2.4.0] - 2022-09-08
 
 ### Added

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
@@ -52,6 +52,8 @@ import java.util.Objects;
 import static io.ballerina.runtime.api.TypeTags.ARRAY_TAG;
 import static io.ballerina.stdlib.http.api.HttpConstants.DEFAULT_HOST;
 import static io.ballerina.stdlib.http.api.HttpConstants.EXTRA_PATH_INDEX;
+import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_SCHEME;
+import static io.ballerina.stdlib.http.api.HttpConstants.SCHEME_SEPARATOR;
 import static io.ballerina.stdlib.http.api.HttpUtil.getParameterTypes;
 import static io.ballerina.stdlib.http.api.service.signature.ParamUtils.castParam;
 import static io.ballerina.stdlib.http.api.service.signature.ParamUtils.castParamArray;
@@ -87,7 +89,7 @@ public class HttpDispatcher {
             Map<String, Map<String, String>> matrixParams = new HashMap<>();
             String uriWithoutMatrixParams = URIUtil.extractMatrixParams(rawUri, matrixParams, inboundReqMsg);
 
-            URI validatedUri = getValidatedURI(uriWithoutMatrixParams);
+            URI validatedUri = getValidatedURI(HTTP_SCHEME + SCHEME_SEPARATOR + uriWithoutMatrixParams);
 
             String basePath = servicesRegistry.findTheMostSpecificBasePath(validatedUri.getRawPath(),
                                                                            servicesOnInterface, sortedServiceURIs);
@@ -147,7 +149,7 @@ public class HttpDispatcher {
             inboundReqMsg.setProperty(HttpConstants.TO, uriWithoutMatrixParams);
             inboundReqMsg.setProperty(HttpConstants.MATRIX_PARAMS, matrixParams);
 
-            URI validatedUri = getValidatedURI(uriWithoutMatrixParams);
+            URI validatedUri = getValidatedURI(HTTP_SCHEME + SCHEME_SEPARATOR + uriWithoutMatrixParams);
 
             String basePath = servicesRegistry.findTheMostSpecificBasePath(validatedUri.getRawPath(),
                                                                            servicesOnInterface, sortedServiceURIs);


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/3543

## Examples
```ballerina
import ballerina/http;
import ballerina/test;

final http:Client clientEPTest = check new ("http://localhost:8080/");

service / on new http:Listener(8080) {

    resource function get foo() returns http:Ok {
        return {body:{name:"foo"}};
    }
}

@test:Config{}
public function testHttpEnumMethods() returns error? {
    json response = check clientEPTest->get("/foo");
    test:assertEquals(response, {name:"foo"});
}

```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
