### PR TITLE
[2201.3.x] Fix union types getting restricted by compiler plugin

### DIFF
--- a/ballerina-tests/modules/records/records.bal
+++ b/ballerina-tests/modules/records/records.bal
@@ -1,0 +1,40 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public enum Status {
+    OPEN,
+    CLOSED,
+    HOLD
+}
+
+public type RecordA readonly & record {|
+    readonly string id;
+    string name;
+    Status status;
+    int capacity;
+    boolean night;
+    int elevationgain;
+|};
+
+public type RecordB readonly & record {|
+    readonly string id;
+    string name;
+    Status status;
+    string difficulty;
+    boolean groomed;
+    boolean trees;
+    boolean night;
+|};

--- a/ballerina-tests/tests/anydata_union_return_type_service.bal
+++ b/ballerina-tests/tests/anydata_union_return_type_service.bal
@@ -16,7 +16,7 @@
 
 import ballerina/http;
 import ballerina/test;
-import http_service_tests.records;
+import http_tests.records;
 
 public type TestRecord records:RecordA|records:RecordA;
 

--- a/ballerina-tests/tests/anydata_union_return_type_service.bal
+++ b/ballerina-tests/tests/anydata_union_return_type_service.bal
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/test;
+import http_service_tests.records;
+
+public type TestRecord records:RecordA|records:RecordA;
+
+service /unionReturnType on generalListener {
+    resource function get unionResponse() returns TestRecord[] {
+        records:RecordA response = {
+            capacity: 10,
+            elevationgain: 120,
+            id: "2",
+            name: "Test",
+            night: false,
+            status: records:HOLD
+        };
+        return [response];
+    }
+}
+
+@test:Config {}
+function testUnionReturnType() returns error? {
+    http:Client 'client = check new("http://localhost:9000");
+    TestRecord[] response = check 'client->get("/unionReturnType/unionResponse");
+    test:assertEquals(response, [{
+        capacity: 10,
+        elevationgain: 120,
+        id: "2",
+        name: "Test",
+        night: false,
+        status: records:HOLD
+    }]);
+}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -39,7 +39,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "constraint"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -237,7 +237,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -649,4 +649,40 @@ public class CompilerPluginTest {
                 .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR)).count();
         Assert.assertEquals(availableErrors, 0);
     }
+
+    @Test
+    public void testAnydataUnionTypeAsReturnType() {
+        Package currentPackage = loadPackage("sample_package_30");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        long availableErrors = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR)).count();
+        Assert.assertEquals(availableErrors, 0);
+    }
+
+    @Test
+    public void testInvalidUnionTypesAsReturnType() {
+        Package currentPackage = loadPackage("sample_package_31");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errorCount(), 9);
+        assertTrue(diagnosticResult, 0, "invalid resource method return type: expected " +
+                "'anydata|http:Response|http:StatusCodeResponse|error', but found 'TestRecord1[]'", HTTP_102);
+        assertTrue(diagnosticResult, 1, "invalid resource method return type: expected " +
+                "'anydata|http:Response|http:StatusCodeResponse|error', but found 'TestRecord2[]'", HTTP_102);
+        assertTrue(diagnosticResult, 2, "invalid resource method return type: expected " +
+                "'anydata|http:Response|http:StatusCodeResponse|error', but found 'TestRecord3[]'", HTTP_102);
+        assertTrue(diagnosticResult, 3, "invalid resource method return type: expected " +
+                "'anydata|http:Response|http:StatusCodeResponse|error', but found 'TestRecord4[]'", HTTP_102);
+        assertTrue(diagnosticResult, 4, "invalid resource method return type: expected " +
+                "'anydata|http:Response|http:StatusCodeResponse|error', but found 'TestRecord5[]'", HTTP_102);
+        assertTrue(diagnosticResult, 5, "invalid resource method return type: expected " +
+                "'anydata|http:Response|http:StatusCodeResponse|error', but found 'TestRecord6[]'", HTTP_102);
+        assertTrue(diagnosticResult, 6, "invalid resource method return type: expected " +
+                "'anydata|http:Response|http:StatusCodeResponse|error', but found 'TestRecord7[]'", HTTP_102);
+        assertTrue(diagnosticResult, 7, "invalid resource method return type: expected 'anydata|" +
+                "http:Response|http:StatusCodeResponse|error', but found 'http:StatusCodeResponse[]'", HTTP_102);
+        assertTrue(diagnosticResult, 8, "invalid resource method return type: expected " +
+                "'anydata|http:Response|http:StatusCodeResponse|error', but found 'error[]'", HTTP_102);
+    }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_23/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_23/service.bal
@@ -97,9 +97,11 @@ service http:Service on new http:Listener(9090) {
         return [tbPerson, tbPerson].cloneReadOnly();
     }
 
-    resource function get returnReadonlyRecordArr() returns readonly & Person[] { // allowed
-        return [{id:123, name: "john"}, {id:124, name: "khan"}].cloneReadOnly();
-    }
+    // Disabling due to https://github.com/ballerina-platform/ballerina-lang/issues/39425
+    // Once it's fixed, this can be uncommented.
+    //resource function get returnReadonlyRecordArr() returns readonly & Person[] { // allowed
+    //    return [{id:123, name: "john"}, {id:124, name: "khan"}].cloneReadOnly();
+    //}
 
     // Currently following give error reported in https://github.com/ballerina-platform/ballerina-lang/issues/35332
     // Once it's fixed, uncomment the following case

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_30/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_30/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "http_test"
+name = "sample_30"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_30/modules/records/records.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_30/modules/records/records.bal
@@ -1,0 +1,40 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public enum Status {
+    OPEN,
+    CLOSED,
+    HOLD
+}
+
+public type RecordC readonly & record {|
+    readonly string id;
+    string name;
+    Status status;
+    int capacity;
+    boolean night;
+    int elevationgain;
+|};
+
+public type RecordD readonly & record {|
+    readonly string id;
+    string name;
+    Status status;
+    string difficulty;
+    boolean groomed;
+    boolean trees;
+    boolean night;
+|};

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_30/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_30/service.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 import ballerina/http;
-import sample_28.records;
+import sample_30.records;
 
 type RecordA record {|
     string name;

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_30/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_30/service.bal
@@ -1,0 +1,85 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import sample_28.records;
+
+type RecordA record {|
+    string name;
+|};
+
+type RecordB readonly & record {|
+    int age;
+|};
+
+type TestRecord1 RecordA;
+
+type TestRecord2 RecordA|RecordB;
+
+type TestRecord3 RecordA|string;
+
+type TestRecord4 RecordA|map<string>;
+
+type TestRecord5 RecordA|table<map<string>>;
+
+type TestRecord6 int|table<map<string>>;
+
+type TestRecord7 records:RecordC|records:RecordD;
+
+type TestRecord8 records:RecordC|xml;
+
+service on new http:Listener(4000) {
+
+    resource function hello1 [string... path]() returns TestRecord1[] {
+        return [{name: "Hello, World"}];
+    }
+
+    resource function hello2 [string... path]() returns TestRecord2[] {
+        return [{name: "Hello, World"}];
+    }
+
+    resource function hello3 [string... path]() returns TestRecord3[] {
+        return [{name: "Hello, World"}];
+    }
+
+    resource function hello4 [string... path]() returns TestRecord4[] {
+        return [{}];
+    }
+
+    resource function hello5 [string... path]() returns TestRecord5[] {
+        return [{name: "Hello, World"}];
+    }
+
+    resource function hello6 [string... path]() returns TestRecord6[] {
+        return [1];
+    }
+
+    resource function hello7 [string... path]() returns TestRecord7[] {
+        records:RecordC response = {
+            capacity: 10,
+            elevationgain: 120,
+            id: "2",
+            name: "Test",
+            night: false,
+            status: records:HOLD
+        };
+        return [response];
+    }
+
+    resource function hello8 [string... path]() returns TestRecord8[] {
+        return [xml`<A>Test</A>`];
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_31/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_31/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "http_test"
+name = "sample_31"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_31/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_31/service.bal
@@ -1,0 +1,78 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+type RecordA record {|
+    string name;
+|};
+
+type RecordB readonly & record {|
+    int age;
+|};
+
+type TestRecord1 RecordA|http:Request;
+
+type TestRecord2 RecordA|http:Service;
+
+type TestRecord3 RecordA|http:Client;
+
+type TestRecord4 RecordB|http:Client;
+
+type TestRecord5 RecordA|http:Response;
+
+type TestRecord6 int|http:StatusCodeResponse;
+
+type TestRecord7 RecordA|error;
+
+service on new http:Listener(4000) {
+
+    resource function hello1 [string... path]() returns TestRecord1[] {
+        return [{name: "Hello, World"}];
+    }
+
+    resource function hello2 [string... path]() returns TestRecord2[] {
+        return [{name: "Hello, World"}];
+    }
+
+    resource function hello3 [string... path]() returns TestRecord3[] {
+        return [{name: "Hello, World"}];
+    }
+
+    resource function hello4 [string... path]() returns TestRecord4[] {
+        return [{age: 12}];
+    }
+
+    resource function hello5 [string... path]() returns TestRecord5[] {
+        return [{name: "Hello, World"}];
+    }
+
+    resource function hello6 [string... path]() returns TestRecord6[] {
+        return [12];
+    }
+
+    resource function hello7 [string... path]() returns TestRecord7[] {
+        return [{name: "Hello, World"}];
+    }
+
+    resource function hello8 [string... path]() returns http:StatusCodeResponse[] {
+        return [http:ACCEPTED];
+    }
+
+    resource function hello9 [string... path]() returns error[] {
+        return [error("Test error")];
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
@@ -56,6 +56,7 @@ public class Constants {
     public static final String HTTP_RESPONSE_ERROR_INTERCEPTOR = "http:ResponseErrorInterceptor";
     public static final String ALLOWED_INTERCEPTOR_RETURN_UNION = "anydata|http:Response|http:StatusCodeResponse|" +
                                                                   "http:NextService|error?";
+    public static final String STATUS_CODE_RESPONSE = "StatusCodeResponse";
     public static final String DEFAULT = "default";
     public static final String GET = "get";
     public static final String HEAD = "head";


### PR DESCRIPTION
## Purpose
$subject
Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/3929
## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
