### PR TITLE
Add ALPN extension for HTTP/1.1

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -19,13 +19,13 @@ path = "../native/build/libs/http-native-2.6.0-SNAPSHOT.jar"
 groupId = "io.ballerina.stdlib"
 artifactId = "mime-native"
 version = "2.6.0"
-path = "./lib/mime-native-2.6.0-20221221-115900-6a10328.jar"
+path = "./lib/mime-native-2.6.0-20230103-182900-902c334.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "constraint-native"
 version = "1.1.0"
-path = "./lib/constraint-native-1.1.0-20221122-134300-fc2d3aa.jar"
+path = "./lib/constraint-native-1.1.0-20230103-174400-ecce026.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.netty"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -340,4 +340,3 @@ modules = [
 	{org = "ballerina", packageName = "url", moduleName = "url"}
 ]
 
-

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Fix unnecessary warnings in native-image build](https://github.com/ballerina-platform/ballerina-standard-library/issues/3861)
 
+### Added
+
+- [Add http/1.1 as the ALPN extension when communicating over HTTP/1.1](https://github.com/ballerina-platform/ballerina-standard-library/issues/3766)
+
 ## [2.5.2] - 2022-12-22
 
 ### Fixed

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/Util.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/Util.java
@@ -140,6 +140,7 @@ public class Util {
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(Util.class);
+    public static final String HTTP_1_1 = "http/1.1";
 
     private static String getStringValue(HttpCarbonMessage msg, String key, String defaultValue) {
         String value = (String) msg.getProperty(key);
@@ -1150,5 +1151,12 @@ public class Util {
         } else {
             ctx.channel().attr(Constants.MUTUAL_SSL_RESULT_ATTRIBUTE).set(MUTUAL_SSL_DISABLED);
         }
+    }
+
+    public static void setAlpnProtocols(SSLEngine sslEngine) {
+        SSLParameters sslParams = sslEngine.getSSLParameters();
+        String[] protocols = {HTTP_1_1};
+        sslParams.setApplicationProtocols(protocols);
+        sslEngine.setSSLParameters(sslParams);
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/HttpServerChannelInitializer.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/HttpServerChannelInitializer.java
@@ -171,6 +171,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
                     .getServerReferenceCountedOpenSslContext(ocspStaplingEnabled);
             sslHandler = context.newHandler(ch.alloc());
             sslEngine = sslHandler.engine();
+            Util.setAlpnProtocols(sslEngine);
 
             ReferenceCountedOpenSslEngine engine = (ReferenceCountedOpenSslEngine) sslEngine;
             engine.setOcspResponse(response.getEncoded());
@@ -184,6 +185,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
             } else {
                 sslEngine = sslHandlerFactory.buildServerSSLEngine(keystoreSslContext);
             }
+            Util.setAlpnProtocols(sslEngine);
             sslHandler = new SslHandler(sslEngine);
             setSslHandshakeTimeOut(sslConfig, sslHandler);
             serverPipeline.addLast(Constants.SSL_HANDLER, sslHandler);

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/HttpClientChannelInitializer.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/HttpClientChannelInitializer.java
@@ -144,6 +144,7 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
                 SSLEngine sslEngine = Util
                         .configureHttpPipelineForSSL(socketChannel, httpRoute.getHost(), httpRoute.getPort(),
                                 sslConfig);
+                Util.setAlpnProtocols(sslEngine);
                 clientPipeline.addLast(Constants.SSL_COMPLETION_HANDLER,
                         new SslHandshakeCompletionHandlerForClient(connectionAvailabilityFuture, this, targetHandler,
                                 sslEngine));


### PR DESCRIPTION
## Purpose
This will add the ALPN extension as `http/1.1` when the connection is initiated with HTTP/1.1 protocol.
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/3766

## Examples
Try a Ballerina server and a client after setting `httpVersion = http:HTTP_1_1`. Enable SSL debug logs when you run the two programs. You could see the following extension appearing on SSL debug logs.

<img width="659" alt="Screenshot 2023-01-05 at 12 33 39" src="https://user-images.githubusercontent.com/11239305/210721353-06fac247-b8bb-476c-9528-f0c2867395e6.png">

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- ~[ ] Added tests~ [Code is already covered from existing test cases. This will only be visible if SSL debug logs are enabled.] 
- ~[ ] Updated the spec~ [This will only be visible if SSL debug logs are enabled. Will only use for troubleshooting if there is a connection issue at the SSL handshake level.]
- ~[ ] Checked native-image compatibility~ [Same as above.]
