### PR TITLE
Change `testIntTableOrMapofIntArrayDatabinding` http client test

### DIFF
--- a/ballerina-tests/http-client-tests/tests/http_client_data_binding_anydata.bal
+++ b/ballerina-tests/http-client-tests/tests/http_client_data_binding_anydata.bal
@@ -357,7 +357,7 @@ function testIntTableDatabinding() returns error? {
 
 @test:Config {}
 function testIntTableOrMapofIntArrayDatabinding() returns error? {
-    table<map<int>>|map<int>[] response = check clientDBBackendClient->get("/anydataTest/intTableType");
+    map<int>[]|table<map<int>> response = check clientDBBackendClient->get("/anydataTest/intTableType");
     if response is map<int>[] {
         map<int> entry = response[0];
         int? val1 = entry["id"];


### PR DESCRIPTION
## Purpose

Changed the `testIntTableOrMapofIntArrayDatabinding` http client test. Previously the test was failing when adhering to the first match policy in the Ballerina type conversion. See https://github.com/ballerina-platform/ballerina-lang/issues/39168. So I just interchanged the order of member types in the contextually expected union type.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
