### PR TITLE
[4.x] Add JWT information to `http:RequestContext`

### DIFF
--- a/ballerina-tests/http-interceptor-tests/tests/http2_interceptors_basic_tests.bal
+++ b/ballerina-tests/http-interceptor-tests/tests/http2_interceptors_basic_tests.bal
@@ -15,10 +15,14 @@
 // under the License.
 
 import ballerina/http;
+import ballerina/jwt;
 import ballerina/test;
 import ballerina/http_test_common as common;
 
 int http2InterceptorBasicTestsPort1 = common:getHttp2Port(interceptorBasicTestsPort1);
+
+[jwt:Header, jwt:Payload] reqCtxJwtValues = [];
+error? reqCtxJwtDecodeError = ();
 
 final http:Client http2InterceptorsBasicTestsClientEP1 = check new ("http://localhost:" + http2InterceptorBasicTestsPort1.toString(),
     http2Settings = {http2PriorKnowledge: true});
@@ -512,4 +516,82 @@ function tesHttp2GetRequestInterceptorBasePath() returns error? {
     common:assertHeaderValue(check res.getHeader("last-interceptor"), "default-request-interceptor");
     common:assertHeaderValue(check res.getHeader("default-request-interceptor"), "true");
     common:assertHeaderValue(check res.getHeader("last-request-interceptor"), "true");
+}
+
+@http:ServiceConfig {
+    interceptors : [new RequestInterceptorJwtInformation()]
+}
+service /requestInterceptorJwtInformation on new http:Listener(jwtInformationInReqCtxtTestPort, secureSocket = {
+        key: {
+            certFile: common:CERT_FILE,
+            keyFile: common:KEY_FILE
+        }
+    }) {
+    resource function 'default .(http:Caller caller, http:Request req) returns error? {
+        check caller->respond("Hello client");
+    }
+}
+
+@test:Config{}
+function testJwtInformationInRequestContext() returns error? {
+    http:Client jwtClient = check new("https://localhost:" + jwtInformationInReqCtxtTestPort.toString(),
+    secureSocket = {
+        cert: common:CERT_FILE
+    },
+    auth = {
+        username: "ballerina",
+        issuer: "wso2",
+        audience: ["ballerina", "ballerina.org", "ballerina.io"],
+        keyId: "5a0b754-895f-4279-8843-b745e11a57e9",
+        jwtId: "JlbmMiOiJBMTI4Q0JDLUhTMjU2In",
+        customClaims: { "scp": "admin" },
+        expTime: 3600,
+        signatureConfig: {
+            config: {
+                keyFile: common:KEY_FILE
+            }
+        }
+    });
+    string response = check jwtClient->get("/requestInterceptorJwtInformation");
+    test:assertEquals(response, "Hello client");
+    test:assertEquals(reqCtxJwtValues[0], {"alg":"RS256","typ":"JWT","kid":"5a0b754-895f-4279-8843-b745e11a57e9"});
+    test:assertEquals(reqCtxJwtValues[1].iss, "wso2");
+    test:assertEquals(reqCtxJwtValues[1].sub, "ballerina");
+    test:assertEquals(reqCtxJwtValues[1].aud, ["ballerina","ballerina.org","ballerina.io"]);
+    test:assertEquals(reqCtxJwtValues[1].jti, "JlbmMiOiJBMTI4Q0JDLUhTMjU2In");
+    test:assertEquals(reqCtxJwtValues[1]["scp"], "admin");
+}
+
+@test:Config{}
+function testJwtInformationDecodeErrorInRequestContext() returns error? {
+    http:Client jwtClient = check new("https://localhost:" + jwtInformationInReqCtxtTestPort.toString(),
+        secureSocket = {
+            cert: common:CERT_FILE
+        });
+    string response = check jwtClient->get("/requestInterceptorJwtInformation", {"authorization": "Bearer abcd"});
+    test:assertEquals(response, "Hello client");
+    if reqCtxJwtDecodeError is http:ListenerAuthError {
+        test:assertEquals((<http:ListenerAuthError>reqCtxJwtDecodeError).message(), "an error occured while decoding jwt string.");
+        error? cause = (<http:ListenerAuthError>reqCtxJwtDecodeError).cause();
+        if cause is error {
+            test:assertEquals(cause.message(), "Invalid JWT.");
+        } else {
+            test:assertFail("Expected a ListenerAuthError");
+        }
+    } else {
+        test:assertFail("Expected a ListenerAuthError");
+    }
+}
+
+@test:Config{
+    dependsOn: [testJwtInformationDecodeErrorInRequestContext]
+}
+function testNilJwtInformationValueInRequestContext() returns error? {
+    http:Client jwtClient = check new("https://localhost:" + jwtInformationInReqCtxtTestPort.toString(),
+        secureSocket = {
+            cert: common:CERT_FILE
+        });
+    string response = check jwtClient->get("/requestInterceptorJwtInformation");
+    test:assertEquals(response, "Hello client");
+    test:assertTrue(reqCtxJwtDecodeError is ());
 }

--- a/ballerina-tests/http-interceptor-tests/tests/test_common.bal
+++ b/ballerina-tests/http-interceptor-tests/tests/test_common.bal
@@ -500,18 +500,6 @@ service class ResponseInterceptorReturnsError {
        ctx.set("last-interceptor", "response-interceptor-error");
        return error("Response interceptor returns an error");
     }
-}service class RequestInterceptorJwtInformation {
-    *http:RequestInterceptor;
-
-    resource function 'default [string... path](http:RequestContext ctx, http:Request req) returns http:NextService|error? {
-        [jwt:Header, jwt:Payload]|error? result = ctx.getJWTInfo();
-        if result is [jwt:Header, jwt:Payload] {
-            reqCtxJwtValues = result;
-        } else {
-            reqCtxJwtDecodeError = result;
-        }
-        return ctx.next();
-    }
 }
 
 service class ResponseInterceptorSkip {

--- a/ballerina-tests/http-interceptor-tests/tests/test_common.bal
+++ b/ballerina-tests/http-interceptor-tests/tests/test_common.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/http;
+import ballerina/jwt;
 import ballerina/lang.'string as strings;
 
 public type Person record {|
@@ -499,6 +500,18 @@ service class ResponseInterceptorReturnsError {
        ctx.set("last-interceptor", "response-interceptor-error");
        return error("Response interceptor returns an error");
     }
+}service class RequestInterceptorJwtInformation {
+    *http:RequestInterceptor;
+
+    resource function 'default [string... path](http:RequestContext ctx, http:Request req) returns http:NextService|error? {
+        [jwt:Header, jwt:Payload]|error? result = ctx.getJWTInfo();
+        if result is [jwt:Header, jwt:Payload] {
+            reqCtxJwtValues = result;
+        } else {
+            reqCtxJwtDecodeError = result;
+        }
+        return ctx.next();
+    }
 }
 
 service class ResponseInterceptorSkip {
@@ -624,6 +637,20 @@ function getErrorType(error err) returns string {
         }
     } else {
         return "NormalError";
+    }
+}
+
+service class RequestInterceptorJwtInformation {
+    *http:RequestInterceptor;
+
+    resource function 'default [string... path](http:RequestContext ctx, http:Request req) returns http:NextService|error? {
+        [jwt:Header, jwt:Payload]|error? result = ctx.getJWTInfo();
+        if result is [jwt:Header, jwt:Payload] {
+            reqCtxJwtValues = result;
+        } else {
+            reqCtxJwtDecodeError = result;
+        }
+        return ctx.next();
     }
 }
 

--- a/ballerina-tests/http-interceptor-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-interceptor-tests/tests/test_service_ports.bal
@@ -23,6 +23,7 @@ const int interceptorPassthroughTestPort = 9632;
 const int interceptorBackendTestPort = 9633;
 const int interceptorUserAgentTestPort = 9634;
 const int getRequestInterceptorBasePathTestPort = 9588;
+const int jwtInformationInReqCtxtTestPort = 9527;
 
 const int requestInterceptorCallerRespondErrorTestPort = 9623;
 const int requestInterceptorCtxNextTestPort = 9612;

--- a/changelog.md
+++ b/changelog.md
@@ -9,8 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- [Fixed server push not working with nghttp2 HTTP/2 client](https://github.com/ballerina-platform/ballerina-standard-library/issues/3077)
+- [Fix server push not working with nghttp2 HTTP/2 client](https://github.com/ballerina-platform/ballerina-standard-library/issues/3077)
 - [Fix the issue - Errors occur at the SSL Connection creation are hidden](https://github.com/ballerina-platform/ballerina-standard-library/issues/3862)
+- [Fix integrate JWT information into `http:RequestContext`](https://github.com/ballerina-platform/ballerina-standard-library/issues/3408)
 
 ## [2.6.0] - 2023-02-20
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -2108,10 +2108,16 @@ public isolated class RequestContext {
     # + return - Attribute value or an error if the member value is not of the expected type
     public isolated function getWithType(string key, ReqCtxMemberType targetType = <>) returns targetType|ListenerError = external;
 
-    # Removes an member from the request context object. It panics if there is no such member.
+    # Removes a member from the request context object. It panics if there is no such member.
     #
     # + key - Represents the member key
     public isolated function remove(string key) {}
+    
+    # Provides the JWT information from the request.
+    #
+    # + return - `[jwt:Header, jwt:Payload]` if decoding the header is successful, `error` if any error occurs
+    #             while decoding, or `nil` if no jwt header found.
+    public function getJWTInfo() returns [jwt:Header, jwt:Payload]|error? {}
 
     # Calls the next service in the interceptor pipeline.
     #

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -388,6 +388,9 @@ public class HttpConstants {
     public static final String TARGET_SERVICE = "TARGET_SERVICE";
     public static final String INTERCEPT_RESPONSE = "interceptResponse";
     public static final String INTERCEPT_RESPONSE_ERROR = "interceptResponseError";
+    public static final String AUTHORIZATION_HEADER = "authorization";
+    public static final String AUTHORIZATION_STRING = "authString";
+    public static final String BEARER_AUTHORIZATION_HEADER = "Bearer ";
 
     //Service Endpoint
     public static final int SERVICE_ENDPOINT_NAME_INDEX = 0;
@@ -562,6 +565,7 @@ public class HttpConstants {
     public static final String EMPTY = "";
     public static final String QUOTATION_MARK = "\"";
     public static final String DOUBLE_SLASH = "//";
+    public static final String WHITESPACE = " ";
     public static final String REGEX = "(?<!(http:|https:))//";
     public static final String SCHEME_SEPARATOR = "://";
     public static final String HTTP_SCHEME = "http";

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
@@ -50,10 +50,13 @@ import java.util.Map;
 import java.util.Objects;
 
 import static io.ballerina.runtime.api.TypeTags.ARRAY_TAG;
+import static io.ballerina.stdlib.http.api.HttpConstants.AUTHORIZATION_HEADER;
+import static io.ballerina.stdlib.http.api.HttpConstants.BEARER_AUTHORIZATION_HEADER;
 import static io.ballerina.stdlib.http.api.HttpConstants.DEFAULT_HOST;
 import static io.ballerina.stdlib.http.api.HttpConstants.EXTRA_PATH_INDEX;
 import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_SCHEME;
 import static io.ballerina.stdlib.http.api.HttpConstants.SCHEME_SEPARATOR;
+import static io.ballerina.stdlib.http.api.HttpConstants.WHITESPACE;
 import static io.ballerina.stdlib.http.api.HttpUtil.getParameterTypes;
 import static io.ballerina.stdlib.http.api.service.signature.ParamUtils.castParam;
 import static io.ballerina.stdlib.http.api.service.signature.ParamUtils.castParamArray;
@@ -414,6 +417,11 @@ public class HttpDispatcher {
 
     static BObject createRequestContext(HttpCarbonMessage httpCarbonMessage) {
         BObject requestContext = ValueCreatorUtils.createRequestContextObject();
+        String authHeader = httpCarbonMessage.getHeader(AUTHORIZATION_HEADER);
+        if (Objects.nonNull(authHeader) && authHeader.contains(BEARER_AUTHORIZATION_HEADER)) {
+            requestContext.addNativeData(HttpConstants.AUTHORIZATION_STRING,
+                    StringUtils.fromString(authHeader.split(WHITESPACE)[1]));
+        }
         BArray interceptors = httpCarbonMessage.getProperty(HttpConstants.INTERCEPTORS) instanceof BArray ?
                               (BArray) httpCarbonMessage.getProperty(HttpConstants.INTERCEPTORS) : null;
         requestContext.addNativeData(HttpConstants.INTERCEPTORS, interceptors);

--- a/native/src/main/java/io/ballerina/stdlib/http/api/ValueCreatorUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/ValueCreatorUtils.java
@@ -109,19 +109,19 @@ public class ValueCreatorUtils {
      * @param fieldValues values to be used for fields when creating the object value instance.
      * @return value of the object.
      */
-    private static BObject createObjectValue(Module module, String objectTypeName,
-                                             Object... fieldValues) {
+    private static BObject createObjectValue(Module module, String objectTypeName, Object... fieldValues) {
 
-        Object[] fields = new Object[fieldValues.length * 2];
+        if (fieldValues.length > 0) {
+            Object[] fields = new Object[fieldValues.length * 2];
 
-        // Adding boolean values for each arg
-        for (int i = 0, j = 0; i < fieldValues.length; i++) {
-            fields[j++] = fieldValues[i];
-            fields[j++] = true;
+            // Adding boolean values for each arg
+            for (int i = 0, j = 0; i < fieldValues.length; i++) {
+                fields[j++] = fieldValues[i];
+                fields[j++] = true;
+            }
+            return ValueCreator.createObjectValue(module, objectTypeName, fields);
         }
-
-        // passing scheduler, strand and properties as null for the moment, but better to expose them via this method
-        return ValueCreator.createObjectValue(module, objectTypeName, null, null, null, fields);
+        return ValueCreator.createObjectValue(module, objectTypeName);
     }
 
     private ValueCreatorUtils() {}

--- a/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternRequestContext.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternRequestContext.java
@@ -28,6 +28,8 @@ import io.ballerina.stdlib.http.api.HttpErrorType;
 import io.ballerina.stdlib.http.api.HttpUtil;
 import org.ballerinalang.langlib.value.EnsureType;
 
+import java.util.Objects;
+
 /**
  * Utilities related to HTTP request context.
  */
@@ -66,6 +68,14 @@ public class ExternRequestContext {
             return HttpUtil.createHttpError("request context object does not contain the configured interceptors",
                                             HttpErrorType.INTERCEPTOR_RETURN_ERROR);
         }
+    }
+
+    public static Object getAuthString(BObject requestCtx) {
+        Object authString = requestCtx.getNativeData(HttpConstants.AUTHORIZATION_STRING);
+        if (Objects.nonNull(authString) && authString instanceof BString) {
+            return authString;
+        }
+        return null;
     }
 
     private static Object getNextInterceptor(BObject requestCtx, BArray interceptors) {


### PR DESCRIPTION
## Purpose
$subject
Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/3408
## Examples
```bal
service class RequestInterceptorJwtInformation {
    *http:RequestInterceptor;

    resource function 'default [string... path](http:RequestContext ctx, http:Request req) returns http:NextService|error? {
        [jwt:Header, jwt:Payload]|error? result = ctx.getJWTInfo();
        if result is [jwt:Header, jwt:Payload] {
            
        } else if result is error {
            // handle the error
        }
        return ctx.next();
    }
}
```
## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [x] Checked native-image compatibility
