### PR TITLE
[Master] Fix the test order of ALPN resolving to H1 path

### DIFF
--- a/ballerina-tests/tests/ssl_wellknown_cert_test.bal
+++ b/ballerina-tests/tests/ssl_wellknown_cert_test.bal
@@ -76,7 +76,7 @@ function testWellknownCertBackendWithinLocalService() returns error? {
     test:assertEquals(response, "American Samoa", msg = "Found unexpected output");
 }
 
-@test:Config {}
+@test:Config {dependsOn:[testWellknownCertBackendWithinService]}
 function testWellknownCertBackendWithinFunction() returns error? {
     http:Client restCountriesEp = check new ("https://restcountries.com");
     Country[] countries = check restCountriesEp->get("/v2/callingcode/1");


### PR DESCRIPTION
## Purpose
Fixes Related to https://github.com/wso2-enterprise/internal-support-ballerina/issues/206 and https://github.com/ballerina-platform/ballerina-standard-library/issues/3650

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
