### PR TITLE
Add code modifier for @http:payload annotation injection

### DIFF
--- a/ballerina-tests/http-dispatching-tests/tests/service_dispatching_data_binding_anydata_test.bal
+++ b/ballerina-tests/http-dispatching-tests/tests/service_dispatching_data_binding_anydata_test.bal
@@ -70,14 +70,14 @@ service /anydataB on generalListener {
         return j;
     }
 
-    resource function post checkIntMap(@http:Payload map<int> person) returns json|error {
+    resource function post checkIntMap(map<int> person) returns json|error {
         int? a = person["name"];
         int? b = person["team"];
         json responseJson = {"1": a, "2": b};
         return responseJson;
     }
 
-    resource function post checkIntTable(@http:Payload table<map<int>> tbl)
+    resource function post checkIntTable(table<map<int>> tbl)
             returns http:InternalServerError|map<int> {
         object {
             public isolated function next() returns record {|map<int> value;|}?;
@@ -99,14 +99,14 @@ service /anydataB on generalListener {
         return j;
     }
 
-    resource function post checkStringMap(@http:Payload map<string> person) returns json|error {
+    resource function post checkStringMap(map<string> person) returns json|error {
         string? a = person["name"];
         string? b = person["team"];
         json responseJson = {"1": a, "2": b};
         return responseJson;
     }
 
-    resource function post checkStringTable(@http:Payload table<map<string>> tbl)
+    resource function post checkStringTable(table<map<string>> tbl)
             returns http:InternalServerError|map<string> {
         object {
             public isolated function next() returns record {|map<string> value;|}?;
@@ -120,24 +120,24 @@ service /anydataB on generalListener {
     }
 
     // record
-    resource function post checkRecord(@http:Payload Person person) returns json {
+    resource function post checkRecord(Person person) returns json {
         string name = person.name;
         int age = person.age;
         return {Key: name, Age: age};
     }
 
-    resource function post checkRecordArray(@http:Payload Person[] j) returns Person[] {
+    resource function post checkRecordArray(Person[] j) returns Person[] {
         return j;
     }
 
-    resource function post checkRecordMap(@http:Payload map<Person> person) returns json|error {
+    resource function post checkRecordMap(map<Person> person) returns json|error {
         Person? a = person["name"];
         Person? b = person["team"];
         json responseJson = {"1": a, "2": b};
         return responseJson;
     }
 
-    resource function post checkRecordTable(@http:Payload table<Person> tbl) returns http:InternalServerError|Person {
+    resource function post checkRecordTable(table<Person> tbl) returns http:InternalServerError|Person {
         object {
             public isolated function next() returns record {|Person value;|}?;
         } iterator = tbl.iterator();
@@ -149,12 +149,12 @@ service /anydataB on generalListener {
         }
     }
 
-    resource function post checkRecordWithTuple(@http:Payload RestaurantNew restaurant) returns RestaurantNew {
+    resource function post checkRecordWithTuple(RestaurantNew restaurant) returns RestaurantNew {
         return restaurant;
     }
 
     // byte[]
-    resource function post checkByteArr(@http:Payload byte[] j) returns http:InternalServerError|string {
+    resource function post checkByteArr(byte[] j) returns http:InternalServerError|string {
         var name = strings:fromBytes(j);
         if (name is string) {
             return name;
@@ -163,7 +163,7 @@ service /anydataB on generalListener {
         }
     }
 
-    resource function post checkByteArrArray(@http:Payload byte[][] j) returns http:InternalServerError|string {
+    resource function post checkByteArrArray(byte[][] j) returns http:InternalServerError|string {
         var name = strings:fromBytes(j[0]);
         if (name is string) {
             return name;
@@ -172,14 +172,14 @@ service /anydataB on generalListener {
         }
     }
 
-    resource function post checkByteArrMap(@http:Payload map<byte[]> person) returns json|error {
+    resource function post checkByteArrMap(map<byte[]> person) returns json|error {
         byte[] a = person["name"] ?: [87, 87, 87, 50];
         byte[] b = person["team"] ?: [50, 87, 87, 50];
         json responseJson = {"1": check strings:fromBytes(a), "2": check strings:fromBytes(b)};
         return responseJson;
     }
 
-    resource function post checkByteArrTable(@http:Payload table<map<byte[]>> tbl)
+    resource function post checkByteArrTable(table<map<byte[]>> tbl)
             returns http:InternalServerError|map<byte[]> {
         object {
             public isolated function next() returns record {|map<byte[]> value;|}?;
@@ -193,22 +193,22 @@ service /anydataB on generalListener {
     }
 
     // xml
-    resource function post checkXml(@http:Payload xml j) returns xml {
+    resource function post checkXml(xml j) returns xml {
         return j;
     }
 
-    resource function post checkXmlArray(@http:Payload xml[] j) returns xml[] {
+    resource function post checkXmlArray(xml[] j) returns xml[] {
         return j;
     }
 
-    resource function post checkXmlMap(@http:Payload map<xml> person) returns json|error {
+    resource function post checkXmlMap(map<xml> person) returns json|error {
         xml a = person["name"] ?: xml `<name>This is Name</name>`;
         xml b = person["team"] ?: xml `<name>This is Team</name>`;
         json responseJson = {"1": a.toJson(), "2": b.toJson()};
         return responseJson;
     }
 
-    resource function post checkXmlTable(@http:Payload table<map<xml>> tbl)
+    resource function post checkXmlTable(table<map<xml>> tbl)
             returns http:InternalServerError|map<xml> {
         object {
             public isolated function next() returns record {|map<xml> value;|}?;
@@ -222,7 +222,7 @@ service /anydataB on generalListener {
     }
 
     // table
-    resource function post checkArrayOfTable(@http:Payload table<map<int>>[] tbls)
+    resource function post checkArrayOfTable(table<map<int>>[] tbls)
             returns http:InternalServerError|map<int> {
         table<map<int>> tbl = tbls[0];
         object {
@@ -236,7 +236,7 @@ service /anydataB on generalListener {
         }
     }
 
-    resource function post checkMapOfTable(@http:Payload map<table<map<int>>> tbls)
+    resource function post checkMapOfTable(map<table<map<int>>> tbls)
             returns http:InternalServerError|map<int> {
         table<map<int>>? tbl = tbls["team"];
         if tbl is table<map<int>> {
@@ -255,7 +255,7 @@ service /anydataB on generalListener {
     }
 
     // readonly
-    resource function post checkReadonlyArr(@http:Payload readonly & Person[] abc) returns json {
+    resource function post checkReadonlyArr(readonly & Person[] abc) returns json {
         Person[] xyz = abc;
         if xyz is readonly & Person[] {
             return {status: "readonly", value: xyz[0]};
@@ -270,8 +270,8 @@ service /anydataB on generalListener {
     }
 
     // Union
-    resource function post checkUnionTypesWithXmlJson(@http:Payload json|xml payload) returns json|xml {
-        if payload is json {
+    resource function post checkUnionTypesWithXmlJson(map<json>|xml payload) returns json|xml {
+        if payload is map<json> {
             return {result: "It's json"};
         } else {
             return payload;
@@ -294,7 +294,7 @@ service /anydataB on generalListener {
         }
     }
 
-    resource function post checkUnionWithStringMapXml(@http:Payload xml|map<string> person) returns json|error {
+    resource function post checkUnionWithStringMapXml(xml|map<string> person) returns json|error {
         if person is map<string> {
             string? a = person["name"];
             string? b = person["team"];
@@ -328,7 +328,7 @@ service /anydataB on generalListener {
         }
     }
 
-    resource function post checkUnionWithRecords(@http:Payload Person|Stock person) returns json {
+    resource function post checkUnionWithRecords(Person|Stock person) returns json {
         if person is Person {
             string name = person.name;
             int age = person.age;
@@ -341,7 +341,7 @@ service /anydataB on generalListener {
     }
 
     // readonly union
-    resource function post checkUnionTypesWithStringNilWithReadonly(@http:Payload readonly & byte[]? payload)
+    resource function post checkUnionTypesWithStringNilWithReadonly(readonly & byte[]? payload)
         returns json {
         if payload is byte[] {
             return {result: "payload"};
@@ -350,7 +350,7 @@ service /anydataB on generalListener {
         }
     }
 
-    resource function post checkUnionTypesWithReadonlyByteArrWithNil(@http:Payload readonly & byte[]|() payload)
+    resource function post checkUnionTypesWithReadonlyByteArrWithNil(readonly & byte[]|() payload)
         returns json {
         if payload is byte[] {
             return {result: "payload"};
@@ -360,11 +360,11 @@ service /anydataB on generalListener {
     }
 
     // builtin subtypes
-    resource function post checkXmlElement(@http:Payload xml:Element payload) returns xml:Element {
+    resource function post checkXmlElement(xml:Element payload) returns xml:Element {
         return payload;
     }
 
-    resource function post checkCustomXmlElement(@http:Payload newXmlElement payload) returns newXmlElement {
+    resource function post checkCustomXmlElement(newXmlElement payload) returns newXmlElement {
         return payload;
     }
 

--- a/ballerina-tests/http-dispatching-tests/tests/service_dispatching_data_binding_test.bal
+++ b/ballerina-tests/http-dispatching-tests/tests/service_dispatching_data_binding_test.bal
@@ -54,14 +54,14 @@ service /dataBinding on generalListener {
         check caller->respond({Key: name, Team: team});
     }
 
-    resource function post body4(@http:Payload xml person, http:Caller caller, http:Request req) returns error? {
+    resource function post body4(xml person, http:Caller caller, http:Request req) returns error? {
         xmllib:Element elem = <xmllib:Element>person;
         string name = <string>elem.getName();
         string team = <string>(person/*).toString();
         check caller->respond({Key: name, Team: team});
     }
 
-    resource function post body5(http:Caller caller, @http:Payload byte[] person) returns error? {
+    resource function post body5(http:Caller caller, byte[] person) returns error? {
         http:Response res = new;
         var name = strings:fromBytes(person);
         if (name is string) {
@@ -73,17 +73,17 @@ service /dataBinding on generalListener {
         check caller->respond(res);
     }
 
-    resource function post body6(http:Caller caller, http:Request req, @http:Payload Person person) returns error? {
+    resource function post body6(http:Caller caller, http:Request req, Person person) returns error? {
         string name = person.name;
         int age = person.age;
         check caller->respond({Key: name, Age: age});
     }
 
-    resource function post body7(http:Caller caller, http:Request req, @http:Payload Stock person) returns error? {
+    resource function post body7(http:Caller caller, http:Request req, Stock person) returns error? {
         check caller->respond();
     }
 
-    resource function post body8(http:Caller caller, @http:Payload Person[] persons) returns error? {
+    resource function post body8(http:Caller caller, Person[] persons) returns error? {
         var jsonPayload = persons.cloneWithType(json);
         if (jsonPayload is json) {
             check caller->respond(jsonPayload);
@@ -92,22 +92,21 @@ service /dataBinding on generalListener {
         }
     }
 
-    resource function 'default body9(http:Caller caller, @http:Payload map<string> person) returns error? {
+    resource function 'default body9(http:Caller caller, map<string> person) returns error? {
         string? a = person["name"];
         string? b = person["team"];
         json responseJson = {"1": a, "2": b};
         check caller->respond(responseJson);
     }
 
-    resource function 'default body10(http:Caller caller,
-            @http:Payload {mediaType: "application/x-www-form-urlencoded"} map<string> person) returns error? {
+    resource function 'default body10(http:Caller caller, map<string> person) returns error? {
         string? a = person["name"];
         string? b = person["team"];
         json responseJson = {"1": a, "2": b};
         check caller->respond(responseJson);
     }
 
-    resource function post body11(@http:Payload map<string> text) returns string {
+    resource function post body11(map<string> text) returns string {
         return "body11";
     }
 
@@ -179,13 +178,13 @@ service /readonlyRecord on generalListener {
 
     // Locates the album whose ID value matches the id
     // parameter sent by the client, then returns that album as a response.
-    resource function post albums(@http:Payload Album album) returns Album {
+    resource function post albums(Album album) returns Album {
         // Add the new album to the table.
         albums.add(album);
         return album;
     }
 
-    resource function post tableBinding(http:Caller caller, @http:Payload table<Album> key(id) albums) returns error? {
+    resource function post tableBinding(http:Caller caller, table<Album> key(id) albums) returns error? {
         Album? album = albums["1"];
         check caller->respond(album);
     }

--- a/ballerina-tests/http-dispatching-tests/tests/service_dispatching_default_data_binding.bal
+++ b/ballerina-tests/http-dispatching-tests/tests/service_dispatching_default_data_binding.bal
@@ -1,0 +1,70 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+import ballerina/http;
+
+type DDPerson record {|
+    readonly int id;
+|};
+
+type Pp DDPerson;
+
+final http:Client defaultDBClient = check new ("http://localhost:" + generalPort.toString());
+
+service /default on generalListener {
+
+    resource function post okWithBody(string? xyz, DDPerson abc) returns http:Ok {
+       return {body: abc};
+    }
+
+    resource function post singleStructured(DDPerson p) returns DDPerson {
+        return p; // p is payload param
+    }
+
+    resource function post singleStructuredArray(DDPerson[] p) returns string {
+        return "done"; // p is payload param
+    }
+
+    resource function post singleStructuredTypeRef(Pp p) returns string {
+        return "done"; // p is payload param
+    }
+
+    resource function post singleStructuredWithBasicType(string q, DDPerson p) returns string {
+        return "done"; // p is payload param
+    }
+
+    resource function post singleBasicType(string q) returns string {
+        return "done"; // q is query param
+    }
+
+    resource function post singleBasicTypeArray(string[] q) returns string {
+        return "done"; // q is query param
+    }
+}
+
+@test:Config {}
+function testOKWithBody() returns error? {
+    DDPerson p = check defaultDBClient->post("/default/okWithBody", {id:234});
+    test:assertEquals(p, {id:234});
+}
+
+@test:Config {}
+function testSingleStructured() returns error? {
+    DDPerson p = check defaultDBClient->post("/default/singleStructured", {id:234});
+    test:assertEquals(p, {id:234});
+}
+

--- a/ballerina-tests/http-dispatching-tests/tests/service_dispatching_default_data_binding.bal
+++ b/ballerina-tests/http-dispatching-tests/tests/service_dispatching_default_data_binding.bal
@@ -32,7 +32,7 @@ service /default on generalListener {
         return {body: abc};
     }
 
-    resource function post singleStructured(DDPerson p) returns DDPerson {
+    resource function post singleStructured(DDPerson? p) returns DDPerson? {
         return p; // p is payload param
     }
 
@@ -48,7 +48,7 @@ service /default on generalListener {
         return {person: p, query: q}; // p is payload param
     }
 
-    resource function post singleStructuredWithHeaderParam(@http:Header string h, DDPerson p) returns map<json> {
+        resource function post singleStructuredWithHeaderParam(@http:Header string h, DDPerson p) returns map<json> {
         return {person: p, header: h}; // p is payload param
     }
 

--- a/ballerina-tests/http-dispatching-tests/tests/service_dispatching_default_data_binding.bal
+++ b/ballerina-tests/http-dispatching-tests/tests/service_dispatching_default_data_binding.bal
@@ -16,6 +16,7 @@
 
 import ballerina/test;
 import ballerina/http;
+import ballerina/url;
 
 type DDPerson record {|
     readonly int id;
@@ -28,43 +29,128 @@ final http:Client defaultDBClient = check new ("http://localhost:" + generalPort
 service /default on generalListener {
 
     resource function post okWithBody(string? xyz, DDPerson abc) returns http:Ok {
-       return {body: abc};
+        return {body: abc};
     }
 
     resource function post singleStructured(DDPerson p) returns DDPerson {
         return p; // p is payload param
     }
 
-    resource function post singleStructuredArray(DDPerson[] p) returns string {
-        return "done"; // p is payload param
+    resource function post singleStructuredArray(DDPerson[] p) returns DDPerson[] {
+        return p; // p is payload param
     }
 
-    resource function post singleStructuredTypeRef(Pp p) returns string {
-        return "done"; // p is payload param
+    resource function post singleStructuredTypeRef(Pp p) returns Pp {
+        return p; // p is payload param
     }
 
-    resource function post singleStructuredWithBasicType(string q, DDPerson p) returns string {
-        return "done"; // p is payload param
+    resource function post singleStructuredWithBasicType(string q, DDPerson p) returns map<json> {
+        return {person: p, query: q}; // p is payload param
+    }
+
+        resource function post singleStructuredWithHeaderParam(@http:Header string h, DDPerson p) returns map<json> {
+        return {person: p, header: h}; // p is payload param
     }
 
     resource function post singleBasicType(string q) returns string {
-        return "done"; // q is query param
+        return q; // q is query param
     }
 
-    resource function post singleBasicTypeArray(string[] q) returns string {
-        return "done"; // q is query param
+    resource function post singleBasicTypeArray(string[] q) returns string[] {
+        return q; // q is query param
     }
+
+    resource function post singlePayloadBasicType(@http:Payload string p) returns string {
+        return p; // p is payload param
+    }
+
+    resource function post singlePayloadBasicTypeArray(@http:Payload string[] p) returns string[] {
+        return p; // p is payload param
+    }
+
+    resource function post queryLikeMapJson(map<json> p) returns map<json> {
+        return p; // p is payload param
+    }
+
+    resource function post queryParamCheck(@http:Query map<json> q) returns map<json> {
+        return q; // q is payload param
+    }
+}
+
+@test:Config {}
+function testQueryType() returns error? {
+    map<json> jsonObj = {name: "test", value: "json"};
+    string jsonEncoded = check url:encode(jsonObj.toJsonString(), "UTF-8");
+    map<json> p = check defaultDBClient->post("/default/queryParamCheck?q=" + jsonEncoded, {name: "Payload", value: "MapJson"});
+    test:assertEquals(p, {name: "test", value: "json"});
+}
+
+
+@test:Config {}
+function testQueryLikePayloadType() returns error? {
+    map<json> jsonObj = {name: "test", value: "json"};
+    string jsonEncoded = check url:encode(jsonObj.toJsonString(), "UTF-8");
+    map<json> p = check defaultDBClient->post("/default/queryLikeMapJson?q=" + jsonEncoded, {name: "Payload", value: "MapJson"});
+    test:assertEquals(p, {name: "Payload", value: "MapJson"});
+}
+
+@test:Config {}
+function testSinglePayloadBasicTypeArray() returns error? {
+    string[] p = check defaultDBClient->post("/default/singlePayloadBasicTypeArray?q=hello,go", ["ballerina","lang"], {h:"this_is_header"});
+    test:assertEquals(p[0], "ballerina");
+}
+
+@test:Config {}
+function testSinglePayloadBasicType() returns error? {
+    string p = check defaultDBClient->post("/default/singlePayloadBasicType?q=hello", "ballerina", {h:"this_is_header"});
+    test:assertEquals(p, "ballerina");
+}
+
+
+@test:Config {}
+function testSingleBasicTypeArray() returns error? {
+    string[] p = check defaultDBClient->post("/default/singleBasicTypeArray?q=hello,go", ["ballerina","lang"], {h:"this_is_header"});
+    test:assertEquals(p[0], "hello");
+}
+
+@test:Config {}
+function testSingleBasicType() returns error? {
+    string p = check defaultDBClient->post("/default/singleBasicType?q=hello", "ballerina", {h:"this_is_header"});
+    test:assertEquals(p, "hello");
+}
+
+@test:Config {}
+function testSingleStructuredWithHeaderParam() returns error? {
+    map<json> p = check defaultDBClient->post("/default/singleStructuredWithHeaderParam", {id: 234}, {h:"this_is_header"});
+    test:assertEquals(p, {person: {id: 234}, header: "this_is_header"});
+}
+
+@test:Config {}
+function testSingleStructuredWithBasicType() returns error? {
+    map<json> p = check defaultDBClient->post("/default/singleStructuredWithBasicType?q=hello", {id: 234});
+    test:assertEquals(p, {person: {id: 234}, query: "hello"});
+}
+
+@test:Config {}
+function testSingleStructuredTypeRef() returns error? {
+    DDPerson p = check defaultDBClient->post("/default/singleStructuredTypeRef", {id: 234});
+    test:assertEquals(p, {id: 234});
+}
+
+@test:Config {}
+function testSingleStructuredArray() returns error? {
+    DDPerson[] p = check defaultDBClient->post("/default/singleStructuredArray", [{id: 234}, {id: 345}]);
+    test:assertEquals(p, [{id: 234}, {id: 345}]);
 }
 
 @test:Config {}
 function testOKWithBody() returns error? {
-    DDPerson p = check defaultDBClient->post("/default/okWithBody", {id:234});
-    test:assertEquals(p, {id:234});
+    DDPerson p = check defaultDBClient->post("/default/okWithBody", {id: 234});
+    test:assertEquals(p, {id: 234});
 }
 
 @test:Config {}
 function testSingleStructured() returns error? {
-    DDPerson p = check defaultDBClient->post("/default/singleStructured", {id:234});
-    test:assertEquals(p, {id:234});
+    DDPerson p = check defaultDBClient->post("/default/singleStructured", {id: 234});
+    test:assertEquals(p, {id: 234});
 }
-

--- a/ballerina-tests/http-dispatching-tests/tests/service_dispatching_default_data_binding.bal
+++ b/ballerina-tests/http-dispatching-tests/tests/service_dispatching_default_data_binding.bal
@@ -48,7 +48,7 @@ service /default on generalListener {
         return {person: p, query: q}; // p is payload param
     }
 
-        resource function post singleStructuredWithHeaderParam(@http:Header string h, DDPerson p) returns map<json> {
+    resource function post singleStructuredWithHeaderParam(@http:Header string h, DDPerson p) returns map<json> {
         return {person: p, header: h}; // p is payload param
     }
 

--- a/ballerina/http_annotation.bal
+++ b/ballerina/http_annotation.bal
@@ -112,6 +112,12 @@ public type HttpHeader record {|
 # The annotation which is used to define the Header resource signature parameter.
 public annotation HttpHeader Header on parameter;
 
+# Defines the query resource signature parameter.
+public type HttpQuery record {||};
+
+# The annotation which is used to define the query resource signature parameter.
+public annotation HttpQuery Query on parameter;
+
 # Defines the HTTP response cache configuration. By default the `no-cache` directive is setted to the `cache-control`
 # header. In addition to that `etag` and `last-modified` headers are also added for cache validation.
 #

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Introduce `getWithType()` method on request context objects](https://github.com/ballerina-platform/ballerina-standard-library/issues/3090)
 - [Introduce `hasKey()` and `keys()` methods on request context objects](https://github.com/ballerina-platform/ballerina-standard-library/issues/4070)
 
+### Added
+- [Make @http:Payload annotation optional for post, put and patch](https://github.com/ballerina-platform/ballerina-standard-library/issues/3276)
+
+## [2.6.0] 
+
 ### Fixed
 
 - [Fix unnecessary warnings in native-image build](https://github.com/ballerina-platform/ballerina-standard-library/issues/3861)

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -57,6 +57,8 @@ import static io.ballerina.stdlib.http.compiler.CompilerPluginTestConstants.HTTP
 import static io.ballerina.stdlib.http.compiler.CompilerPluginTestConstants.HTTP_148;
 import static io.ballerina.stdlib.http.compiler.CompilerPluginTestConstants.HTTP_149;
 import static io.ballerina.stdlib.http.compiler.CompilerPluginTestConstants.HTTP_150;
+import static io.ballerina.stdlib.http.compiler.CompilerPluginTestConstants.HTTP_151;
+import static io.ballerina.stdlib.http.compiler.CompilerPluginTestConstants.HTTP_152;
 
 /**
  * This class includes tests for Ballerina Http compiler plugin.
@@ -240,7 +242,7 @@ public class CompilerPluginTest {
         assertTrue(diagnosticResult, 4, "invalid resource parameter type: 'http_test/sample_7", HTTP_106);
     }
 
-//    @Test
+    @Test
     public void testInValidQueryInfoArgs() {
         Package currentPackage = loadPackage("sample_package_8");
         PackageCompilation compilation = currentPackage.getCompilation();
@@ -709,5 +711,29 @@ public class CompilerPluginTest {
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         Assert.assertEquals(diagnosticResult.errorCount(), 12);
+    }
+
+    @Test
+    public void testCodeModifierErrorTest() {
+        Package currentPackage = loadPackage("sample_package_35");
+        DiagnosticResult modifierDiagnosticResult = currentPackage.runCodeGenAndModifyPlugins();
+        Assert.assertEquals(modifierDiagnosticResult.errorCount(), 5);
+        assertTrue(modifierDiagnosticResult, 0, "ambiguous types for parameter 'a' and 'b'. Use " +
+                "annotations to avoid ambiguity", HTTP_151);
+        assertTrue(modifierDiagnosticResult, 1, "ambiguous types for parameter 'c' and 'd'. Use " +
+                "annotations to avoid ambiguity", HTTP_151);
+        assertTrue(modifierDiagnosticResult, 2, "ambiguous types for parameter 'e' and 'f'. Use " +
+                "annotations to avoid ambiguity", HTTP_151);
+        assertTrue(modifierDiagnosticResult, 3, "invalid union type for default payload param: 'g'. " +
+                "Use basic structured types", HTTP_152);
+        assertTrue(modifierDiagnosticResult, 4, "ambiguous types for parameter 'q' and 'p'. Use " +
+                "annotations to avoid ambiguity", HTTP_151);
+    }
+
+    @Test
+    public void testCodeModifierWithServiceClassesPayloadAnnotation() {
+        Package currentPackage = loadPackage("sample_package_36");
+        DiagnosticResult modifierDiagnosticResult = currentPackage.runCodeGenAndModifyPlugins();
+        Assert.assertEquals(modifierDiagnosticResult.errorCount(), 0);
     }
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -147,7 +147,7 @@ public class CompilerPluginTest {
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         Assert.assertEquals(diagnosticResult.errorCount(), 9);
         assertError(diagnosticResult, 0, "invalid multiple resource parameter annotations for 'abc': expected one of " +
-                "the following types: 'http:Payload', 'http:CallerInfo', 'http:Header'", HTTP_108);
+                "the following types: 'http:Payload', 'http:CallerInfo', 'http:Header', 'http:Query'", HTTP_108);
         assertError(diagnosticResult, 1, "invalid usage of payload annotation for a non entity body " +
                 "resource : 'get'. Use an accessor that supports entity body", HTTP_129);
         assertError(diagnosticResult, 2, "invalid usage of payload annotation for a non entity body " +
@@ -155,7 +155,7 @@ public class CompilerPluginTest {
         assertError(diagnosticResult, 3, "invalid usage of payload annotation for a non entity body resource" +
                 " : 'options'. Use an accessor that supports entity body", HTTP_129);
         assertError(diagnosticResult, 4, "invalid annotation type on param 'a': expected one of the following types: " +
-                "'http:Payload', 'http:CallerInfo', 'http:Headers'", CompilerPluginTestConstants.HTTP_104);
+            "'http:Payload', 'http:CallerInfo', 'http:Header', 'http:Query'", CompilerPluginTestConstants.HTTP_104);
         assertTrue(diagnosticResult, 5, "invalid payload parameter type: 'string|ballerina/http:",
                     CompilerPluginTestConstants.HTTP_107);
         assertTrue(diagnosticResult, 6, "incompatible record field type: 'ballerina/mime:",
@@ -192,7 +192,7 @@ public class CompilerPluginTest {
                 "expected: 'string','int','float','decimal','boolean', an array of the above types or a record " +
                 "which consists of the above types", HTTP_109);
         assertError(diagnosticResult, 7, "invalid multiple resource parameter annotations for 'abc': expected one of " +
-                "the following types: 'http:Payload', 'http:CallerInfo', 'http:Header'", HTTP_108);
+                "the following types: 'http:Payload', 'http:CallerInfo', 'http:Header', 'http:Query'", HTTP_108);
         assertError(diagnosticResult, 8, "invalid type of header param 'abc': One of the following types is " +
                 "expected: 'string','int','float','decimal','boolean', an array of the above types or a record " +
                 "which consists of the above types", HTTP_109);
@@ -219,7 +219,7 @@ public class CompilerPluginTest {
         assertError(diagnosticResult, 1, "invalid type of caller param 'abc': expected 'http:Caller'",
                 HTTP_111);
         assertError(diagnosticResult, 2, "invalid multiple resource parameter annotations for 'abc': expected one of " +
-                "the following types: 'http:Payload', 'http:CallerInfo', 'http:Header'", HTTP_108);
+                "the following types: 'http:Payload', 'http:CallerInfo', 'http:Header', 'http:Query'", HTTP_108);
         assertTrue(diagnosticResult, 3, expectedMsg, HTTP_118);
         assertError(diagnosticResult, 4, "invalid type of caller param 'abc': expected 'http:Caller'",
                 HTTP_111);
@@ -240,7 +240,7 @@ public class CompilerPluginTest {
         assertTrue(diagnosticResult, 4, "invalid resource parameter type: 'http_test/sample_7", HTTP_106);
     }
 
-    @Test
+//    @Test
     public void testInValidQueryInfoArgs() {
         Package currentPackage = loadPackage("sample_package_8");
         PackageCompilation compilation = currentPackage.getCompilation();
@@ -701,5 +701,13 @@ public class CompilerPluginTest {
         Package currentPackage = loadPackage("sample_package_33");
         DiagnosticResult modifierDiagnosticResult = currentPackage.runCodeGenAndModifyPlugins();
         Assert.assertEquals(modifierDiagnosticResult.errorCount(), 0);
+    }
+
+    @Test
+    public void testQueryAnnotation() {
+        Package currentPackage = loadPackage("sample_package_34");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errorCount(), 12);
     }
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -695,4 +695,11 @@ public class CompilerPluginTest {
                 .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR)).count();
         Assert.assertEquals(availableErrors, 0);
     }
+
+    @Test
+    public void testCodeModifierPayloadAnnotation() {
+        Package currentPackage = loadPackage("sample_package_31");
+        DiagnosticResult modifierDiagnosticResult = currentPackage.runCodeGenAndModifyPlugins();
+        Assert.assertEquals(modifierDiagnosticResult.errorCount(), 0);
+    }
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -314,9 +314,9 @@ public class CompilerPluginTest {
         assertError(diagnosticResult, 8, "incompatible respond method argument type : expected " +
                 "'http:Error' according to the 'http:CallerInfo' annotation", HTTP_114);
         assertError(diagnosticResult, 9, "incompatible respond method argument type : expected " +
-                "'http:Ok' according to the 'http:CallerInfo' annotation", HTTP_114); 
+                "'http:Ok' according to the 'http:CallerInfo' annotation", HTTP_114);
         assertError(diagnosticResult, 10, "incompatible respond method argument type : expected " +
-                "'http:StatusCodeResponse' according to the 'http:CallerInfo' annotation", HTTP_114);       
+                "'http:StatusCodeResponse' according to the 'http:CallerInfo' annotation", HTTP_114);
     }
 
 
@@ -698,7 +698,7 @@ public class CompilerPluginTest {
 
     @Test
     public void testCodeModifierPayloadAnnotation() {
-        Package currentPackage = loadPackage("sample_package_31");
+        Package currentPackage = loadPackage("sample_package_33");
         DiagnosticResult modifierDiagnosticResult = currentPackage.runCodeGenAndModifyPlugins();
         Assert.assertEquals(modifierDiagnosticResult.errorCount(), 0);
     }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTestConstants.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTestConstants.java
@@ -72,4 +72,6 @@ public class CompilerPluginTestConstants {
     public static final String HTTP_148 = "HTTP_148";
     public static final String HTTP_149 = "HTTP_149";
     public static final String HTTP_150 = "HTTP_150";
+    public static final String HTTP_151 = "HTTP_151";
+    public static final String HTTP_152 = "HTTP_152";
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_31/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_31/service.bal
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
-=======
 // Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
->>>>>>> Add test cases
 //
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_31/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_31/service.bal
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 // Copyright (c) 2023 WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+=======
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+>>>>>>> Add test cases
 //
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_31/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_31/service.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
 //
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_33/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_33/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "http_test"
+name = "sample_33"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_33/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_33/service.bal
@@ -47,4 +47,48 @@ service http:Service on new http:Listener(9090) {
     resource function post singleBasicTypeArray(string[] q) returns string {
         return "done"; // q is query param
     }
+
+    resource function post xmlTest(xml p) returns string {
+        return "done"; // p is payload param
+    }
+
+    resource function post xmlElementTest(xml:Element p) returns string {
+        return "done"; // p is payload param
+    }
+
+    resource function post testUnion(Person|xml p) returns string {
+        return "done"; // p is payload param
+    }
+
+    resource function post testNilableUnion(map<json>? p) returns string {
+        return "done"; // p is payload param
+    }
+
+    resource function post testReadonly(readonly & Person p) returns string {
+        return "done";
+    }
+
+    resource function post testReadonlyUnion(readonly & (Person|xml) p) returns string {
+        return "done";
+    }
+
+    resource function post testTable(table<map<int>> abc) returns string {
+        return "done";
+    }
+
+    resource function post testByteArrArr(byte[][] abc) returns string {
+        return "done";
+    }
+
+    resource function post testTuple([int, string, Person] abc) returns string {
+        return "done";
+    }
+
+    resource function post testInlineRecord(@http:Payload record {|string abc;|} abc) returns string {
+        return "done";
+    }
+
+    resource function post okWithBody(string? xyz, Person abc) returns http:Ok {
+        return {body: abc};
+    }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_33/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_33/service.bal
@@ -1,0 +1,50 @@
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+type Person record {|
+    readonly int id;
+|};
+
+type Pp Person;
+
+service http:Service on new http:Listener(9090) {
+
+    resource function post singleStructured(Person p) returns string {
+        return "done"; // p is payload param
+    }
+
+    resource function post singleStructuredArray(Person[] p) returns string {
+        return "done"; // p is payload param
+    }
+
+    resource function post singleStructuredTypeRef(Pp p) returns string {
+        return "done"; // p is payload param
+    }
+
+    resource function post singleStructuredWithBasicType(string q, Person p) returns string {
+        return "done"; // p is payload param
+    }
+
+    resource function post singleBasicType(string q) returns string {
+        return "done"; // q is query param
+    }
+
+    resource function post singleBasicTypeArray(string[] q) returns string {
+        return "done"; // q is query param
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_34/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_34/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "http_test"
+name = "sample_34"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_34/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_34/service.bal
@@ -1,0 +1,146 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/mime;
+
+type Caller record {|
+    int id;
+|};
+
+// This is user-defined type
+public type Count int;
+public type TypeJson json;
+public type Name string;
+public type FirstName Name;
+public type FullName FirstName;
+
+service http:Service on new http:Listener(9090) {
+
+    resource function get callerInfo1(@http:Query string a, @http:Query int[] b, @http:Query float? c,
+        @http:Query decimal[]? d) returns string {
+        return "done";
+    }
+
+    resource function get callerInfo2(@http:Query string a, @http:Query int[] b) returns string {
+        return "done";
+    }
+
+    resource function get callerInfo3(@http:Query string a, @http:Query int b, @http:Query float c,
+        @http:Query decimal d, @http:Query boolean e) returns string {
+        return "done";
+    }
+
+    resource function get callerInfo4(@http:Query string? a, @http:Query int? b, @http:Query float? c,
+        @http:Query decimal? d, @http:Query boolean? e) returns string {
+        return "done";
+    }
+
+    resource function get callerInfo5(@http:Query string[] a, @http:Query int[] b, @http:Query float[] c,
+        @http:Query decimal[] d, @http:Query boolean[] e) returns string {
+        return "done";
+    }
+
+    resource function get callerInfo6(@http:Query string[]? a, @http:Query int[]? b, @http:Query float[]? c,
+        @http:Query decimal[]? d, @http:Query boolean[]? e) returns string {
+        return "done";
+    }
+
+    resource function get callerInfo7(@http:Query map<json> aa, @http:Query string? ab,
+        @http:Query boolean[] ac) returns string {
+        return "done";
+    }
+
+    resource function get callerInfo8(@http:Query map<json>[] ba, @http:Query int bb,
+        @http:Query decimal[]? bc) returns string {
+        return "done";
+    }
+
+    resource function get callerInfo9(@http:Query float[] cb, @http:Query int[]? cc,
+        @http:Query map<json>? ca) returns string {
+        return "done";
+    }
+
+    resource function get callerInfo10(@http:Query string[] db, @http:Query boolean dc,
+        @http:Query map<json>[]? da) returns string {
+        return "done";
+    }
+
+    resource function get callerErr1(@http:Query mime:Entity abc) returns string {
+        return "done";
+    }
+
+    resource function get callerErr2(@http:Query int|string a) returns string {
+        return "done";
+    }
+
+    resource function get callerErr3(@http:Query int|string[]|float b) returns string {
+        return "done";
+    }
+
+    resource function get callerErr4(@http:Query int[]|json c) returns string {
+        return "done";
+    }
+
+    resource function get callerErr5(@http:Query xml? d, @http:Query string e) returns string {
+        return "done";
+    }
+
+    resource function get callerErr6(@http:Query int[]? b, @http:Query json a, @http:Query json[] aa) returns string {
+        return "done";
+    }
+
+    resource function get callerErr7(@http:Query string? b, @http:Query map<int> a) returns string {
+        return "done";
+    }
+
+    resource function get callerErr8(@http:Query map<int>[] b, @http:Query int[] c) returns string {
+        return "done";
+    }
+
+    resource function get callerErr9(@http:Query map<string>? c, @http:Query map<json> d) returns string {
+        return "done";
+    }
+
+    resource function get callerErr10(@http:Query json[] d, @http:Query xml e) returns string {
+            return "done";
+    }
+
+    resource function get pets(@http:Query Count count) returns http:Ok {
+        http:Ok ok = {body: ()};
+        return ok;
+    }
+
+    resource function get petsUnion(@http:Query Count? count) returns http:Ok {
+        http:Ok ok = {body: ()};
+        return ok;
+    }
+
+    resource function get petsArr(@http:Query Count[] count) returns http:Ok {
+        http:Ok ok = {body: ()};
+        return ok;
+    }
+
+    resource function get petsMap(@http:Query map<TypeJson> count) returns http:Ok {
+        http:Ok ok = {body: ()};
+        return ok;
+    }
+
+    resource function get nestedTypeRef(@http:Query FullName names) returns http:Ok {
+        http:Ok ok = {body: ()};
+        return ok;
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_35/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_35/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "http_test"
+name = "sample_35"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_35/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_35/service.bal
@@ -1,0 +1,55 @@
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+type Person record {|
+    readonly int id;
+|};
+
+type Pp Person;
+
+service http:Service on new http:Listener(9090) {
+
+    resource function post ambiguous1(Person a, Person b) returns string {
+        return "done"; // ambiguous
+    }
+
+    resource function post ambiguous2(map<json> c, Person d) returns string {
+        return "done"; // ambiguous
+    }
+
+    resource function post ambiguous3(byte[] e, Person f) returns string {
+        return "done"; // ambiguous
+    }
+
+    resource function post ambiguous4(map<json>|string g, Person h) returns string {
+        return "done"; // ambiguous
+    }
+
+    resource function post multiple1(@http:Payload @http:Query map<json> g) returns string {
+        return "done"; // multiple annotation
+    }
+
+    resource function post unionError(http:Request|string p) returns string {
+        return "done"; // p is payload param
+    }
+
+    resource function post testMultipleWithUnion(Person q, map<json>? p) returns string {
+        return "done";
+    }
+}
+

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_36/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_36/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "http_test"
+name = "sample_36"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_36/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_36/service.bal
@@ -1,0 +1,60 @@
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+type Person record {|
+    readonly int id;
+|};
+
+class HelloWorld {
+    string hello = "HelloWorld";
+
+    function greeting() returns string{
+        return self.hello;
+    }
+}
+
+service class SClass {
+   *http:Service;
+   resource function post foo(map<json> p) returns string {
+       return "done";
+   }
+}
+
+service class InterceptorService {
+    *http:RequestInterceptor;
+
+    resource function post [string... path](string q1, int q2, Person payload, @http:Header string foo, http:Caller caller) returns error? {
+        check caller->respond(payload);
+    }
+}
+
+service class ErrorInterceptorService {
+    *http:RequestErrorInterceptor;
+
+    resource function 'default [string... path](http:RequestContext ctx, http:Request req, Person payload, error err) returns http:NextService|error? {
+        req.setTextPayload("interceptor");
+        return ctx.next();
+    }
+}
+
+service http:Service on new http:Listener(9090) {
+
+    resource function post singleStructured(Person p) returns string {
+        return "done"; // p is payload param
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
@@ -40,6 +40,7 @@ public class Constants {
     public static final String PAYLOAD_ANNOTATION_TYPE = "HttpPayload";
     public static final String CALLER_ANNOTATION_TYPE = "HttpCallerInfo";
     public static final String HEADER_ANNOTATION_TYPE = "HttpHeader";
+    public static final String QUERY_ANNOTATION_TYPE = "HttpQuery";
     public static final String CALLER_ANNOTATION_NAME = "CallerInfo";
     public static final String FIELD_RESPONSE_TYPE = "respondType";
     public static final String RESPOND_METHOD_NAME = "respond";
@@ -69,10 +70,12 @@ public class Constants {
     public static final String RELATION = "relation";
     public static final String PARAM = "$param$";
     public static final String SELF = "self";
+    public static final String MEDIA_TYPE_FIELD = "mediaType";
 
     public static final String EMPTY = "";
     public static final String COLON = ":";
     public static final String PLUS = "+";
+    public static final String SPACE = " ";
     public static final String COMMA_WITH_SPACE = ", ";
     public static final String DEFAULT_PATH_REGEX = "\\[\\s*(string)\\s*(\\.{3})\\s*\\w+\\s*\\]";
     public static final String SUFFIX_SEPARATOR_REGEX = "\\+";

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
@@ -51,6 +51,7 @@ public class Constants {
     public static final String REQUEST_ERROR_INTERCEPTOR = "RequestErrorInterceptor";
     public static final String RESPONSE_ERROR_INTERCEPTOR = "ResponseErrorInterceptor";
     public static final String SERVICE = "Service";
+    public static final String HTTP_SERVICE = "http:Service";
     public static final String HTTP_REQUEST_INTERCEPTOR = "http:RequestInterceptor";
     public static final String HTTP_REQUEST_ERROR_INTERCEPTOR = "http:RequestErrorInterceptor";
     public static final String HTTP_RESPONSE_INTERCEPTOR = "http:ResponseInterceptor";

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpCompilerPlugin.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpCompilerPlugin.java
@@ -30,6 +30,7 @@ import io.ballerina.stdlib.http.compiler.codeaction.AddResponseContentTypeCodeAc
 import io.ballerina.stdlib.http.compiler.codeaction.ChangeHeaderParamTypeToStringArrayCodeAction;
 import io.ballerina.stdlib.http.compiler.codeaction.ChangeHeaderParamTypeToStringCodeAction;
 import io.ballerina.stdlib.http.compiler.codeaction.ChangeReturnTypeWithCallerCodeAction;
+import io.ballerina.stdlib.http.compiler.codemodifier.HttpServiceModifier;
 
 import java.util.List;
 
@@ -40,6 +41,7 @@ public class HttpCompilerPlugin extends CompilerPlugin {
 
     @Override
     public void init(CompilerPluginContext context) {
+        context.addCodeModifier(new HttpServiceModifier());
         context.addCodeAnalyzer(new HttpServiceAnalyzer());
         getCodeActions().forEach(context::addCodeAction);
     }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
@@ -36,12 +36,12 @@ public enum HttpDiagnosticCodes {
     HTTP_103("HTTP_103", "invalid resource method annotation type: expected 'http:" + RESOURCE_CONFIG_ANNOTATION +
             "', but found '%s'", ERROR),
     HTTP_104("HTTP_104", "invalid annotation type on param '%s': expected one of the following types: " +
-            "'http:Payload', 'http:CallerInfo', 'http:Headers'", ERROR),
+            "'http:Payload', 'http:CallerInfo', 'http:Header', 'http:Query'", ERROR),
     HTTP_105("HTTP_105", "invalid resource parameter '%s'", ERROR),
     HTTP_106("HTTP_106", "invalid resource parameter type: '%s'", ERROR),
     HTTP_107("HTTP_107", "invalid payload parameter type: '%s'", ERROR),
-    HTTP_108("HTTP_108", "invalid multiple resource parameter annotations for '%s'" +
-            ": expected one of the following types: 'http:Payload', 'http:CallerInfo', 'http:Header'", ERROR),
+    HTTP_108("HTTP_108", "invalid multiple resource parameter annotations for '%s': expected one of the following" +
+            " types: 'http:Payload', 'http:CallerInfo', 'http:Header', 'http:Query'", ERROR),
     HTTP_109("HTTP_109", "invalid type of header param '%s': One of the following types is expected: " +
             "'string','int','float','decimal','boolean', an array of the above types or a record which consists of " +
             "the above types", ERROR),

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
@@ -106,6 +106,8 @@ public enum HttpDiagnosticCodes {
     HTTP_149("HTTP_149", "cannot resolve linked resource without method" , ERROR),
     HTTP_150("HTTP_150", "cannot find '%s' resource with resource link name: '%s'" , ERROR),
 
+    HTTP_151("HTTP_151", "ambiguous payload and query parameter type: '%s'", ERROR),
+
     HTTP_HINT_101("HTTP_HINT_101", "Payload annotation can be added", INTERNAL),
     HTTP_HINT_102("HTTP_HINT_102", "Header annotation can be added", INTERNAL),
     HTTP_HINT_103("HTTP_HINT_103", "Response content-type can be added", INTERNAL),

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
@@ -106,7 +106,8 @@ public enum HttpDiagnosticCodes {
     HTTP_149("HTTP_149", "cannot resolve linked resource without method" , ERROR),
     HTTP_150("HTTP_150", "cannot find '%s' resource with resource link name: '%s'" , ERROR),
 
-    HTTP_151("HTTP_151", "ambiguous payload and query parameter type: '%s'", ERROR),
+    HTTP_151("HTTP_151", "ambiguous types for parameter '%s' and '%s'. Use annotations to avoid ambiguity", ERROR),
+    HTTP_152("HTTP_152", "invalid union type for default payload param: '%s'. Use basic structured types", ERROR),
 
     HTTP_HINT_101("HTTP_HINT_101", "Payload annotation can be added", INTERNAL),
     HTTP_HINT_102("HTTP_HINT_102", "Header annotation can be added", INTERNAL),

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpServiceValidator.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.stdlib.http.compiler;
 
+import io.ballerina.compiler.api.symbols.IntersectionTypeSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.ServiceDeclarationSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
@@ -42,6 +43,7 @@ import io.ballerina.tools.diagnostics.DiagnosticFactory;
 import io.ballerina.tools.diagnostics.DiagnosticInfo;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -70,20 +72,13 @@ public class HttpServiceValidator implements AnalysisTask<SyntaxNodeAnalysisCont
 
     @Override
     public void perform(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext) {
-        List<Diagnostic> diagnostics = syntaxNodeAnalysisContext.semanticModel().diagnostics();
-        boolean erroneousCompilation = diagnostics.stream()
-                .anyMatch(d -> DiagnosticSeverity.ERROR.equals(d.diagnosticInfo().severity()));
-        if (erroneousCompilation) {
+        if (diagnosticContainsErrors(syntaxNodeAnalysisContext)) {
             return;
         }
 
-        ServiceDeclarationNode serviceDeclarationNode = (ServiceDeclarationNode) syntaxNodeAnalysisContext.node();
-        Optional<Symbol> serviceSymOptional = syntaxNodeAnalysisContext.semanticModel().symbol(serviceDeclarationNode);
-        if (serviceSymOptional.isPresent()) {
-            List<TypeSymbol> listenerTypes = ((ServiceDeclarationSymbol) serviceSymOptional.get()).listenerTypes();
-            if (listenerTypes.stream().noneMatch(this::isListenerBelongsToHttpModule)) {
-                return;
-            }
+        ServiceDeclarationNode serviceDeclarationNode = getServiceDeclarationNode(syntaxNodeAnalysisContext);
+        if (serviceDeclarationNode == null) {
+            return;
         }
 
         extractServiceAnnotationAndValidate(syntaxNodeAnalysisContext, serviceDeclarationNode);
@@ -108,6 +103,74 @@ public class HttpServiceValidator implements AnalysisTask<SyntaxNodeAnalysisCont
         }
 
         validateResourceLinks(syntaxNodeAnalysisContext, linksMetaData);
+    }
+
+    public static boolean diagnosticContainsErrors(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext) {
+        List<Diagnostic> diagnostics = syntaxNodeAnalysisContext.semanticModel().diagnostics();
+        return diagnostics.stream()
+                .anyMatch(d -> DiagnosticSeverity.ERROR.equals(d.diagnosticInfo().severity()));
+    }
+
+    public static ServiceDeclarationNode getServiceDeclarationNode(SyntaxNodeAnalysisContext context) {
+        ServiceDeclarationNode serviceDeclarationNode = (ServiceDeclarationNode) context.node();
+        Optional<Symbol> serviceSymOptional = context.semanticModel().symbol(serviceDeclarationNode);
+        if (serviceSymOptional.isPresent()) {
+            List<TypeSymbol> listenerTypes = ((ServiceDeclarationSymbol) serviceSymOptional.get()).listenerTypes();
+            if (listenerTypes.stream().noneMatch(HttpServiceValidator::isListenerBelongsToHttpModule)) {
+                return null;
+            }
+        }
+        return serviceDeclarationNode;
+    }
+
+    private static boolean isListenerBelongsToHttpModule(TypeSymbol listenerType) {
+        if (listenerType.typeKind() == TypeDescKind.UNION) {
+            return ((UnionTypeSymbol) listenerType).memberTypeDescriptors().stream()
+                    .filter(typeDescriptor -> typeDescriptor instanceof TypeReferenceTypeSymbol)
+                    .map(typeReferenceTypeSymbol -> (TypeReferenceTypeSymbol) typeReferenceTypeSymbol)
+                    .anyMatch(typeReferenceTypeSymbol -> isHttpModule(typeReferenceTypeSymbol.getModule().get()));
+        }
+
+        if (listenerType.typeKind() == TypeDescKind.TYPE_REFERENCE) {
+            return isHttpModule(((TypeReferenceTypeSymbol) listenerType).typeDescriptor().getModule().get());
+        }
+        return false;
+    }
+
+    private static boolean isHttpModule(ModuleSymbol moduleSymbol) {
+        return HTTP.equals(moduleSymbol.getName().get()) && BALLERINA.equals(moduleSymbol.id().orgName());
+    }
+
+    public static TypeSymbol getEffectiveTypeFromReadonlyIntersection(IntersectionTypeSymbol intersectionTypeSymbol) {
+        List<TypeSymbol> effectiveTypes = new ArrayList<>();
+        for (TypeSymbol typeSymbol : intersectionTypeSymbol.memberTypeDescriptors()) {
+            if (typeSymbol.typeKind() == TypeDescKind.READONLY) {
+                continue;
+            }
+            effectiveTypes.add(typeSymbol);
+        }
+        if (effectiveTypes.size() == 1) {
+            return effectiveTypes.get(0);
+        }
+        return null;
+    }
+
+    public static TypeDescKind getReferencedTypeDescKind(TypeSymbol typeSymbol) {
+        TypeDescKind kind = typeSymbol.typeKind();
+        if (kind == TypeDescKind.TYPE_REFERENCE) {
+            TypeSymbol typeDescriptor = ((TypeReferenceTypeSymbol) typeSymbol).typeDescriptor();
+            kind = getReferencedTypeDescKind(typeDescriptor);
+        }
+        return kind;
+    }
+
+    public static boolean isAllowedQueryParamBasicType(TypeDescKind kind, TypeSymbol typeSymbol) {
+        if (kind == TypeDescKind.TYPE_REFERENCE) {
+            TypeSymbol typeDescriptor = ((TypeReferenceTypeSymbol) typeSymbol).typeDescriptor();
+            kind =  getReferencedTypeDescKind(typeDescriptor);
+        }
+        return kind == TypeDescKind.STRING || kind == TypeDescKind.INT || kind == TypeDescKind.FLOAT ||
+                kind == TypeDescKind.DECIMAL || kind == TypeDescKind.BOOLEAN;
     }
 
     private void validateResourceLinks(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext,
@@ -183,7 +246,7 @@ public class HttpServiceValidator implements AnalysisTask<SyntaxNodeAnalysisCont
     }
 
     private static void validateServiceConfigAnnotation(SyntaxNodeAnalysisContext ctx,
-                                                            Optional<MappingConstructorExpressionNode> maps) {
+                                                        Optional<MappingConstructorExpressionNode> maps) {
         MappingConstructorExpressionNode mapping = maps.get();
         for (MappingFieldNode field : mapping.fields()) {
             String fieldName = field.toString();
@@ -203,24 +266,6 @@ public class HttpServiceValidator implements AnalysisTask<SyntaxNodeAnalysisCont
                 }
             }
         }
-    }
-
-    private boolean isListenerBelongsToHttpModule(TypeSymbol listenerType) {
-        if (listenerType.typeKind() == TypeDescKind.UNION) {
-            return ((UnionTypeSymbol) listenerType).memberTypeDescriptors().stream()
-                    .filter(typeDescriptor -> typeDescriptor instanceof TypeReferenceTypeSymbol)
-                    .map(typeReferenceTypeSymbol -> (TypeReferenceTypeSymbol) typeReferenceTypeSymbol)
-                    .anyMatch(typeReferenceTypeSymbol -> isHttpModule(typeReferenceTypeSymbol.getModule().get()));
-        }
-
-        if (listenerType.typeKind() == TypeDescKind.TYPE_REFERENCE) {
-            return isHttpModule(((TypeReferenceTypeSymbol) listenerType).typeDescriptor().getModule().get());
-        }
-        return false;
-    }
-
-    private boolean isHttpModule(ModuleSymbol moduleSymbol) {
-        return HTTP.equals(moduleSymbol.getName().get()) && BALLERINA.equals(moduleSymbol.id().orgName());
     }
 
     private void reportInvalidFunctionType(SyntaxNodeAnalysisContext ctx, FunctionDefinitionNode node) {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/HttpPayloadParamIdentifier.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/HttpPayloadParamIdentifier.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.compiler.codemodifier;
+
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
+import io.ballerina.compiler.api.symbols.IntersectionTypeSymbol;
+import io.ballerina.compiler.api.symbols.MapTypeSymbol;
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
+import io.ballerina.compiler.api.symbols.ResourceMethodSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TupleTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeList;
+import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.http.compiler.HttpDiagnosticCodes;
+import io.ballerina.stdlib.http.compiler.HttpServiceValidator;
+import io.ballerina.stdlib.http.compiler.codemodifier.context.ParamAvailability;
+import io.ballerina.stdlib.http.compiler.codemodifier.context.ParamData;
+import io.ballerina.stdlib.http.compiler.codemodifier.context.PayloadParamContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static io.ballerina.stdlib.http.compiler.Constants.DEFAULT;
+import static io.ballerina.stdlib.http.compiler.Constants.GET;
+import static io.ballerina.stdlib.http.compiler.Constants.HEAD;
+import static io.ballerina.stdlib.http.compiler.Constants.OPTIONS;
+import static io.ballerina.stdlib.http.compiler.Constants.PAYLOAD_ANNOTATION_TYPE;
+import static io.ballerina.stdlib.http.compiler.Constants.QUERY_ANNOTATION_TYPE;
+import static io.ballerina.stdlib.http.compiler.HttpCompilerPluginUtil.updateDiagnostic;
+
+
+/**
+ * {@code HttpPayloadParamIdentifier} identifies the payload param during the initial syntax node analysis.
+ *
+ * @since 2201.5.0
+ */
+public class HttpPayloadParamIdentifier extends HttpServiceValidator {
+    private final Map<DocumentId, PayloadParamContext> payloadParamContextMap;
+
+    public HttpPayloadParamIdentifier(Map<DocumentId, PayloadParamContext> payloadParamContextMap) {
+        this.payloadParamContextMap = payloadParamContextMap;
+    }
+
+    @Override
+    public void perform(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext) {
+        if (diagnosticContainsErrors(syntaxNodeAnalysisContext)) {
+            return;
+        }
+
+        ServiceDeclarationNode serviceDeclarationNode = getServiceDeclarationNode(syntaxNodeAnalysisContext);
+        if (serviceDeclarationNode == null) {
+            return;
+        }
+        int serviceId = serviceDeclarationNode.hashCode();
+        NodeList<Node> members = serviceDeclarationNode.members();
+        for (Node member : members) {
+            if (member.kind() == SyntaxKind.RESOURCE_ACCESSOR_DEFINITION) {
+                validateResource(syntaxNodeAnalysisContext, (FunctionDefinitionNode) member, serviceId);
+            }
+        }
+    }
+
+    void validateResource(SyntaxNodeAnalysisContext ctx, FunctionDefinitionNode member, int serviceId) {
+        extractInputParamTypeAndValidate(ctx, member, serviceId);
+    }
+
+    void extractInputParamTypeAndValidate(SyntaxNodeAnalysisContext ctx, FunctionDefinitionNode member,
+                                          int serviceId) {
+
+        Optional<Symbol> resourceMethodSymbolOptional = ctx.semanticModel().symbol(member);
+        int resourceId = member.hashCode();
+        if (resourceMethodSymbolOptional.isEmpty()) {
+            return;
+        }
+        Optional<String> resourceMethodOptional = resourceMethodSymbolOptional.get().getName();
+
+        if (resourceMethodOptional.isPresent()) {
+            String accessor = resourceMethodOptional.get();
+            if (accessor.equals(GET) || accessor.equals(HEAD) || accessor.equals(OPTIONS)) {
+                return; // No modification is done for non-entity body resources
+            }
+        } else {
+            return; // No modification is done for non resources functions
+        }
+
+        Optional<List<ParameterSymbol>> parametersOptional =
+                ((ResourceMethodSymbol) resourceMethodSymbolOptional.get()).typeDescriptor().params();
+        if (parametersOptional.isEmpty()) {
+            return; // No modification is done for non param resources functions
+        }
+
+        List<ParamData> nonAnnotatedParams = new ArrayList<>();
+        List<ParamData> annotatedParams = new ArrayList<>();
+        ParamAvailability paramAvailability = new ParamAvailability();
+        int index = 0;
+        for (ParameterSymbol param : parametersOptional.get()) {
+            List<AnnotationSymbol> annotations = param.annotations().stream()
+                    .filter(annotationSymbol -> annotationSymbol.typeDescriptor().isPresent())
+                    .collect(Collectors.toList());
+            if (annotations.isEmpty()) {
+                nonAnnotatedParams.add(new ParamData(param, index++));
+            } else {
+                annotatedParams.add(new ParamData(param, index++));
+            }
+        }
+
+        for (ParamData annotatedParam : annotatedParams) {
+            validateAnnotatedParams(annotatedParam.getParameterSymbol(), paramAvailability);
+            if (paramAvailability.isAnnotatedPayloadParam()) {
+                return;
+            }
+        }
+
+        for (ParamData nonAnnotatedParam : nonAnnotatedParams) {
+            ParameterSymbol parameterSymbol = nonAnnotatedParam.getParameterSymbol();
+            if (validateNonAnnotatedParams(ctx, parameterSymbol.typeDescriptor(),
+                                           paramAvailability)) { //TODO change name of the func
+                paramAvailability.setPayloadParamSymbol(parameterSymbol);
+                this.payloadParamContextMap.put(ctx.documentId(),
+                                                new PayloadParamContext(ctx, parameterSymbol, serviceId, resourceId,
+                                                                        nonAnnotatedParam.getIndex()));
+            }
+            if (paramAvailability.isErrorOccurred()) {
+                return;
+            }
+        }
+    }
+
+    private static void validateAnnotatedParams(ParameterSymbol parameterSymbol, ParamAvailability paramAvailability) {
+        List<AnnotationSymbol> annotations = parameterSymbol.annotations().stream()
+                .filter(annotationSymbol -> annotationSymbol.typeDescriptor().isPresent())
+                .collect(Collectors.toList());
+        for (AnnotationSymbol annotation : annotations) {
+            Optional<TypeSymbol> annotationTypeSymbol = annotation.typeDescriptor();
+            if (annotationTypeSymbol.isEmpty()) {
+                return;
+            }
+            Optional<String> annotationTypeNameOptional = annotationTypeSymbol.get().getName();
+            if (annotationTypeNameOptional.isEmpty()) {
+                return;
+            }
+            String typeName = annotationTypeNameOptional.get();
+            switch (typeName) {
+                case PAYLOAD_ANNOTATION_TYPE: {
+                    paramAvailability.setAnnotatedPayloadParam(true);
+                    break;
+                }
+                case QUERY_ANNOTATION_TYPE: {
+                    paramAvailability.setAnnotatedQueryParam(true);
+                    break;
+                }
+                case DEFAULT: {
+                }
+
+            }
+        }
+    }
+
+    private static boolean validateNonAnnotatedParams(SyntaxNodeAnalysisContext analysisContext,
+                                                      TypeSymbol typeSymbol, ParamAvailability paramAvailability) {
+        if (typeSymbol.typeKind() == TypeDescKind.INTERSECTION) {
+            typeSymbol = getEffectiveTypeFromReadonlyIntersection((IntersectionTypeSymbol) typeSymbol);
+            if (typeSymbol == null) {
+                return false;
+            }
+        }
+        TypeDescKind kind = typeSymbol.typeKind();
+        if (kind == TypeDescKind.TYPE_REFERENCE) {
+            if (typeSymbol.typeKind() == TypeDescKind.INTERSECTION) {
+                return false;
+            }
+            TypeSymbol typeDescriptor = ((TypeReferenceTypeSymbol) typeSymbol).typeDescriptor();
+            return validateNonAnnotatedParams(analysisContext, typeDescriptor, paramAvailability);
+        } else if (kind == TypeDescKind.NIL || kind == TypeDescKind.ERROR || kind == TypeDescKind.OBJECT) {
+            return false;
+        } else if (kind == TypeDescKind.RECORD) {
+            if (paramAvailability.isDefaultPayloadParam()) {
+                reportAmbiguousPayloadParam(analysisContext, typeSymbol);
+                paramAvailability.setErrorOccurred(true);
+                return false;
+            }
+            paramAvailability.setDefaultPayloadParam(true);
+            return true;
+        } else if (kind == TypeDescKind.MAP) {
+            TypeSymbol constrainedTypeSymbol = ((MapTypeSymbol) typeSymbol).typeParam();
+            TypeDescKind constrainedType = getReferencedTypeDescKind(constrainedTypeSymbol);
+            if (constrainedType == TypeDescKind.TYPE_REFERENCE) {
+                TypeSymbol typeDescriptor = ((TypeReferenceTypeSymbol) typeSymbol).typeDescriptor();
+                return validateNonAnnotatedParams(analysisContext, typeDescriptor, paramAvailability);
+            }
+            if (paramAvailability.isDefaultPayloadParam()) {
+                reportAmbiguousPayloadParam(analysisContext, typeSymbol);
+                paramAvailability.setErrorOccurred(true);
+                return false;
+            }
+            paramAvailability.setDefaultPayloadParam(true);
+            return true;
+        } else if (kind == TypeDescKind.ARRAY) {
+            TypeSymbol arrTypeSymbol = ((ArrayTypeSymbol) typeSymbol).memberTypeDescriptor();
+            TypeDescKind elementKind = getReferencedTypeDescKind(arrTypeSymbol);
+            if (elementKind == TypeDescKind.BYTE) {
+                if (paramAvailability.isDefaultPayloadParam()) {
+                    reportAmbiguousPayloadParam(analysisContext, typeSymbol); // TODO Error to be specific with Byte[]
+                    paramAvailability.setErrorOccurred(true);
+                    return false;
+                }
+                paramAvailability.setDefaultPayloadParam(true);
+                return true;
+            } else if (isAllowedQueryParamBasicType(elementKind, arrTypeSymbol)) {
+                return true;
+            } else if (elementKind == TypeDescKind.MAP || elementKind == TypeDescKind.RECORD) {
+                if (paramAvailability.isDefaultPayloadParam()) {
+                    reportAmbiguousPayloadParam(analysisContext, typeSymbol);
+                    paramAvailability.setErrorOccurred(true);
+                    return false;
+                }
+                paramAvailability.setDefaultPayloadParam(true);
+                return true;
+            } else if (elementKind == TypeDescKind.TYPE_REFERENCE) {
+                TypeSymbol typeDescriptor = ((TypeReferenceTypeSymbol) typeSymbol).typeDescriptor();
+                return validateNonAnnotatedParams(analysisContext, typeDescriptor, paramAvailability);
+            }
+        } else if (kind == TypeDescKind.UNION) {
+            List<TypeSymbol> typeDescriptors = ((UnionTypeSymbol) typeSymbol).memberTypeDescriptors();
+            return typeDescriptors.stream().anyMatch(symbol -> validateNonAnnotatedParams(analysisContext, symbol,
+                                                                                          paramAvailability));
+        } else if (kind == TypeDescKind.TUPLE) {
+            List<TypeSymbol> tupleFieldSymbols = ((TupleTypeSymbol) typeSymbol).memberTypeDescriptors();
+            return tupleFieldSymbols.stream().anyMatch(field -> validateNonAnnotatedParams(analysisContext, field,
+                                                                                           paramAvailability));
+        } else if (isAllowedQueryParamBasicType(kind, typeSymbol)) {
+            return true;
+        }
+        return false;
+    }
+
+    private static void reportAmbiguousPayloadParam(SyntaxNodeAnalysisContext analysisContext, TypeSymbol typeSymbol) {
+        updateDiagnostic(analysisContext, typeSymbol.getLocation().get(), HttpDiagnosticCodes.HTTP_151,
+                         typeSymbol.getName());
+
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/HttpPayloadParamIdentifier.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/HttpPayloadParamIdentifier.java
@@ -258,7 +258,7 @@ public class HttpPayloadParamIdentifier extends HttpServiceValidator {
             return tupleFieldSymbols.stream().anyMatch(field -> validateNonAnnotatedParams(analysisContext, field,
                                                                                            paramAvailability));
         } else if (isAllowedQueryParamBasicType(kind, typeSymbol)) {
-            return true;
+            return false;
         }
         return false;
     }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/HttpPayloadParamIdentifier.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/HttpPayloadParamIdentifier.java
@@ -187,7 +187,6 @@ public class HttpPayloadParamIdentifier extends HttpServiceValidator {
                 }
                 case DEFAULT: {
                 }
-
             }
         }
     }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/HttpServiceModifier.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/HttpServiceModifier.java
@@ -22,7 +22,7 @@ import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.plugins.CodeModifier;
 import io.ballerina.projects.plugins.CodeModifierContext;
-import io.ballerina.stdlib.http.compiler.codemodifier.context.PayloadParamContext;
+import io.ballerina.stdlib.http.compiler.codemodifier.context.DocumentContext;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,7 +33,7 @@ import java.util.Map;
  * @since 2201.5.0
  */
 public class HttpServiceModifier extends CodeModifier {
-    private final Map<DocumentId, PayloadParamContext> payloadParamContextMap;
+    private final Map<DocumentId, DocumentContext> payloadParamContextMap;
 
     public HttpServiceModifier() {
         this.payloadParamContextMap = new HashMap<>();

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/HttpServiceModifier.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/HttpServiceModifier.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.compiler.codemodifier;
+
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.plugins.CodeModifier;
+import io.ballerina.projects.plugins.CodeModifierContext;
+import io.ballerina.stdlib.http.compiler.codemodifier.context.PayloadParamContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * {@code HttpServiceModifier} handles required code-modification related to http-service.
+ *
+ * @since 2201.5.0
+ */
+public class HttpServiceModifier extends CodeModifier {
+    private final Map<DocumentId, PayloadParamContext> payloadParamContextMap;
+
+    public HttpServiceModifier() {
+        this.payloadParamContextMap = new HashMap<>();
+    }
+
+    @Override
+    public void init(CodeModifierContext codeModifierContext) {
+        codeModifierContext.addSyntaxNodeAnalysisTask(new HttpPayloadParamIdentifier(this.payloadParamContextMap),
+                                                      SyntaxKind.SERVICE_DECLARATION);
+        codeModifierContext.addSourceModifierTask(new PayloadAnnotationModifierTask(this.payloadParamContextMap));
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/HttpServiceModifier.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/HttpServiceModifier.java
@@ -25,6 +25,7 @@ import io.ballerina.projects.plugins.CodeModifierContext;
 import io.ballerina.stdlib.http.compiler.codemodifier.context.DocumentContext;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -41,8 +42,9 @@ public class HttpServiceModifier extends CodeModifier {
 
     @Override
     public void init(CodeModifierContext codeModifierContext) {
-        codeModifierContext.addSyntaxNodeAnalysisTask(new HttpPayloadParamIdentifier(this.payloadParamContextMap),
-                                                      SyntaxKind.SERVICE_DECLARATION);
+        codeModifierContext.addSyntaxNodeAnalysisTask(
+                new HttpPayloadParamIdentifier(this.payloadParamContextMap),
+                List.of(SyntaxKind.SERVICE_DECLARATION, SyntaxKind.CLASS_DEFINITION));
         codeModifierContext.addSourceModifierTask(new PayloadAnnotationModifierTask(this.payloadParamContextMap));
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/PayloadAnnotationModifierTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/PayloadAnnotationModifierTask.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.compiler.codemodifier;
+
+import io.ballerina.compiler.syntax.tree.AbstractNodeFactory;
+import io.ballerina.compiler.syntax.tree.AnnotationNode;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.FunctionSignatureNode;
+import io.ballerina.compiler.syntax.tree.IdentifierToken;
+import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
+import io.ballerina.compiler.syntax.tree.ModulePartNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeFactory;
+import io.ballerina.compiler.syntax.tree.NodeList;
+import io.ballerina.compiler.syntax.tree.ParameterNode;
+import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
+import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
+import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
+import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.compiler.syntax.tree.Token;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.Module;
+import io.ballerina.projects.ModuleId;
+import io.ballerina.projects.plugins.ModifierTask;
+import io.ballerina.projects.plugins.SourceModifierContext;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.http.compiler.Constants;
+import io.ballerina.stdlib.http.compiler.codemodifier.context.PayloadParamContext;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+import io.ballerina.tools.text.TextDocument;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@code HttpPayloadParamIdentifier} injects the @http:Payload annotation to the Payload param which found during the
+ * initial analysis.
+ *
+ * @since 2201.5.0
+ */
+public class PayloadAnnotationModifierTask implements ModifierTask<SourceModifierContext> {
+
+    private final Map<DocumentId, PayloadParamContext> payloadParamContextMap;
+
+    public PayloadAnnotationModifierTask(Map<DocumentId, PayloadParamContext> payloadParamContextMap) {
+        this.payloadParamContextMap = payloadParamContextMap;
+    }
+
+    @Override
+    public void modify(SourceModifierContext modifierContext) {
+        boolean erroneousCompilation = modifierContext.compilation().diagnosticResult()
+                .diagnostics().stream()
+                .anyMatch(d -> DiagnosticSeverity.ERROR.equals(d.diagnosticInfo().severity()));
+        if (erroneousCompilation) {
+            return;
+        }
+
+        for (Map.Entry<DocumentId, PayloadParamContext> entry : payloadParamContextMap.entrySet()) {
+            DocumentId documentId = entry.getKey();
+            PayloadParamContext payloadParamContext = entry.getValue();
+            SyntaxNodeAnalysisContext analysisContext = payloadParamContext.getContext();
+            ModuleId moduleId = analysisContext.moduleId();
+            Module currentModule = modifierContext.currentPackage().module(moduleId);
+            Document currentDoc = currentModule.document(documentId);
+            ModulePartNode rootNode = currentDoc.syntaxTree().rootNode();
+            NodeList<ModuleMemberDeclarationNode> newMembers = updateMemberNodes(rootNode.members(),
+                                                                                 payloadParamContext);
+            ModulePartNode newModulePart = rootNode.modify(rootNode.imports(), newMembers, rootNode.eofToken());
+            SyntaxTree updatedSyntaxTree = currentDoc.syntaxTree().modifyWith(newModulePart);
+            TextDocument textDocument = updatedSyntaxTree.textDocument();
+            if (currentModule.documentIds().contains(documentId)) {
+                modifierContext.modifySourceFile(textDocument, documentId);
+            } else {
+                modifierContext.modifyTestSourceFile(textDocument, documentId);
+            }
+        }
+    }
+
+    private NodeList<ModuleMemberDeclarationNode> updateMemberNodes(NodeList<ModuleMemberDeclarationNode> oldMembers,
+                                                                    PayloadParamContext payloadParamContext) {
+
+        List<ModuleMemberDeclarationNode> updatedMembers = new ArrayList<>();
+        for (ModuleMemberDeclarationNode memberNode : oldMembers) {
+            if (memberNode.kind() != SyntaxKind.SERVICE_DECLARATION) { //TODO check for service class
+                updatedMembers.add(memberNode);
+                continue;
+            }
+            ServiceDeclarationNode serviceNode = (ServiceDeclarationNode) memberNode;
+            int serviceId = serviceNode.hashCode();
+
+            if (serviceId != payloadParamContext.getServiceId()) {
+                updatedMembers.add(memberNode);
+                continue;
+            }
+            NodeList<Node> members = serviceNode.members();
+            List<Node> resourceMembers = new ArrayList<>();
+            for (Node member : members) {
+                if (member.kind() != SyntaxKind.RESOURCE_ACCESSOR_DEFINITION) {
+                    resourceMembers.add(member);
+                    continue;
+                }
+                FunctionDefinitionNode resourceNode = (FunctionDefinitionNode) member;
+                int resourceId = resourceNode.hashCode();
+
+                if (resourceId != payloadParamContext.getResourceId()) {
+                    resourceMembers.add(member);
+                    continue;
+                }
+                FunctionSignatureNode functionSignatureNode = resourceNode.functionSignature();
+                SeparatedNodeList<ParameterNode> parameterNodes = functionSignatureNode.parameters();
+                List<Node> newParameterNodes = new ArrayList<>();
+                int index = 0;
+                for (ParameterNode parameterNode : parameterNodes) {
+                    if (index++ != payloadParamContext.getIndex()) {
+                        newParameterNodes.add(parameterNode);
+                        newParameterNodes.add(AbstractNodeFactory.createToken(SyntaxKind.COMMA_TOKEN));
+                        continue;
+                    }
+                    RequiredParameterNode param = (RequiredParameterNode) parameterNode;
+                    //add the annotation
+                    AnnotationNode payloadAnnotation = getHttpPayloadAnnotation();
+                    NodeList<AnnotationNode> annotations = NodeFactory.createNodeList();
+                    NodeList<AnnotationNode> updatedAnnotations = annotations.add(payloadAnnotation);
+                    RequiredParameterNode.RequiredParameterNodeModifier paramModifier = param.modify();
+                    paramModifier.withAnnotations(updatedAnnotations);
+                    RequiredParameterNode updatedParam = paramModifier.apply();
+                    newParameterNodes.add(updatedParam);
+                    newParameterNodes.add(AbstractNodeFactory.createToken(SyntaxKind.COMMA_TOKEN));
+                }
+                if (newParameterNodes.size() > 1) {
+                    newParameterNodes.remove(newParameterNodes.size() - 1);
+                }
+
+                FunctionSignatureNode.FunctionSignatureNodeModifier signatureModifier = functionSignatureNode.modify();
+                SeparatedNodeList<ParameterNode> separatedNodeList = AbstractNodeFactory.createSeparatedNodeList(
+                        new ArrayList<>(newParameterNodes));
+                signatureModifier.withParameters(separatedNodeList);
+                FunctionSignatureNode updatedFunctionNode = signatureModifier.apply();
+
+                FunctionDefinitionNode.FunctionDefinitionNodeModifier resourceModifier = resourceNode.modify();
+                resourceModifier.withFunctionSignature(updatedFunctionNode);
+                FunctionDefinitionNode updatedResourceNode = resourceModifier.apply();
+                resourceMembers.add(updatedResourceNode);
+            }
+            NodeList<Node> resourceNodeList = AbstractNodeFactory.createNodeList(resourceMembers);
+            ServiceDeclarationNode.ServiceDeclarationNodeModifier serviceDeclarationNodeModifier = serviceNode.modify();
+            ServiceDeclarationNode updatedServiceDeclarationNode =
+                    serviceDeclarationNodeModifier.withMembers(resourceNodeList).apply();
+            updatedMembers.add(updatedServiceDeclarationNode);
+        }
+        return AbstractNodeFactory.createNodeList(updatedMembers);
+    }
+
+    private AnnotationNode getHttpPayloadAnnotation() {
+        String payloadIdentifierString = Constants.HTTP + SyntaxKind.COLON_TOKEN.stringValue() +
+                Constants.PAYLOAD_ANNOTATION + Constants.SPACE;
+        IdentifierToken identifierToken = NodeFactory.createIdentifierToken(payloadIdentifierString);
+        SimpleNameReferenceNode nameReferenceNode = NodeFactory.createSimpleNameReferenceNode(identifierToken);
+        Token atToken = NodeFactory.createToken(SyntaxKind.AT_TOKEN);
+        return NodeFactory.createAnnotationNode(atToken, nameReferenceNode, null);
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/context/DocumentContext.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/context/DocumentContext.java
@@ -23,7 +23,6 @@ import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import java.util.HashMap;
 import java.util.Map;
 
-
 /**
  * {@code PayloadParamContext} contains details of unannotated payload parameter.
  *

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/context/DocumentContext.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/context/DocumentContext.java
@@ -18,8 +18,10 @@
 
 package io.ballerina.stdlib.http.compiler.codemodifier.context;
 
-import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**
@@ -27,39 +29,28 @@ import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
  *
  *  @since 2201.5.0
  */
-public class PayloadParamContext {
+public class DocumentContext {
     private final SyntaxNodeAnalysisContext context;
-    private final ParameterSymbol parameterSymbol;
-    private final int serviceId;
-    private final int resourceId;
-    private final int index;
+    private final Map<Integer, ServiceContext> serviceContextMap;
 
-    public PayloadParamContext(SyntaxNodeAnalysisContext context, ParameterSymbol parameterSymbol, int serviceId,
-                               int resourceId, int index) {
+    public DocumentContext(SyntaxNodeAnalysisContext context) {
         this.context = context;
-        this.parameterSymbol = parameterSymbol;
-        this.serviceId = serviceId;
-        this.resourceId = resourceId;
-        this.index = index;
-    }
-
-    public ParameterSymbol getParameterSymbol() {
-        return parameterSymbol;
+        this.serviceContextMap = new HashMap<>();
     }
 
     public SyntaxNodeAnalysisContext getContext() {
         return context;
     }
 
-    public int getIndex() {
-        return index;
+    public void addServiceContext(ServiceContext serviceContext) {
+        serviceContextMap.put(serviceContext.getServiceId(), serviceContext);
     }
 
-    public int getResourceId() {
-        return resourceId;
+    public boolean containsService(int serviceId) {
+        return serviceContextMap.containsKey(serviceId);
     }
 
-    public int getServiceId() {
-        return serviceId;
+    public ServiceContext getServiceContext(int serviceId) {
+        return serviceContextMap.get(serviceId);
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/context/ParamAvailability.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/context/ParamAvailability.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.compiler.codemodifier.context;
+
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
+
+/**
+ * {@code ParamAvailability} cache the data required during the payload param identification.
+ *
+ * @since 2201.5.0
+ */
+public class ParamAvailability {
+
+    private boolean annotatedPayloadParam = false;
+    private boolean defaultPayloadParam = false;
+    private boolean annotatedQueryParam = false;
+    private boolean errorOccurred = false;
+    private ParameterSymbol payloadParamSymbol;
+
+    public boolean isAnnotatedPayloadParam() {
+        return annotatedPayloadParam;
+    }
+
+    public void setAnnotatedPayloadParam(boolean annotatedPayloadParam) {
+        this.annotatedPayloadParam = annotatedPayloadParam;
+    }
+
+    public boolean isAnnotatedQueryParam() {
+        return annotatedQueryParam;
+    }
+
+    public void setAnnotatedQueryParam(boolean annotatedQueryParam) {
+        this.annotatedQueryParam = annotatedQueryParam;
+    }
+
+    public boolean isDefaultPayloadParam() {
+        return defaultPayloadParam;
+    }
+
+    public void setDefaultPayloadParam(boolean defaultPayloadParam) {
+        this.defaultPayloadParam = defaultPayloadParam;
+    }
+
+    public boolean isErrorOccurred() {
+        return errorOccurred;
+    }
+
+    public void setErrorOccurred(boolean errorOccurred) {
+        this.errorOccurred = errorOccurred;
+    }
+
+    public ParameterSymbol getPayloadParamSymbol() {
+        return payloadParamSymbol;
+    }
+
+    public void setPayloadParamSymbol(ParameterSymbol payloadParamSymbol) {
+        this.payloadParamSymbol = payloadParamSymbol;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/context/ParamAvailability.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/context/ParamAvailability.java
@@ -28,8 +28,6 @@ import io.ballerina.compiler.api.symbols.ParameterSymbol;
 public class ParamAvailability {
 
     private boolean annotatedPayloadParam = false;
-    private boolean defaultPayloadParam = false;
-    private boolean annotatedQueryParam = false;
     private boolean errorOccurred = false;
     private ParameterSymbol payloadParamSymbol;
 
@@ -41,21 +39,10 @@ public class ParamAvailability {
         this.annotatedPayloadParam = annotatedPayloadParam;
     }
 
-    public boolean isAnnotatedQueryParam() {
-        return annotatedQueryParam;
-    }
-
-    public void setAnnotatedQueryParam(boolean annotatedQueryParam) {
-        this.annotatedQueryParam = annotatedQueryParam;
-    }
-
     public boolean isDefaultPayloadParam() {
-        return defaultPayloadParam;
+        return payloadParamSymbol != null;
     }
 
-    public void setDefaultPayloadParam(boolean defaultPayloadParam) {
-        this.defaultPayloadParam = defaultPayloadParam;
-    }
 
     public boolean isErrorOccurred() {
         return errorOccurred;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/context/ParamData.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/context/ParamData.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.compiler.codemodifier.context;
+
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
+
+/**
+ * {@code ParamData} holds payload param data.
+ *
+ * @since 2201.5.0
+ */
+public class ParamData {
+
+    private ParameterSymbol parameterSymbol;
+    private int index;
+
+    public ParamData(ParameterSymbol parameterSymbol, int index) {
+        this.setParameterSymbol(parameterSymbol);
+        this.setIndex(index);
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
+    }
+
+    public ParameterSymbol getParameterSymbol() {
+        return parameterSymbol;
+    }
+
+    public void setParameterSymbol(ParameterSymbol parameterSymbol) {
+        this.parameterSymbol = parameterSymbol;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/context/PayloadParamContext.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/context/PayloadParamContext.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.compiler.codemodifier.context;
+
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+
+
+/**
+ * {@code PayloadParamContext} contains details of unannotated payload parameter.
+ *
+ *  @since 2201.5.0
+ */
+public class PayloadParamContext {
+    private final SyntaxNodeAnalysisContext context;
+    private final ParameterSymbol parameterSymbol;
+    private final int serviceId;
+    private final int resourceId;
+    private final int index;
+
+    public PayloadParamContext(SyntaxNodeAnalysisContext context, ParameterSymbol parameterSymbol, int serviceId,
+                               int resourceId, int index) {
+        this.context = context;
+        this.parameterSymbol = parameterSymbol;
+        this.serviceId = serviceId;
+        this.resourceId = resourceId;
+        this.index = index;
+    }
+
+    public ParameterSymbol getParameterSymbol() {
+        return parameterSymbol;
+    }
+
+    public SyntaxNodeAnalysisContext getContext() {
+        return context;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public int getResourceId() {
+        return resourceId;
+    }
+
+    public int getServiceId() {
+        return serviceId;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/context/ResourceContext.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/context/ResourceContext.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.compiler.codemodifier.context;
+
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
+
+/**
+ * {@code ResourceContext} contains details of the resource where the unannotated payload parameter is located.
+ *
+ * @since 2201.5.0
+ */
+public class ResourceContext {
+    private final int index;
+    private final ParameterSymbol parameterSymbol;
+
+    public ResourceContext(ParameterSymbol parameterSymbol, int index) {
+        this.parameterSymbol = parameterSymbol;
+        this.index = index;
+    }
+
+    public ParameterSymbol getParameterSymbol() {
+        return parameterSymbol;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/context/ServiceContext.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/context/ServiceContext.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.compiler.codemodifier.context;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * {@code ServiceContext} contains details of the service where the unannotated payload parameter is located.
+ *
+ *  @since 2201.5.0
+ */
+public class ServiceContext {
+    private final int serviceId;
+    private final Map<Integer, ResourceContext> resourceContextMap;
+
+    public ServiceContext(int serviceId) {
+        this.serviceId = serviceId;
+        this.resourceContextMap = new HashMap<>();
+    }
+
+    public void setResourceContext(int resourceId, ResourceContext payloadParamInfo) {
+        this.resourceContextMap.put(resourceId, payloadParamInfo);
+    }
+
+    public int getServiceId() {
+        return serviceId;
+    }
+
+    public boolean containsResource(int resourceId) {
+        return resourceContextMap.containsKey(resourceId);
+    }
+
+    public ResourceContext getResourceContext(int resourceId) {
+        return resourceContextMap.get(resourceId);
+    }
+}

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -598,22 +598,25 @@ which retrieved by the `Content-type` header of the request. The data binding ha
 parameter type. The type of payload parameter can be one of the `anytype`. If the header is not present or not a 
 standard header, the binding type is inferred by the parameter type.
 
-The listener identifies the default payload parameter which is defined without the @http:Payload annotation when the 
-following conditions are met.
-- Parameters must include only one structured type of map/record or a list of map/record. But byte[] is an exception
+When the following conditions are met, the listener identifies the default payload parameter, which is defined 
+without the @http:Payload annotation:
+- The default payload parameter rules are only applicable to POST, PUT, PATCH, DELETE, and DEFAULT accessors.
+- Parameters must contain only one structured(map/record/table/tuple/array) type or xml. However, byte[] is an exception,
   and it is considered as a payload param.
-    - resource function post(Student[] p) {} -> Student[] is payload
-    - resource function post(int[] p) {} -> int[] is query
-    - resource function post(int p) {} -> int is query
-    - resource function post(Student p) {} -> Student is payload
-
-- If there is more than one structured type, the ambiguity must be resolved using @http:Payload annotation.
-    - resource function post(@http:Payload Student p, Student q) {} -> p is payload, q is query
-- If there are no structured types all are considered query params
+    - resource function post(Student[] p) {} -> Student[] is payload param type
+    - resource function post(int[] p) {} -> int[] is query param type
+    - resource function post(int p) {} -> int is query param type
+    - resource function post(Student p) {} -> Student is payload param type
+- If there's more than one structured type, the ambiguity must be resolved using the @http:Payload annotation.
+    - resource function post(@http:Payload Student p, map<json> q) {} -> p is payload, q is query
+- If there are no structured types, all parameters are considered query parameters.
     - resource function post(@http:Payload string p, string q) {}
-- If the query param is structured, then @http:Query annotation is required.
+- If the query parameter is structured, then the @http:Query annotation is required.
     - resource function post(@http:Query map<json> p) {}
-- The above rules are only applicable to POST, PUT, PATCH, DELETE and DEFAULT accessors
+- The only types allowed in the union for a parameter are structured types, xml, and nil.
+    - resource function post(Student|xml p) {} -> Student|xml is payload param type
+    - resource function post(map<json>|xml p) {} -> map<json>|xml is payload param type
+    - resource function post(Student? p) {} -> Student? is payload param type
 
 Following table explains the compatible `anydata` types with each common media type. In the absence of a standard media 
 type, the binding type is inferred by the payload parameter type itself. If the type is not compatible with the media 


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/3276

## Examples

When the following conditions are met, the listener identifies the default payload parameter, which is defined 
without the @http:Payload annotation:
- The default payload parameter rules are only applicable to POST, PUT, PATCH, DELETE, and DEFAULT accessors.
- Parameters must contain only one structured(map/record/table/tuple/array) type or xml. However, byte[] is an exception,
  and it is considered as a payload param.
    - resource function post(Student[] p) {} -> Student[] is payload param type
    - resource function post(int[] p) {} -> int[] is query param type
    - resource function post(int p) {} -> int is query param type
    - resource function post(Student p) {} -> Student is payload param type
- If there's more than one structured type, the ambiguity must be resolved using the @http:Payload annotation.
    - resource function post(@http:Payload Student p, map<json> q) {} -> p is payload, q is query
- If there are no structured types, all parameters are considered query parameters.
    - resource function post(@http:Payload string p, string q) {}
- If the query parameter is structured, then the @http:Query annotation is required.
    - resource function post(@http:Query map<json> p) {}
- The only types allowed in the union for a parameter are structured types, xml, and nil.
    - resource function post(Student|xml p) {} -> Student|xml is payload param type
    - resource function post(map<json>|xml p) {} -> map<json>|xml is payload param type
    - resource function post(Student? p) {} -> Student? is payload param type
    
```ballerina
import ballerina/http;

type Person record {|
    readonly int id;
|};

service on ep {

    resource function post person(string? xyz, Person abc) returns Person {
       return abc;
    }
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [ ] Checked native-image compatibility
