### PR TITLE
[Master] Fix illegal reflection access warning in native build

### DIFF
--- a/ballerina-tests/Ballerina.toml
+++ b/ballerina-tests/Ballerina.toml
@@ -4,4 +4,9 @@ name = "http_tests"
 version = "2.6.0"
 
 [[platform.java11.dependency]]
+scope = "testOnly"
 path = "../native/build/libs/http-native-2.6.0-SNAPSHOT.jar"
+
+[[platform.java11.dependency]]
+scope = "testOnly"
+path = "../test-utils/build/libs/http-test-utils-2.6.0-SNAPSHOT.jar"

--- a/ballerina-tests/tests/http_listener_method_service_test.bal
+++ b/ballerina-tests/tests/http_listener_method_service_test.bal
@@ -144,7 +144,11 @@ function testImmediateStopMethod() returns error? {
     }
 }
 
-@test:Config {dependsOn:[testImmediateStopMethod]}
+// Disabling these test cases due to this issue: https://github.com/ballerina-platform/ballerina-standard-library/issues/3747
+@test:Config {
+    enable: false,
+    dependsOn:[testImmediateStopMethod]
+}
 function testInvokingStoppedImmediateService() {
     http:Response|error response = backendImmediateStopTestClient->get("/mock1");
     if response is error {
@@ -155,7 +159,10 @@ function testInvokingStoppedImmediateService() {
     }
 }
 
-@test:Config {dependsOn:[testInvokingStoppedImmediateService]}
+@test:Config {
+    enable: false,
+    dependsOn:[testInvokingStoppedImmediateService]
+}
 function testServiceHealthAttempt2() returns error? {
     http:Response response = check listenerMethodTestClient->get("/startService/health");
     test:assertEquals(response.statusCode, 202, msg = "Found unexpected output");

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -137,3 +137,27 @@ groupId = "org.jvnet.mimepull"
 artifactId = "mimepull"
 version = "1.9.11"
 path = "./lib/mimepull-1.9.11.jar"
+
+[[platform.java11.dependency]]
+groupId = "io.netty"
+artifactId = "netty-codec-socks"
+version = "4.1.86.Final"
+path = "./lib/netty-codec-socks-4.1.86.Final.jar"
+
+[[platform.java11.dependency]]
+groupId = "org.jboss.marshalling"
+artifactId = "jboss-marshalling"
+version = "2.0.5.Final"
+path = "./lib/jboss-marshalling-2.0.5.Final.jar"
+
+[[platform.java11.dependency]]
+groupId = "net.jpountz.lz4"
+artifactId = "lz4"
+version = "1.3.0"
+path = "./lib/lz4-1.3.0.jar"
+
+[[platform.java11.dependency]]
+groupId = "com.google.protobufl"
+artifactId = "protobuf-java"
+version = "3.20.3"
+path = "./lib/protobuf-java-3.20.3.jar"

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- [Fix unnecessary warnings in native-image build](https://github.com/ballerina-platform/ballerina-standard-library/issues/3861)
+
+## [2.5.2] - 2022-12-22
+
+### Fixed
+
 - [Application killed due to a panic has the exit code 0](https://github.com/ballerina-platform/ballerina-standard-library/issues/3796)
 - [Binary payload retrieved from the `http:Request` has different content-length than the original payload](https://github.com/ballerina-platform/ballerina-standard-library/issues/3662)
 - [Address CVE-2022-41915 netty Vulnerability](https://github.com/ballerina-platform/ballerina-standard-library/issues/3833)

--- a/native/src/main/resources/META-INF/native-image/io.ballerina.stdlib/http-native/native-image.properties
+++ b/native/src/main/resources/META-INF/native-image/io.ballerina.stdlib/http-native/native-image.properties
@@ -27,4 +27,5 @@ Args =  --enable-url-protocols=http,https \
         --initialize-at-run-time=io.netty.internal.tcnative.CertificateCompressionAlgo \
         --initialize-at-run-time=io.netty.internal.tcnative.CertificateVerifier \
         --initialize-at-run-time=io.netty.internal.tcnative.SSL \
-        --initialize-at-run-time=io.netty.internal.tcnative.SSLPrivateKeyMethod
+        --initialize-at-run-time=io.netty.internal.tcnative.SSLPrivateKeyMethod \
+        -J--add-opens=java.base/java.nio=ALL-UNNAMED


### PR DESCRIPTION
## Purpose

> $Subject

Fixes : https://github.com/ballerina-platform/ballerina-standard-library/issues/3861

Disabled `immediateStop` test cases, since they can fail intermittently. These tests will be refactored and tracked via https://github.com/ballerina-platform/ballerina-standard-library/issues/3747

## Examples

N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] <s>Added tests</s>
- [ ] <s>Updated the spec</s>
- [x] Checked native-image compatibility (Ran a few samples)
