### PR TITLE
[2201.3.x] Fix illegal reflection access warning in native build

### DIFF
--- a/ballerina-tests/Ballerina.toml
+++ b/ballerina-tests/Ballerina.toml
@@ -1,12 +1,12 @@
 [package]
 org = "ballerina"
 name = "http_tests"
-version = "2.5.2"
+version = "2.5.3"
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../native/build/libs/http-native-2.5.2.jar"
+path = "../native/build/libs/http-native-2.5.3-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../test-utils/build/libs/http-test-utils-2.5.2.jar"
+path = "../test-utils/build/libs/http-test-utils-2.5.3-SNAPSHOT.jar"

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -80,7 +80,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.5.2"
+version = "2.5.3"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -112,7 +112,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_tests"
-version = "2.5.2"
+version = "2.5.3"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina-tests/tests/http_listener_method_service_test.bal
+++ b/ballerina-tests/tests/http_listener_method_service_test.bal
@@ -144,7 +144,11 @@ function testImmediateStopMethod() returns error? {
     }
 }
 
-@test:Config {dependsOn:[testImmediateStopMethod]}
+// Disabling these test cases due to this issue: https://github.com/ballerina-platform/ballerina-standard-library/issues/3747
+@test:Config {
+    enable: false,
+    dependsOn:[testImmediateStopMethod]
+}
 function testInvokingStoppedImmediateService() {
     http:Response|error response = backendImmediateStopTestClient->get("/mock1");
     if response is error {
@@ -155,7 +159,10 @@ function testInvokingStoppedImmediateService() {
     }
 }
 
-@test:Config {dependsOn:[testInvokingStoppedImmediateService]}
+@test:Config {
+    enable: false,
+    dependsOn:[testInvokingStoppedImmediateService]
+}
 function testServiceHealthAttempt2() returns error? {
     http:Response response = check listenerMethodTestClient->get("/startService/health");
     test:assertEquals(response.statusCode, 202, msg = "Found unexpected output");

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.5.2"
+version = "2.5.3"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -12,8 +12,8 @@ distribution = "2201.3.0"
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.5.2"
-path = "../native/build/libs/http-native-2.5.2.jar"
+version = "2.5.3"
+path = "../native/build/libs/http-native-2.5.3-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.5.2.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.5.3-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -78,7 +78,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.5.2"
+version = "2.5.3"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -279,7 +279,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -300,7 +300,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.string"}

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ This file contains all the notable changes done to the Ballerina HTTP package th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [Fix unnecessary warnings in native-image build](https://github.com/ballerina-platform/ballerina-standard-library/issues/3861)
+
 ## [2.5.2] - 2022-12-22
 
 ### Fixed

--- a/native/src/main/resources/META-INF/native-image/io.ballerina.stdlib/http-native/native-image.properties
+++ b/native/src/main/resources/META-INF/native-image/io.ballerina.stdlib/http-native/native-image.properties
@@ -27,4 +27,5 @@ Args =  --enable-url-protocols=http,https \
         --initialize-at-run-time=io.netty.internal.tcnative.CertificateCompressionAlgo \
         --initialize-at-run-time=io.netty.internal.tcnative.CertificateVerifier \
         --initialize-at-run-time=io.netty.internal.tcnative.SSL \
-        --initialize-at-run-time=io.netty.internal.tcnative.SSLPrivateKeyMethod
+        --initialize-at-run-time=io.netty.internal.tcnative.SSLPrivateKeyMethod \
+        -J--add-opens=java.base/java.nio=ALL-UNNAMED


### PR DESCRIPTION
## Purpose

> $Subject

Fixes : https://github.com/ballerina-platform/ballerina-standard-library/issues/3861

Disabled `immediateStop` test cases, since they can fail intermittently. These tests will be refactored and tracked via https://github.com/ballerina-platform/ballerina-standard-library/issues/3747

## Examples

N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] <s>Added tests</s>
- [ ] <s>Updated the spec</s>
- [x] Checked native-image compatibility (Ran a few samples)
