### PR TITLE
[2201.3.x] Introduce new methods on `RequestContext`

### DIFF
--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -38,7 +38,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "constraint"
-version = "1.0.1"
+version = "1.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -309,7 +309,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.5.0"
+version = "2.5.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},

--- a/ballerina-tests/tests/req_ctx_methods_test.bal
+++ b/ballerina-tests/tests/req_ctx_methods_test.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/test;
 import ballerina/http;
 

--- a/ballerina-tests/tests/req_ctx_methods_test.bal
+++ b/ballerina-tests/tests/req_ctx_methods_test.bal
@@ -1,0 +1,86 @@
+import ballerina/test;
+import ballerina/http;
+
+@test:Config {}
+function testReqCtxHasKeySuccess() {
+    http:RequestContext reqCtx = new;
+    reqCtx.set("key", "value");
+    test:assertTrue(reqCtx.hasKey("key"), msg = "Failed to check if the key exists");
+}
+
+@test:Config {}
+function testReqCtxHasKeyFailure() {
+    http:RequestContext reqCtx = new;
+    test:assertFalse(reqCtx.hasKey("key"), msg = "Failed to check if the key exists");
+}
+
+@test:Config {}
+function testReqCtxKeysSuccess() {
+    http:RequestContext reqCtx = new;
+    test:assertEquals(reqCtx.keys(), [], msg = "Failed to get the keys");
+    reqCtx.set("key1", "value1");
+    test:assertEquals(reqCtx.keys(), ["key1"], msg = "Failed to get the keys");
+    reqCtx.set("key2", "value2");
+    test:assertEquals(reqCtx.keys(), ["key1", "key2"], msg = "Failed to get the keys");
+}
+
+@test:Config {}
+function testReqCtxGetSuccess() returns error? {
+    http:RequestContext reqCtx = new;
+    reqCtx.set("key", "value");
+    test:assertEquals(reqCtx.get("key"), "value", msg = "Failed to get the value");
+
+    string value = check reqCtx.get("key").ensureType();
+    test:assertEquals(value, "value", msg = "Failed to get the value");
+}
+
+@test:Config {}
+function testReqCtxGetFailure() {
+    http:RequestContext reqCtx = new;
+    string|error value1 = trap reqCtx.get("key").ensureType();
+    test:assertTrue(value1 is error, msg = "Unexpected value returned");
+
+    reqCtx.set("key", "value");
+    int|error value2 = trap reqCtx.get("key").ensureType();
+    test:assertTrue(value2 is error, msg = "Unexpected value returned");
+}
+
+@test:Config {}
+function testReqCtxGetWithTypeSuccess() returns error? {
+    http:RequestContext reqCtx = new;
+    reqCtx.set("key", "value");
+    string value = check reqCtx.getWithType("key");
+    test:assertEquals(value, "value", msg = "Failed to get the value with type");
+
+    User user = {id: 1, age: 25};
+    reqCtx.set("user", user);
+    User user1 = check reqCtx.getWithType("user");
+    test:assertEquals(user1, user, msg = "Failed to get the value with type");
+}
+
+@test:Config {}
+function testReqCtxGetWithTypeFailure() {
+    http:RequestContext reqCtx = new;
+    string|error value1 = reqCtx.getWithType("key");
+    test:assertTrue(value1 is error, msg = "Unexpected value returned");
+
+    reqCtx.set("key", "value");
+    User|error value2 = reqCtx.getWithType("key");
+    test:assertTrue(value2 is error, msg = "Unexpected value returned");
+}
+
+@test:Config {}
+function testReqCtxRemoveSuccess() {
+    http:RequestContext reqCtx = new;
+    reqCtx.set("key", "value");
+    test:assertTrue(reqCtx.hasKey("key"), msg = "Failed to check if the key exists");
+    reqCtx.remove("key");
+    test:assertFalse(reqCtx.hasKey("key"), msg = "Failed to check if the key exists");
+}
+
+@test:Config {}
+function testReqCtxRemoveFailure() {
+    http:RequestContext reqCtx = new;
+    error? value = trap reqCtx.remove("key");
+    test:assertTrue(value is error, msg = "Unexpected value returned");
+}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -39,7 +39,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "constraint"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -237,7 +237,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/http_request_context.bal
+++ b/ballerina/http_request_context.bal
@@ -17,15 +17,21 @@
 import ballerina/jballerina.java;
 import ballerina/lang.value;
 
+# Request context attribute type.
+public type ReqCtxAttribute value:Cloneable|isolated object {};
+
+# Request context attribute type descriptor.
+public type ReqCtxAttributeType typedesc<ReqCtxAttribute>;
+
 # Represents an HTTP Context that allows user to pass data between interceptors.
 public isolated class RequestContext {
-    private final map<value:Cloneable|isolated object {}> attributes = {};
+    private final map<ReqCtxAttribute> attributes = {};
 
     # Sets an attribute to the request context object.
     #
     # + key - Represents the attribute key
     # + value - Represents the attribute value
-    public isolated function set(string key, value:Cloneable|isolated object {} value) {
+    public isolated function set(string key, ReqCtxAttribute value) {
         if value is value:Cloneable {
             lock {
                 self.attributes[key] = value.clone();
@@ -42,7 +48,7 @@ public isolated class RequestContext {
     #
     # + key - Represents the attribute key
     # + return - Attribute value
-    public isolated function get(string key) returns value:Cloneable|isolated object {} {
+    public isolated function get(string key) returns ReqCtxAttribute {
         lock {
             value:Cloneable|isolated object {} value = self.attributes.get(key);
 
@@ -54,12 +60,41 @@ public isolated class RequestContext {
         }
     }
 
+    # Checks whether the request context object has an attribute corresponds to the key.
+    #
+    # + key - Represents the attribute key
+    # + return - true if the attribute exists, else false
+    public isolated function hasKey(string key) returns boolean {
+        lock {
+            return self.attributes.hasKey(key);
+        }
+    }
+
+    # Returns the attribute keys of the request context object.
+    #
+    # + return - Array of attribute keys
+    public isolated function keys() returns string[] {
+        lock {
+            return self.attributes.keys().clone();
+        }
+    }
+
+    # Gets an attribute value with type from the request context object.
+    #
+    # + key - Represents the attribute key
+    # + targetType - Represents the expected type of the attribute value
+    # + return - Attribute value or an error if the attribute value is not of the expected type
+    public isolated function getWithType(string key, ReqCtxAttributeType targetType = <>)
+        returns targetType|ListenerError = @java:Method {
+        'class: "io.ballerina.stdlib.http.api.nativeimpl.ExternRequestContext"
+    } external;
+
     # Removes an attribute from the request context object. It panics if there is no such member.
     #
     # + key - Represents the attribute key
     public isolated function remove(string key) {
         lock {
-            value:Cloneable|isolated object {} err = trap self.attributes.remove(key);
+            ReqCtxAttribute err = trap self.attributes.remove(key);
             if err is error {
                 panic err;
             }
@@ -68,15 +103,8 @@ public isolated class RequestContext {
 
     # Calls the next service in the interceptor pipeline.
     #
-    # + return - The next service object in the pipeline. An error is returned, if the call fails 
-    public isolated function next() returns NextService|error? {
-        lock {
-            return externRequestCtxNext(self);
-        }
-    }
+    # + return - The next service object in the pipeline. An error is returned, if the call fails
+    public isolated function next() returns NextService|error? = @java:Method {
+        'class: "io.ballerina.stdlib.http.api.nativeimpl.ExternRequestContext"
+    } external;
 }
-
-isolated function externRequestCtxNext(RequestContext requestCtx) returns NextService|error? = @java:Method {
-    name: "next",
-    'class: "io.ballerina.stdlib.http.api.nativeimpl.ExternRequestContext"
-} external;

--- a/ballerina/http_request_context.bal
+++ b/ballerina/http_request_context.bal
@@ -17,40 +17,40 @@
 import ballerina/jballerina.java;
 import ballerina/lang.value;
 
-# Request context attribute type.
-public type ReqCtxAttribute value:Cloneable|isolated object {};
+# Request context member type.
+public type ReqCtxMember value:Cloneable|isolated object {};
 
-# Request context attribute type descriptor.
-public type ReqCtxAttributeType typedesc<ReqCtxAttribute>;
+# Request context member type descriptor.
+public type ReqCtxMemberType typedesc<ReqCtxMember>;
 
 # Represents an HTTP Context that allows user to pass data between interceptors.
 public isolated class RequestContext {
-    private final map<ReqCtxAttribute> attributes = {};
+    private final map<ReqCtxMember> members = {};
 
-    # Sets an attribute to the request context object.
+    # Sets a member to the request context object.
     #
-    # + key - Represents the attribute key
-    # + value - Represents the attribute value
-    public isolated function set(string key, ReqCtxAttribute value) {
+    # + key - Represents the member key
+    # + value - Represents the member value
+    public isolated function set(string key, ReqCtxMember value) {
         if value is value:Cloneable {
             lock {
-                self.attributes[key] = value.clone();
+                self.members[key] = value.clone();
             }
         }
         else {
             lock {
-                self.attributes[key] = value;
+                self.members[key] = value;
             }   
         }
     }
 
-    # Gets an attribute value from the request context object.
+    # Gets a member value from the request context object. It panics if there is no such member.
     #
-    # + key - Represents the attribute key
-    # + return - Attribute value
-    public isolated function get(string key) returns ReqCtxAttribute {
+    # + key - Represents the member key
+    # + return - Member value
+    public isolated function get(string key) returns ReqCtxMember {
         lock {
-            value:Cloneable|isolated object {} value = self.attributes.get(key);
+            value:Cloneable|isolated object {} value = self.members.get(key);
 
             if value is value:Cloneable {
                 return value.clone();
@@ -60,41 +60,42 @@ public isolated class RequestContext {
         }
     }
 
-    # Checks whether the request context object has an attribute corresponds to the key.
+    # Checks whether the request context object has a member corresponds to the key.
     #
-    # + key - Represents the attribute key
-    # + return - true if the attribute exists, else false
+    # + key - Represents the member key
+    # + return - true if the member exists, else false
     public isolated function hasKey(string key) returns boolean {
         lock {
-            return self.attributes.hasKey(key);
+            return self.members.hasKey(key);
         }
     }
 
-    # Returns the attribute keys of the request context object.
+    # Returns the member keys of the request context object.
     #
-    # + return - Array of attribute keys
+    # + return - Array of member keys
     public isolated function keys() returns string[] {
         lock {
-            return self.attributes.keys().clone();
+            return self.members.keys().clone();
         }
     }
 
-    # Gets an attribute value with type from the request context object.
+    # Gets a member value with type from the request context object.
     #
-    # + key - Represents the attribute key
-    # + targetType - Represents the expected type of the attribute value
-    # + return - Attribute value or an error if the attribute value is not of the expected type
-    public isolated function getWithType(string key, ReqCtxAttributeType targetType = <>)
+    # + key - Represents the member key
+    # + targetType - Represents the expected type of the member value
+    # + return - Attribute value or an error. The error is returned if the member does not exist or
+    #  if the member value is not of the expected type
+    public isolated function getWithType(string key, ReqCtxMemberType targetType = <>)
         returns targetType|ListenerError = @java:Method {
         'class: "io.ballerina.stdlib.http.api.nativeimpl.ExternRequestContext"
     } external;
 
-    # Removes an attribute from the request context object. It panics if there is no such member.
+    # Removes a member from the request context object. It panics if there is no such member.
     #
-    # + key - Represents the attribute key
+    # + key - Represents the member key
     public isolated function remove(string key) {
         lock {
-            ReqCtxAttribute err = trap self.attributes.remove(key);
+            ReqCtxMember err = trap self.members.remove(key);
             if err is error {
                 panic err;
             }

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Fix unnecessary warnings in native-image build](https://github.com/ballerina-platform/ballerina-standard-library/issues/3861)
 - [Http Compiler Plugin fails for payload type with cyclic fields](https://github.com/ballerina-platform/ballerina-standard-library/issues/3966)
+- [Fix union types getting restricted by compiler plugin](https://github.com/ballerina-platform/ballerina-standard-library/issues/3929)
 
 ## [2.5.2] - 2022-12-22
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- [Introduce `getWithType()` method on request context objects](https://github.com/ballerina-platform/ballerina-standard-library/issues/3090)
+- [Introduce `hasKey()` and `keys()` methods on request context objects](https://github.com/ballerina-platform/ballerina-standard-library/issues/4070)
+
 ### Fixed
 
 - [Fix unnecessary warnings in native-image build](https://github.com/ballerina-platform/ballerina-standard-library/issues/3861)

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -2059,34 +2059,54 @@ service class RequestInterceptor {
 ##### 8.1.1.1 Request context  
 Following is the rough definition of the interceptor context.
 ```ballerina
+# Request context attribute type.
+public type ReqCtxAttribute value:Cloneable|isolated object {};
+
+# Request context attribute type descriptor.
+public type ReqCtxAttributeType typedesc<ReqCtxAttribute>;
+
+# Represents an HTTP Context that allows user to pass data between interceptors.
 public isolated class RequestContext {
-    private final map<value:Cloneable|isolated object {}> attributes = {};
+    private final map<ReqCtxAttribute> attributes = {};
 
-    public isolated function add(string 'key, value:Cloneable|isolated object {} value) {
-        if value is value:Cloneable {
-            lock {
-                self.attributes['key] = value.clone();
-            }
-        }
-        else {
-            lock {
-                self.attributes['key] = value;
-            }   
-        }
-    }
+    # Sets an attribute to the request context object.
+    #
+    # + key - Represents the attribute key
+    # + value - Represents the attribute value
+    public isolated function set(string key, ReqCtxAttribute value) {}
 
-    public isolated function get(string 'key) returns value:Cloneable|isolated object {} {
-        lock {
-            return self.attributes.get('key);
-        }
-    }
+    # Gets an attribute value from the request context object.
+    #
+    # + key - Represents the attribute key
+    # + return - Attribute value
+    public isolated function get(string key) returns ReqCtxAttribute {}
 
-    public isolated function remove(string 'key) {
-        lock {
-            value:Cloneable|isolated object {} _ = self.attributes.remove('key);
-        }
-    }
+    # Checks whether the request context object has an attribute corresponds to the key.
+    #
+    # + key - Represents the attribute key
+    # + return - true if the attribute exists, else false
+    public isolated function hasKey(string key) returns boolean {}
 
+    # Returns the attribute keys of the request context object.
+    #
+    # + return - Array of attribute keys
+    public isolated function keys() returns string[] {}
+
+    # Gets an attribute value with type from the request context object.
+    #
+    # + key - Represents the attribute key
+    # + targetType - Represents the expected type of the attribute value
+    # + return - Attribute value or an error if the attribute value is not of the expected type
+    public isolated function getWithType(string key, ReqCtxAttributeType targetType = <>) returns targetType|ListenerError = external;
+
+    # Removes an attribute from the request context object. It panics if there is no such member.
+    #
+    # + key - Represents the attribute key
+    public isolated function remove(string key) {}
+
+    # Calls the next service in the interceptor pipeline.
+    #
+    # + return - The next service object in the pipeline. An error is returned, if the call fails
     public isolated function next() returns NextService|error? = external;
 }
 ```

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -586,6 +586,8 @@ public class HttpConstants {
 
     public static final String OBSERVABILITY_CONTEXT_PROPERTY = "observabilityContext";
 
+    public static final BString REQUEST_CTX_ATTRIBUTES = StringUtils.fromString("attributes");
+
     private HttpConstants() {
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -586,7 +586,7 @@ public class HttpConstants {
 
     public static final String OBSERVABILITY_CONTEXT_PROPERTY = "observabilityContext";
 
-    public static final BString REQUEST_CTX_ATTRIBUTES = StringUtils.fromString("attributes");
+    public static final BString REQUEST_CTX_MEMBERS = StringUtils.fromString("members");
 
     private HttpConstants() {
     }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternRequestContext.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternRequestContext.java
@@ -18,6 +18,7 @@
 package io.ballerina.stdlib.http.api.nativeimpl;
 
 import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
@@ -38,7 +39,9 @@ public class ExternRequestContext {
             Object value = attributes.getOrThrow(key);
             return EnsureType.ensureType(value, targetType);
         } catch (Exception exp) {
-            return exp;
+            return HttpUtil.createHttpError("no attribute found for key: " + key.getValue(),
+                                            HttpErrorType.GENERIC_LISTENER_ERROR, 
+                                            exp instanceof BError ? (BError) exp : null);
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternRequestContext.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternRequestContext.java
@@ -34,13 +34,13 @@ import org.ballerinalang.langlib.value.EnsureType;
 public class ExternRequestContext {
 
     public static Object getWithType(BObject requestCtx, BString key, BTypedesc targetType) {
-        BMap attributes = requestCtx.getMapValue(HttpConstants.REQUEST_CTX_ATTRIBUTES);
+        BMap members = requestCtx.getMapValue(HttpConstants.REQUEST_CTX_MEMBERS);
         try {
-            Object value = attributes.getOrThrow(key);
+            Object value = members.getOrThrow(key);
             return EnsureType.ensureType(value, targetType);
         } catch (Exception exp) {
-            return HttpUtil.createHttpError("no attribute found for key: " + key.getValue(),
-                                            HttpErrorType.GENERIC_LISTENER_ERROR, 
+            return HttpUtil.createHttpError("no member found for key: " + key.getValue(),
+                                            HttpErrorType.GENERIC_LISTENER_ERROR,
                                             exp instanceof BError ? (BError) exp : null);
         }
     }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternRequestContext.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternRequestContext.java
@@ -18,15 +18,30 @@
 package io.ballerina.stdlib.http.api.nativeimpl;
 
 import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
+import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 import io.ballerina.stdlib.http.api.HttpConstants;
 import io.ballerina.stdlib.http.api.HttpErrorType;
 import io.ballerina.stdlib.http.api.HttpUtil;
+import org.ballerinalang.langlib.value.EnsureType;
 
 /**
  * Utilities related to HTTP request context.
  */
 public class ExternRequestContext {
+
+    public static Object getWithType(BObject requestCtx, BString key, BTypedesc targetType) {
+        BMap attributes = requestCtx.getMapValue(HttpConstants.REQUEST_CTX_ATTRIBUTES);
+        try {
+            Object value = attributes.getOrThrow(key);
+            return EnsureType.ensureType(value, targetType);
+        } catch (Exception exp) {
+            return exp;
+        }
+    }
+
     public static Object next(BObject requestCtx) {
         BArray interceptors = getInterceptors(requestCtx);
         if (interceptors != null) {


### PR DESCRIPTION
## Purpose

> $Subject

Fixes : https://github.com/ballerina-platform/ballerina-standard-library/issues/3090
Fixes : https://github.com/ballerina-platform/ballerina-standard-library/issues/4070

## Examples

```bal
public function main() returns error? {
    http:RequestContext ctx = new();
    ctx.set("key", "value");
    
    if ctx.hasKey("key") {
        string value = check ctx.get("key").ensureType();
        io:println("Context value : " + value.toString());
    }

    io:println("Context keys : " + ctx.keys().toString());

    string value = check ctx.getWithType("key");
    io:println("Context value : " + value.toString());
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [ ] <s>Checked native-image compatibility</s>
