### PR TITLE
[2201.2.x] Add defaultable param support for query parameter

### DIFF
--- a/ballerina-tests/Ballerina.toml
+++ b/ballerina-tests/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http_tests"
-version = "2.4.2"
+version = "2.4.3"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/http-native-2.4.2.jar"
+path = "../native/build/libs/http-native-2.4.3-SNAPSHOT.jar"

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -79,7 +79,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.4.2"
+version = "2.4.3"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -111,7 +111,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_tests"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina-tests/tests/service_dispatching_query_param_binding_ideal_mapping_test.bal
+++ b/ballerina-tests/tests/service_dispatching_query_param_binding_ideal_mapping_test.bal
@@ -34,6 +34,11 @@ service /queryparamservice on QueryBindingIdealEP {
         json responseJson = { value1: foo ?: "empty", value2: bar};
         return responseJson;
     }
+
+    resource function get test3(string? foo = "baz", int bar = 10) returns json {
+        json responseJson = { value1: foo ?: "empty", value2: bar};
+        return responseJson;
+    }
 }
 
 @test:Config {}
@@ -88,4 +93,16 @@ function testIdealQueryParamBindingWithNoQueryParamValue() {
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }
+}
+
+@test:Config {}
+function testIdealQueryParamBindingWithDefaultableQueryParamValue() returns error? {
+    json response = check queryBindingIdealClient->get("/queryparamservice/test3?foo=WSO2&bar=56");
+    test:assertEquals(response, {value1:"WSO2", value2:56}, msg = "Found unexpected output");
+
+    response = check queryBindingIdealClient->get("/queryparamservice/test3?foo&bar");
+    test:assertEquals(response, {value1:"baz", value2:10}, msg = "Found unexpected output");
+
+    response = check queryBindingIdealClient->get("/queryparamservice/test3");
+    test:assertEquals(response, {value1:"baz", value2:10}, msg = "Found unexpected output");
 }

--- a/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
@@ -121,8 +121,39 @@ service /default on QueryBindingEP {
         return responseJson;
     }
 
+    resource function get checkstringNilable(string? foo = "hello") returns json {
+        json responseJson = { value1: foo};
+        return responseJson;
+    }
+
     resource function get checkInt(int foo = 10) returns json {
         json responseJson = { value1: foo};
+        return responseJson;
+    }
+
+    resource function get checkIntNilable(int? foo = 15) returns json {
+        json responseJson = { value1: foo};
+        return responseJson;
+    }
+
+    resource function get q1(float val = 1.11, boolean isPresent = true, decimal dc = 5.67d) returns json {
+        json responseJson = { fValue: val, bValue: isPresent, dValue: dc };
+        return responseJson;
+    }
+
+    resource function get q2(int[] id = [324441,5652], string[] PersoN = ["hello", "gool"],
+            float[] val = [1.11, 53.9], boolean[] isPresent = [true,false], decimal[] dc = [4.78, 5.67]) returns json {
+        json responseJson = { iValue: id, sValue: PersoN, fValue: val, bValue: isPresent, dValue: dc };
+        return responseJson;
+    }
+
+    resource function get q3(map<json> obj = { name : "test", value : "json" }) returns json {
+        return obj;
+    }
+
+    resource function get q4(map<json>[] objs = [{ name : "test1", value : "json1" },
+            { name : "test2", value : "json2" }]) returns json {
+        json responseJson = { objects : objs };
         return responseJson;
     }
 }
@@ -132,8 +163,35 @@ function testStringDefaultableQueryBinding() returns error? {
     json response = check queryBindingClient->get("/default/checkstring?foo=WSO2&bar=56");
     test:assertEquals(response, {value1:"WSO2"});
 
+    response = check queryBindingClient->get("/default/checkstring?foo=BALLERINA,WSO2&bar=56");
+    test:assertEquals(response, {value1:"BALLERINA"});
+
     response = check queryBindingClient->get("/default/checkstring?bar=12");
     test:assertEquals(response, {value1:"hello"});
+
+    response = check queryBindingClient->get("/default/checkstring?foo");
+    test:assertEquals(response, {value1:"hello"});
+
+    response = check queryBindingClient->get("/default/checkstring?foo=");
+    test:assertEquals(response, {value1:""});
+}
+
+@test:Config {}
+function testStringDefaultableNilableQueryBinding() returns error? {
+    json response = check queryBindingClient->get("/default/checkstringNilable?foo=WSO2&bar=56");
+    test:assertEquals(response, {value1:"WSO2"});
+
+    response = check queryBindingClient->get("/default/checkstringNilable?foo=BALLERINA,WSO2&bar=56");
+    test:assertEquals(response, {value1:"BALLERINA"});
+
+    response = check queryBindingClient->get("/default/checkstringNilable?bar=12");
+    test:assertEquals(response, {value1:"hello"});
+
+    response = check queryBindingClient->get("/default/checkstringNilable?foo");
+    test:assertEquals(response, {value1:"hello"});
+
+    response = check queryBindingClient->get("/default/checkstringNilable?foo=");
+    test:assertEquals(response, {value1:""});
 }
 
 @test:Config {}
@@ -141,10 +199,57 @@ function testIntDefaultableQueryBinding() returns error? {
     json response = check queryBindingClient->get("/default/checkInt?foo=23&bar=56");
     test:assertEquals(response, {value1:23});
 
+    response = check queryBindingClient->get("/default/checkInt?foo=20,30&bar=56");
+    test:assertEquals(response, {value1:20});
+
     response = check queryBindingClient->get("/default/checkInt?bar=12");
+    test:assertEquals(response, {value1:10});
+
+    response = check queryBindingClient->get("/default/checkInt?foo");
     test:assertEquals(response, {value1:10});
 }
 
+@test:Config {}
+function testIntDefaultableNilableQueryBinding() returns error? {
+    json response = check queryBindingClient->get("/default/checkIntNilable?foo=23&bar=56");
+    test:assertEquals(response, {value1:23});
+
+    response = check queryBindingClient->get("/default/checkIntNilable?foo=20,30&bar=56");
+    test:assertEquals(response, {value1:20});
+
+    response = check queryBindingClient->get("/default/checkIntNilable?bar=12");
+    test:assertEquals(response, {value1:15});
+
+    response = check queryBindingClient->get("/default/checkIntNilable?foo");
+    test:assertEquals(response, {value1:15});
+}
+
+@test:Config {}
+function testRestOfDefaultableQueryBinding() returns error? {
+    json response = check queryBindingClient->get("/default/q1");
+    assertJsonPayloadtoJsonString(response, {fValue: 1.11, bValue: true, dValue: 5.67});
+}
+
+@test:Config {}
+function testArrayRestOfDefaultableQueryBinding() returns error? {
+    json response = check queryBindingClient->get("/default/q2");
+    json expected = {iValue:[324441, 5652], sValue:["hello", "gool"], fValue:[1.11, 53.9], bValue:[true, false],
+        dValue:[4.78, 5.67]};
+    assertJsonPayloadtoJsonString(response, expected);
+}
+
+@test:Config {}
+function testMapJsonOfDefaultableQueryBinding() returns error? {
+    json response = check queryBindingClient->get("/default/q3");
+    assertJsonPayloadtoJsonString(response, { name : "test", value : "json" });
+}
+
+@test:Config {}
+function testMapJsonArrOfDefaultableQueryBinding() returns error? {
+    json response = check queryBindingClient->get("/default/q4");
+    assertJsonPayloadtoJsonString(response, { objects : [{ name : "test1", value : "json1" },
+        { name : "test2", value : "json2" }] });
+}
 
 @test:Config {}
 function testStringQueryBinding() {

--- a/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
@@ -106,14 +106,45 @@ service /queryparamservice on QueryBindingEP {
         return ok;
     }
 
-        resource function get petsMap(map<TypeJson> count) returns json {
+    resource function get petsMap(map<TypeJson> count) returns json {
         return count;
     }
-    
+
     resource function get nestedTypeRef(FullName name) returns string {
         return name;
     }
 }
+
+service /default on QueryBindingEP {
+    resource function get checkstring(string foo = "hello") returns json {
+        json responseJson = { value1: foo};
+        return responseJson;
+    }
+
+    resource function get checkInt(int foo = 10) returns json {
+        json responseJson = { value1: foo};
+        return responseJson;
+    }
+}
+
+@test:Config {}
+function testStringDefaultableQueryBinding() returns error? {
+    json response = check queryBindingClient->get("/default/checkstring?foo=WSO2&bar=56");
+    test:assertEquals(response, {value1:"WSO2"});
+
+    response = check queryBindingClient->get("/default/checkstring?bar=12");
+    test:assertEquals(response, {value1:"hello"});
+}
+
+@test:Config {}
+function testIntDefaultableQueryBinding() returns error? {
+    json response = check queryBindingClient->get("/default/checkInt?foo=23&bar=56");
+    test:assertEquals(response, {value1:23});
+
+    response = check queryBindingClient->get("/default/checkInt?bar=12");
+    test:assertEquals(response, {value1:10});
+}
+
 
 @test:Config {}
 function testStringQueryBinding() {

--- a/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
+++ b/ballerina-tests/tests/service_dispatching_query_param_binding_test.bal
@@ -106,7 +106,7 @@ service /queryparamservice on QueryBindingEP {
         return ok;
     }
 
-    resource function get petsMap(map<TypeJson> count) returns json {
+        resource function get petsMap(map<TypeJson> count) returns json {
         return count;
     }
     

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.4.2"
+version = "2.4.3"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -12,8 +12,8 @@ distribution = "2201.2.0"
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.4.2"
-path = "../native/build/libs/http-native-2.4.2.jar"
+version = "2.4.3"
+path = "../native/build/libs/http-native-2.4.3-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.4.2.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.4.3-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -77,7 +77,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -227,7 +227,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -254,7 +254,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,11 @@ This file contains all the notable changes done to the Ballerina HTTP package th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- [Add defaultable param support for query parameter](https://github.com/ballerina-platform/ballerina-standard-library/issues/1683)
+
 ## [2.4.2] - 2022-11-02
 
 ### Fixed
@@ -29,7 +34,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - [Update default response status as HTTP 201 for POST resources](https://github.com/ballerina-platform/ballerina-standard-library/issues/2469)
-
 
 ### Fixed
 - [User-Agent header is set to a default value or empty in http post request](https://github.com/ballerina-platform/ballerina-standard-library/issues/3283)

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -474,6 +474,15 @@ query param of the request URL has no corresponding parameter in the resource fu
 If the parameter is defined in the function, but there is no such query param in the URL, that request will lead 
 to a 400 BAD REQUEST error response unless the type is nilable (string?)
 
+If the query parameter is defined with a defaultable value in the resource signature, in the absence of particular
+query parameter, the default value will be assigned to the variable.
+
+```ballerina
+resource function get price(int id = 10) { 
+    
+}
+```
+
 The query param consists of query name and values. Sometimes user may send query without value(`foo:`). In such
 situations, when the query param type is nilable, the values returns nil and same happened when the complete query is
 not present in the request. In order to avoid the missing detail, a service level configuration has introduced naming
@@ -544,16 +553,29 @@ service /queryparamservice on new http:Listener(9090) {
 <td> nil </td>
 <td> Error : no query param value found for 'foo' </td>
 </tr>
+<tr>
+<td rowspan=4> 3 </td>
+<td rowspan=4> string foo = "baz"<br/> string? foo = "baz" </td>
+<td> foo=bar </td>
+<td> bar </td>
+<td> bar </td>
+</tr>
+<tr>
+<td> foo=</td>
+<td> "" </td>
+<td> "" </td>
+</tr>
+<tr>
+<td> foo</td>
+<td> baz </td>
+<td> baz </td>
+</tr>
+<tr>
+<td> No query</td>
+<td> baz </td>
+<td> baz </td>
+</tr>
 </table>
-
-If the query parameter is defined with a defaultable value in the resource signature, in the absence of particular
-query parameter, the default value will be assigned to the variable.
-
-```ballerina
-resource function get price(int id = 10) { 
-    
-}
-```
 
 See section [Query](#52-query) to understand accessing query param via the request object.
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -546,6 +546,15 @@ service /queryparamservice on new http:Listener(9090) {
 </tr>
 </table>
 
+If the query parameter is defined with a defaultable value in the resource signature, in the absence of particular
+query parameter, the default value will be assigned to the variable.
+
+```ballerina
+resource function get price(int id = 10) { 
+    
+}
+```
+
 See section [Query](#52-query) to understand accessing query param via the request object.
 
 ##### 2.3.4.4. Payload parameter

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllQueryParams.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllQueryParams.java
@@ -92,6 +92,7 @@ public class AllQueryParams implements Parameter {
                                                    HttpErrorType.QUERY_PARAM_BINDING_ERROR);
                 }
             }
+
             try {
                 BArray queryValueArr = (BArray) queryValue;
                 Type paramType = queryParam.getType();

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllQueryParams.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllQueryParams.java
@@ -78,7 +78,11 @@ public class AllQueryParams implements Parameter {
             boolean queryExist = urlQueryParams.containsKey(StringUtils.fromString(token));
             Object queryValue = urlQueryParams.get(StringUtils.fromString(token));
             if (queryValue == null) {
-                if (queryParam.isNilable() && (treatNilableAsOptional || queryExist)) {
+                if (queryParam.isDefaultable()) {
+                    paramFeed[index++] = queryParam.getType().getZeroValue();
+                    paramFeed[index] = false;
+                    continue;
+                } else if (queryParam.isNilable() && (treatNilableAsOptional || queryExist)) {
                     paramFeed[index++] = null;
                     paramFeed[index] = true;
                     continue;

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
@@ -290,8 +290,9 @@ public class ParamHandler {
 
     private void createQueryParam(int index, ResourceMethodType balResource, Type type, boolean nilable,
                                   boolean readonly) {
-        QueryParam queryParam = new QueryParam(type, HttpUtil.unescapeAndEncodeValue(
-                balResource.getParamNames()[index]), index, nilable, readonly);
+        io.ballerina.runtime.api.types.Parameter parameter = balResource.getParameters()[index];
+        QueryParam queryParam = new QueryParam(type, HttpUtil.unescapeAndEncodeValue(parameter.name), index, nilable,
+                                               readonly, parameter.isDefault);
         this.queryParams.add(queryParam);
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/QueryParam.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/QueryParam.java
@@ -30,15 +30,17 @@ public class QueryParam {
     private final String token;
     private final boolean nilable;
     private final boolean readonly;
+    private final boolean defaultable;
     private final int index;
     private final Type type;
 
-    QueryParam(Type type, String token, int index, boolean nilable, boolean readonly) {
+    QueryParam(Type type, String token, int index, boolean nilable, boolean readonly, boolean defaultable) {
         this.type = type;
         this.token = token;
         this.index = index;
         this.nilable = nilable;
         this.readonly = readonly;
+        this.defaultable = defaultable;
     }
 
     public String getToken() {
@@ -59,5 +61,9 @@ public class QueryParam {
 
     public boolean isReadonly() {
         return this.readonly;
+    }
+
+    public boolean isDefaultable() {
+        return defaultable;
     }
 }


### PR DESCRIPTION
## Purpose
> Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/1683

## Examples
```ballerina
service /default on QueryBindingEP {
    resource function get checkstring(string foo = "hello") returns json {
        json responseJson = { value1: foo};
        return responseJson;
    }

    resource function get checkInt(int foo = 10) returns json {
        json responseJson = { value1: foo};
        return responseJson;
    }
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [ ] Checked native-image compatibility
