### PR TITLE
[2201.4.x] Add new error structure based on status code

### DIFF
--- a/ballerina-tests/http-advanced-tests/Dependencies.toml
+++ b/ballerina-tests/http-advanced-tests/Dependencies.toml
@@ -290,20 +290,21 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.6.0"
+version = "2.6.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
-	{org = "ballerina", name = "time"}
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "url"}
 ]
 
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.6"
+version = "1.0.7"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina-tests/http-advanced-tests/tests/status_code_error_test.bal
+++ b/ballerina-tests/http-advanced-tests/tests/status_code_error_test.bal
@@ -1,0 +1,451 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/test;
+import ballerina/http_test_common as common;
+
+function getStatusCodeError(int statusCode) returns http:StatusCodeError {
+    match statusCode {
+        400 => {
+            return error http:BadRequestError("Bad request error");
+        }
+        401 => {
+            return error http:UnauthorizedError("Unauthorized error");
+        }
+        402 => {
+            return error http:PaymentRequiredError("Payment required error");
+        }
+        403 => {
+            return error http:ForbiddenError("Forbidden error");
+        }
+        404 => {
+            return error http:NotFoundError("Not found error");
+        }
+        405 => {
+            return error http:MethodNotAllowedError("Method not allowed error");
+        }
+        406 => {
+            return error http:NotAcceptableError("Not acceptable error");
+        }
+        407 => {
+            return error http:ProxyAuthenticationRequiredError("Proxy authentication required error");
+        }
+        408 => {
+            return error http:RequestTimeoutError("Request timeout error");
+        }
+        409 => {
+            return error http:ConflictError("Conflict error");
+        }
+        410 => {
+            return error http:GoneError("Gone error");
+        }
+        411 => {
+            return error http:LengthRequiredError("Length required error");
+        }
+        412 => {
+            return error http:PreconditionFailedError("Precondition failed error");
+        }
+        413 => {
+            return error http:PayloadTooLargeError("Payload too large error");
+        }
+        414 => {
+            return error http:URITooLongError("URI too long error");
+        }
+        415 => {
+            return error http:UnsupportedMediaTypeError("Unsupported media type error");
+        }
+        416 => {
+            return error http:RangeNotSatisfiableError("Range not satisfiable error");
+        }
+        417 => {
+            return error http:ExpectationFailedError("Expectation failed error");
+        }
+        421 => {
+            return error http:MisdirectedRequestError("Misdirected request error");
+        }
+        422 => {
+            return error http:UnprocessableEntityError("Unprocessable entity error");
+        }
+        423 => {
+            return error http:LockedError("Locked error");
+        }
+        424 => {
+            return error http:FailedDependencyError("Failed dependency error");
+        }
+        426 => {
+            return error http:UpgradeRequiredError("Upgrade required error");
+        }
+        428 => {
+            return error http:PreconditionRequiredError("Precondition required error");
+        }
+        429 => {
+            return error http:TooManyRequestsError("Too many requests error");
+        }
+        431 => {
+            return error http:RequestHeaderFieldsTooLargeError("Request header fields too large error");
+        }
+        451 => {
+            return error http:UnavailableForLegalReasonsError("Unavailable for legal reasons error");
+        }
+        500 => {
+            return error http:ServerError("Internal server error");
+        }
+        501 => {
+            return error http:NotImplementedError("Not implemented error");
+        }
+        502 => {
+            return error http:BadGatewayError("Bad gateway error");
+        }
+        503 => {
+            return error http:ServiceUnavailableError("Service unavailable error");
+        }
+        504 => {
+            return error http:GatewayTimeoutError("Gateway timeout error");
+        }
+        505 => {
+            return error http:HTTPVersionNotSupportedError("HTTP version not supported error");
+        }
+        506 => {
+            return error http:VariantAlsoNegotiatesError("Variant also negotiates error");
+        }
+        507 => {
+            return error http:InsufficientStorageError("Insufficient storage error");
+        }
+        508 => {
+            return error http:LoopDetectedError("Loop detected error");
+        }
+        510 => {
+            return error http:NotExtendedError("Not extended error");
+        }
+        511 => {
+            return error http:NetworkAuthenticationRequiredError("Network authentication required error");
+        }
+        _ => {
+            return error http:DefaultStatusCodeError("Default error", statusCode = statusCode);
+        }
+    }
+}
+
+type CustomHeaders record {|
+    string header1;
+    string[] header2;
+|};
+
+service on new http:Listener(statusCodeErrorPort) {
+
+    resource function get statusCodeError(int statusCode) returns http:StatusCodeError {
+
+        return getStatusCodeError(statusCode);
+    }
+
+    resource function post statusCodeError(@http:Payload anydata payload, int statusCode,
+            @http:Header CustomHeaders headers) returns http:StatusCodeError {
+
+        return error http:DefaultStatusCodeError("Default error", statusCode = statusCode,
+            body = payload, headers = headers);
+    }
+}
+
+final http:Client clientEndpoint = check new ("http://localhost:" + statusCodeErrorPort.toString());
+
+@test:Config {}
+function test400StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 400);
+    test:assertEquals(response.statusCode, 400);
+    common:assertTextPayload(response.getTextPayload(), "Bad request error");
+}
+
+@test:Config {}
+function test401StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 401);
+    test:assertEquals(response.statusCode, 401);
+    common:assertTextPayload(response.getTextPayload(), "Unauthorized error");
+}
+
+@test:Config {}
+function test403StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 403);
+    test:assertEquals(response.statusCode, 403);
+    common:assertTextPayload(response.getTextPayload(), "Forbidden error");
+}
+
+@test:Config {}
+function test404StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 404);
+    test:assertEquals(response.statusCode, 404);
+    common:assertTextPayload(response.getTextPayload(), "Not found error");
+}
+
+@test:Config {}
+function test405StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 405);
+    test:assertEquals(response.statusCode, 405);
+    common:assertTextPayload(response.getTextPayload(), "Method not allowed error");
+}
+
+@test:Config {}
+function test406StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 406);
+    test:assertEquals(response.statusCode, 406);
+    common:assertTextPayload(response.getTextPayload(), "Not acceptable error");
+}
+
+@test:Config {}
+function test407StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 407);
+    test:assertEquals(response.statusCode, 407);
+    common:assertTextPayload(response.getTextPayload(), "Proxy authentication required error");
+}
+
+@test:Config {}
+function test408StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 408);
+    test:assertEquals(response.statusCode, 408);
+    common:assertTextPayload(response.getTextPayload(), "Request timeout error");
+}
+
+@test:Config {}
+function test409StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 409);
+    test:assertEquals(response.statusCode, 409);
+    common:assertTextPayload(response.getTextPayload(), "Conflict error");
+}
+
+@test:Config {}
+function test410StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 410);
+    test:assertEquals(response.statusCode, 410);
+    common:assertTextPayload(response.getTextPayload(), "Gone error");
+}
+
+@test:Config {}
+function test411StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 411);
+    test:assertEquals(response.statusCode, 411);
+    common:assertTextPayload(response.getTextPayload(), "Length required error");
+}
+
+@test:Config {}
+function test412StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 412);
+    test:assertEquals(response.statusCode, 412);
+    common:assertTextPayload(response.getTextPayload(), "Precondition failed error");
+}
+
+@test:Config {}
+function test413StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 413);
+    test:assertEquals(response.statusCode, 413);
+    common:assertTextPayload(response.getTextPayload(), "Payload too large error");
+}
+
+@test:Config {}
+function test414StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 414);
+    test:assertEquals(response.statusCode, 414);
+    common:assertTextPayload(response.getTextPayload(), "URI too long error");
+}
+
+@test:Config {}
+function test415StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 415);
+    test:assertEquals(response.statusCode, 415);
+    common:assertTextPayload(response.getTextPayload(), "Unsupported media type error");
+}
+
+@test:Config {}
+function test416StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 416);
+    test:assertEquals(response.statusCode, 416);
+    common:assertTextPayload(response.getTextPayload(), "Range not satisfiable error");
+}
+
+@test:Config {}
+function test417StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 417);
+    test:assertEquals(response.statusCode, 417);
+    common:assertTextPayload(response.getTextPayload(), "Expectation failed error");
+}
+
+@test:Config {}
+function test421StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 421);
+    test:assertEquals(response.statusCode, 421);
+    common:assertTextPayload(response.getTextPayload(), "Misdirected request error");
+}
+
+@test:Config {}
+function test422StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 422);
+    test:assertEquals(response.statusCode, 422);
+    common:assertTextPayload(response.getTextPayload(), "Unprocessable entity error");
+}
+
+@test:Config {}
+function test423StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 423);
+    test:assertEquals(response.statusCode, 423);
+    common:assertTextPayload(response.getTextPayload(), "Locked error");
+}
+
+@test:Config {}
+function test424StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 424);
+    test:assertEquals(response.statusCode, 424);
+    common:assertTextPayload(response.getTextPayload(), "Failed dependency error");
+}
+
+@test:Config {}
+function test426StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 426);
+    test:assertEquals(response.statusCode, 426);
+    common:assertTextPayload(response.getTextPayload(), "Upgrade required error");
+}
+
+@test:Config {}
+function test428StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 428);
+    test:assertEquals(response.statusCode, 428);
+    common:assertTextPayload(response.getTextPayload(), "Precondition required error");
+}
+
+@test:Config {}
+function test429StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 429);
+    test:assertEquals(response.statusCode, 429);
+    common:assertTextPayload(response.getTextPayload(), "Too many requests error");
+}
+
+@test:Config {}
+function test431StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 431);
+    test:assertEquals(response.statusCode, 431);
+    common:assertTextPayload(response.getTextPayload(), "Request header fields too large error");
+}
+
+@test:Config {}
+function test451StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 451);
+    test:assertEquals(response.statusCode, 451);
+    common:assertTextPayload(response.getTextPayload(), "Unavailable for legal reasons error");
+}
+
+@test:Config {}
+function test500StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 500);
+    test:assertEquals(response.statusCode, 500);
+    common:assertTextPayload(response.getTextPayload(), "Internal server error");
+}
+
+@test:Config {}
+function test501StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 501);
+    test:assertEquals(response.statusCode, 501);
+    common:assertTextPayload(response.getTextPayload(), "Not implemented error");
+}
+
+@test:Config {}
+function test502StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 502);
+    test:assertEquals(response.statusCode, 502);
+    common:assertTextPayload(response.getTextPayload(), "Bad gateway error");
+}
+
+@test:Config {}
+function test503StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 503);
+    test:assertEquals(response.statusCode, 503);
+    common:assertTextPayload(response.getTextPayload(), "Service unavailable error");
+}
+
+@test:Config {}
+function test504StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 504);
+    test:assertEquals(response.statusCode, 504);
+    common:assertTextPayload(response.getTextPayload(), "Gateway timeout error");
+}
+
+@test:Config {}
+function test505StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 505);
+    test:assertEquals(response.statusCode, 505);
+    common:assertTextPayload(response.getTextPayload(), "HTTP version not supported error");
+}
+
+@test:Config {}
+function test506StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 506);
+    test:assertEquals(response.statusCode, 506);
+    common:assertTextPayload(response.getTextPayload(), "Variant also negotiates error");
+}
+
+@test:Config {}
+function test507StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 507);
+    test:assertEquals(response.statusCode, 507);
+    common:assertTextPayload(response.getTextPayload(), "Insufficient storage error");
+}
+
+@test:Config {}
+function test508StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 508);
+    test:assertEquals(response.statusCode, 508);
+    common:assertTextPayload(response.getTextPayload(), "Loop detected error");
+}
+
+@test:Config {}
+function test510StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 510);
+    test:assertEquals(response.statusCode, 510);
+    common:assertTextPayload(response.getTextPayload(), "Not extended error");
+}
+
+@test:Config {}
+function test511StatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 511);
+    test:assertEquals(response.statusCode, 511);
+    common:assertTextPayload(response.getTextPayload(), "Network authentication required error");
+}
+
+@test:Config {}
+function testDefaultStatusCodeError() returns error? {
+    http:Response response = check clientEndpoint->/statusCodeError(statusCode = 600);
+    test:assertEquals(response.statusCode, 600);
+    common:assertTextPayload(response.getTextPayload(), "Default error");
+}
+
+@test:Config {}
+function testStatusCodeErrorWithMessage() returns error? {
+    json msg = {
+        "message": "Error message",
+        "code": "1234",
+        "description": "Error description",
+        "details": {
+            "api-version": "v1",
+            "allowed-versions": ["v1", "v2"]
+        }
+    };
+    map<string|string[]> headers = {
+        "header1": "value1",
+        "header2": ["value2", "value3"]
+    };
+    http:Response response = check clientEndpoint->/statusCodeError.post(msg, headers, statusCode = 512);
+    test:assertEquals(response.statusCode, 512);
+    common:assertJsonPayload(check response.getJsonPayload(), msg);
+    test:assertEquals("value1", check response.getHeader("header1"));
+    test:assertEquals(["value2", "value3"], check response.getHeaders("header2"));
+}

--- a/ballerina-tests/http-advanced-tests/tests/status_code_error_use_case_test.bal
+++ b/ballerina-tests/http-advanced-tests/tests/status_code_error_use_case_test.bal
@@ -1,0 +1,176 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/time;
+import ballerina/test;
+
+// Custom Error Types
+type Error distinct error;
+
+type ErrorInfo record {|
+    string timeStamp;
+    string message;
+|};
+
+type ErrorDetails record {|
+    *http:ErrorDetail;
+    ErrorInfo body;
+|};
+
+type UserNotFoundError Error & http:NotFoundError & error<ErrorDetails>;
+
+type UserNameAlreadyExistError Error & http:ConflictError & error<ErrorDetails>;
+
+type BadUserError Error & http:BadRequestError & error<ErrorDetails>;
+
+type User record {|
+    readonly int id;
+    *UserWithoutId;
+|};
+
+type UserWithoutId record {|
+    string name;
+    int age;
+|};
+
+isolated table<User> key(id) users = table [
+    {id: 1, name: "John", age: 30},
+    {id: 2, name: "Richard", age: 25},
+    {id: 3, name: "Jane", age: 20}
+];
+
+isolated function getCurrentTimeStamp() returns string {
+    return time:utcToString(time:utcNow());
+}
+
+isolated function getUser(int id) returns User|UserNotFoundError {
+    lock {
+        if users.hasKey(id) {
+            return users.get(id).clone();
+        } else {
+            return error UserNotFoundError("User not found", body = {
+                timeStamp: getCurrentTimeStamp(),
+                message: string `User not found for id: ${id}`
+            });
+        }
+    }
+}
+
+isolated function addUser(readonly & UserWithoutId newUser) returns User|UserNameAlreadyExistError|BadUserError {
+    lock {
+        check validateUserPayload(newUser);
+        if users.filter(user => user.name == newUser.name).length() > 0 {
+            return error UserNameAlreadyExistError("User name already exists", body = {
+                timeStamp: getCurrentTimeStamp(),
+                message: string `User name: ${newUser.name} already exists`
+            });
+        } else {
+            int id = users.length() + 1;
+            User user = {id: id, ...newUser};
+            users.add(user);
+            return user.clone();
+        }
+    }
+}
+
+isolated function validateUserPayload(readonly & UserWithoutId user) returns BadUserError? {
+    string[] messages = [];
+    if user.name.length() < 2 {
+        messages.push("User name should be at least 2 characters");
+    }
+    if user.age < 18 {
+        messages.push("User should be at least 18 years");
+    }
+    if messages.length() > 0 {
+        return error BadUserError("User info is not acceptable", body = {
+            timeStamp: getCurrentTimeStamp(),
+            message: string:'join(" and ", ...messages)
+        });
+    }
+}
+
+service on new http:Listener(statusCodeErrorUseCasePort) {
+
+    resource function get users/[int id]() returns User|UserNotFoundError {
+
+        return getUser(id);
+    }
+
+    resource function post users(@http:Payload readonly & UserWithoutId user)
+            returns User|UserNameAlreadyExistError|BadUserError {
+
+        return addUser(user);
+    }
+
+    resource function 'default [string... path]() returns http:NotFoundError {
+
+        return error http:NotFoundError("Resource not found", body = {
+            timeStamp: getCurrentTimeStamp(),
+            message: string `Resource not found for path: /${string:'join("/", ...path)}`
+        });
+    }
+}
+
+final http:Client statusCodeErrorUseCaseClient = check new ("http://localhost:" + statusCodeErrorUseCasePort.toString());
+
+@test:Config {}
+function testStatusCodeErrorUseCase1() returns error? {
+    User user = check statusCodeErrorUseCaseClient->/users/["1"];
+    test:assertEquals(user, {id: 1, name: "John", age: 30});
+
+    http:Response response = check statusCodeErrorUseCaseClient->/users/["8"];
+    test:assertEquals(response.statusCode, 404);
+    json errorInfo = check response.getJsonPayload();
+    test:assertEquals(errorInfo.message, "User not found for id: 8");
+}
+
+@test:Config {}
+function testStatusCodeErrorUseCase2() returns error? {
+    User _ = check statusCodeErrorUseCaseClient->/users.post({name: "Ravi", age: 30});
+
+    http:Response response = check statusCodeErrorUseCaseClient->/users.post({name: "Ravi", age: 43});
+    test:assertEquals(response.statusCode, 409);
+    json errorInfo = check response.getJsonPayload();
+    test:assertEquals(errorInfo.message, "User name: Ravi already exists");
+}
+
+@test:Config {}
+function testStatusCodeErrorUseCase3() returns error? {
+    http:Response response = check statusCodeErrorUseCaseClient->/users.post({name: "R", age: 43});
+    test:assertEquals(response.statusCode, 400);
+    json errorInfo = check response.getJsonPayload();
+    test:assertEquals(errorInfo.message, "User name should be at least 2 characters");
+
+    response = check statusCodeErrorUseCaseClient->/users.post({name: "Ravi", age: 3});
+    test:assertEquals(response.statusCode, 400);
+    errorInfo = check response.getJsonPayload();
+    test:assertEquals(errorInfo.message, "User should be at least 18 years");
+
+    response = check statusCodeErrorUseCaseClient->/users.post({name: "R", age: 4});
+    test:assertEquals(response.statusCode, 400);
+    errorInfo = check response.getJsonPayload();
+    test:assertEquals(errorInfo.message, "User name should be at least 2 characters " +
+        "and User should be at least 18 years");
+}
+
+@test:Config {}
+function testStatusCodeErrorUseCase4() returns error? {
+    http:Response response = check statusCodeErrorUseCaseClient->/users/["1"]/greeting;
+    test:assertEquals(response.statusCode, 404);
+    json errorInfo = check response.getJsonPayload();
+    test:assertEquals(errorInfo.message, "Resource not found for path: /users/1/greeting");
+}

--- a/ballerina-tests/http-advanced-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-advanced-tests/tests/test_service_ports.bal
@@ -37,3 +37,5 @@ const int trailingHeaderTestPort2 = 9527;
 const int corsConfigTestPort = 9013;
 const int multipartRequestTestPort = 9018;
 const int serviceMediaTypeSubtypePrefixPort = 9579;
+
+const int statusCodeErrorUseCasePort = 9090;

--- a/ballerina-tests/http-advanced-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-advanced-tests/tests/test_service_ports.bal
@@ -39,3 +39,4 @@ const int multipartRequestTestPort = 9018;
 const int serviceMediaTypeSubtypePrefixPort = 9579;
 
 const int statusCodeErrorUseCasePort = 9090;
+const int statusCodeErrorPort = 9092;

--- a/ballerina-tests/http-client-tests/Dependencies.toml
+++ b/ballerina-tests/http-client-tests/Dependencies.toml
@@ -286,20 +286,21 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.6.0"
+version = "2.6.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
-	{org = "ballerina", name = "time"}
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "url"}
 ]
 
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.6"
+version = "1.0.7"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina-tests/http-interceptor-tests/Dependencies.toml
+++ b/ballerina-tests/http-interceptor-tests/Dependencies.toml
@@ -104,6 +104,7 @@ version = "2.6.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
+	{org = "ballerina", name = "jwt"},
 	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "test"}
@@ -158,6 +159,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
+]
+modules = [
+	{org = "ballerina", packageName = "jwt", moduleName = "jwt"}
 ]
 
 [[package]]
@@ -273,20 +277,21 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.6.0"
+version = "2.6.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
-	{org = "ballerina", name = "time"}
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "url"}
 ]
 
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.6"
+version = "1.0.7"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina-tests/http-interceptor-tests/tests/test_common.bal
+++ b/ballerina-tests/http-interceptor-tests/tests/test_common.bal
@@ -27,9 +27,9 @@ service class DefaultRequestInterceptor {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:RequestContext ctx, http:Request req) returns http:NextService|error? {
-       req.setHeader("default-request-interceptor", "true");
-       ctx.set("last-interceptor", "default-request-interceptor");
-       return ctx.next();
+        req.setHeader("default-request-interceptor", "true");
+        ctx.set("last-interceptor", "default-request-interceptor");
+        return ctx.next();
     }
 }
 
@@ -37,9 +37,9 @@ service class DataBindingRequestInterceptor {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:RequestContext ctx, @http:Payload string payload, @http:Header {name: "interceptor"} string header) returns http:NextService|error? {
-       ctx.set("request-payload", payload);
-       ctx.set("last-interceptor", header);
-       return ctx.next();
+        ctx.set("request-payload", payload);
+        ctx.set("last-interceptor", header);
+        return ctx.next();
     }
 }
 
@@ -47,8 +47,8 @@ service class StringPayloadBindingRequestInterceptor {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:RequestContext ctx, @http:Payload string payload) returns http:NextService|error? {
-       ctx.set("request-payload", payload);
-       return ctx.next();
+        ctx.set("request-payload", payload);
+        return ctx.next();
     }
 }
 
@@ -56,8 +56,8 @@ service class RecordPayloadBindingRequestInterceptor {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:RequestContext ctx, @http:Payload Person person) returns http:NextService|error? {
-       ctx.set("request-payload", person);
-       return ctx.next();
+        ctx.set("request-payload", person);
+        return ctx.next();
     }
 }
 
@@ -65,8 +65,8 @@ service class RecordArrayPayloadBindingRequestInterceptor {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:RequestContext ctx, @http:Payload Person[] persons) returns http:NextService|error? {
-       ctx.set("request-payload", persons.toJsonString());
-       return ctx.next();
+        ctx.set("request-payload", persons.toJsonString());
+        return ctx.next();
     }
 }
 
@@ -95,10 +95,10 @@ service class RequestInterceptorSetPayload {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:RequestContext ctx, http:Request req) returns http:NextService|error? {
-       req.setHeader("request-interceptor-setpayload", "true");
-       req.setTextPayload("Text payload from request interceptor");
-       ctx.set("last-interceptor", "request-interceptor-setpayload");
-       return ctx.next();
+        req.setHeader("request-interceptor-setpayload", "true");
+        req.setTextPayload("Text payload from request interceptor");
+        ctx.set("last-interceptor", "request-interceptor-setpayload");
+        return ctx.next();
     }
 }
 
@@ -106,7 +106,7 @@ service class RequestInterceptorCallerRespond {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:Caller caller) returns error? {
-        http:Response res = new();
+        http:Response res = new ();
         res.setHeader("request-interceptor-caller-respond", "true");
         res.setTextPayload("Response from caller inside interceptor");
         check caller->respond(res);
@@ -126,7 +126,7 @@ service class RequestInterceptorCallerRespondContinue {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:RequestContext ctx, http:Caller caller) returns http:NextService|error? {
-        http:Response res = new();
+        http:Response res = new ();
         res.setHeader("last-interceptor", "request-interceptor-caller-respond");
         res.setTextPayload("Response from caller inside interceptor");
         check caller->respond(res);
@@ -138,9 +138,9 @@ service class RequestInterceptorReturnsError {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:RequestContext ctx, http:Request req) returns error {
-       req.setHeader("request-interceptor-error", "true");
-       ctx.set("last-interceptor", "request-interceptor-error");
-       return error("Request interceptor returns an error");
+        req.setHeader("request-interceptor-error", "true");
+        ctx.set("last-interceptor", "request-interceptor-error");
+        return error("Request interceptor returns an error");
     }
 }
 
@@ -148,11 +148,11 @@ service class LastRequestInterceptor {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:RequestContext ctx, http:Request req) returns http:NextService|error? {
-       string|error val = ctx.get("last-interceptor").ensureType(string);
-       string header = val is string ? val : "last-request-interceptor";
-       req.setHeader("last-request-interceptor", "true");
-       req.setHeader("last-interceptor", header);
-       return ctx.next();
+        string|error val = ctx.get("last-interceptor").ensureType(string);
+        string header = val is string ? val : "last-request-interceptor";
+        req.setHeader("last-request-interceptor", "true");
+        req.setHeader("last-interceptor", header);
+        return ctx.next();
     }
 }
 
@@ -160,13 +160,13 @@ service class RequestInterceptorReturnsResponse {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:RequestContext ctx, @http:Payload string payload) returns http:Response {
-       http:Response res = new;
-       string|error val = ctx.get("last-interceptor").ensureType(string);
-       string header = val is string ? val : "request-interceptor-returns-response";
-       res.setHeader("request-interceptor-returns-response", "true");
-       res.setHeader("last-interceptor", header);
-       res.setTextPayload("Response from Interceptor : " + payload);
-       return res;
+        http:Response res = new;
+        string|error val = ctx.get("last-interceptor").ensureType(string);
+        string header = val is string ? val : "request-interceptor-returns-response";
+        res.setHeader("request-interceptor-returns-response", "true");
+        res.setHeader("last-interceptor", header);
+        res.setTextPayload("Response from Interceptor : " + payload);
+        return res;
     }
 }
 
@@ -174,21 +174,21 @@ service class RequestInterceptorReturnsStatusCodeResponse {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:Request req) returns http:NotFound|http:Ok {
-       boolean isHeaderPresent = req.getHeader("header") is string ? true : false;
-       if isHeaderPresent {
-           http:Ok ok = {
-               body: "Response from Request Interceptor",
-               headers: {
-                   "last-interceptor" : "request-interceptor-returns-status"
-               }
-           };
-           return ok;
-       } else {
-           http:NotFound nf = {
-               body: "Header not found in request"
-           };
-           return nf;
-       }
+        boolean isHeaderPresent = req.getHeader("header") is string ? true : false;
+        if isHeaderPresent {
+            http:Ok ok = {
+                body: "Response from Request Interceptor",
+                headers: {
+                    "last-interceptor": "request-interceptor-returns-status"
+                }
+            };
+            return ok;
+        } else {
+            http:NotFound nf = {
+                body: "Header not found in request"
+            };
+            return nf;
+        }
     }
 }
 
@@ -201,20 +201,20 @@ service class RequestInterceptorCheckHeader {
     }
 
     resource function 'default [string... path](http:RequestContext ctx, http:Request req) returns http:Response|http:NextService|error? {
-       req.setHeader("request-interceptor-check-header", "true");
-       ctx.set("last-interceptor", "request-interceptor-check-header");
-       boolean isHeaderPresent = req.getHeader(self.headerName) is string ? true : false;
-       if isHeaderPresent {
-           return ctx.next();
-       } else {
-           http:Response res = new;
-           foreach string reqHeader in req.getHeaderNames() {
-               res.setHeader(reqHeader, check req.getHeader(reqHeader));
-           }
-           res.statusCode = 404;
-           res.setTextPayload("Header : " + self.headerName + " not found");
-           return res;
-       }
+        req.setHeader("request-interceptor-check-header", "true");
+        ctx.set("last-interceptor", "request-interceptor-check-header");
+        boolean isHeaderPresent = req.getHeader(self.headerName) is string ? true : false;
+        if isHeaderPresent {
+            return ctx.next();
+        } else {
+            http:Response res = new;
+            foreach string reqHeader in req.getHeaderNames() {
+                res.setHeader(reqHeader, check req.getHeader(reqHeader));
+            }
+            res.statusCode = 404;
+            res.setTextPayload("Header : " + self.headerName + " not found");
+            return res;
+        }
     }
 }
 
@@ -222,10 +222,10 @@ service class DefaultRequestErrorInterceptor {
     *http:RequestErrorInterceptor;
 
     resource function 'default [string... path](error err, http:RequestContext ctx, http:Request req) returns http:NextService|error? {
-       req.setHeader("default-request-error-interceptor", "true");
-       req.setTextPayload(err.message());
-       ctx.set("last-interceptor", "default-request-error-interceptor");
-       return ctx.next();
+        req.setHeader("default-request-error-interceptor", "true");
+        req.setTextPayload(err.message());
+        ctx.set("last-interceptor", "default-request-error-interceptor");
+        return ctx.next();
     }
 }
 
@@ -233,7 +233,7 @@ service class RequestErrorInterceptorReturnsErrorMsg {
     *http:RequestErrorInterceptor;
 
     resource function 'default [string... path](error err) returns string {
-       return err.message();
+        return err.message();
     }
 }
 
@@ -241,9 +241,9 @@ service class RequestErrorInterceptorReturnsError {
     *http:RequestErrorInterceptor;
 
     resource function 'default [string... path](error err, http:RequestContext ctx, http:Request req) returns error {
-       req.setHeader("request-error-interceptor-error", "true");
-       ctx.set("last-interceptor", "request-error-interceptor-error");
-       return error("Request error interceptor returns an error");
+        req.setHeader("request-error-interceptor-error", "true");
+        ctx.set("last-interceptor", "request-error-interceptor-error");
+        return error("Request error interceptor returns an error");
     }
 }
 
@@ -251,8 +251,8 @@ service class RequestInterceptorWithoutCtxNext {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:RequestContext ctx, http:Request req) {
-       req.setHeader("request-interceptor-without-ctx-next", "true");
-       ctx.set("last-interceptor", "request-interceptor-without-ctx-next");
+        req.setHeader("request-interceptor-without-ctx-next", "true");
+        ctx.set("last-interceptor", "request-interceptor-without-ctx-next");
     }
 }
 
@@ -260,9 +260,9 @@ service class GetRequestInterceptor {
     *http:RequestInterceptor;
 
     resource function get [string... path](http:RequestContext ctx, http:Request req) returns http:NextService|error? {
-       req.setHeader("get-interceptor", "true");
-       ctx.set("last-interceptor", "get-interceptor");
-       return ctx.next();
+        req.setHeader("get-interceptor", "true");
+        ctx.set("last-interceptor", "get-interceptor");
+        return ctx.next();
     }
 }
 
@@ -270,9 +270,9 @@ service class GetFooRequestInterceptor {
     *http:RequestInterceptor;
 
     resource function get [string... path](http:RequestContext ctx, http:Request req) returns http:NextService|error? {
-       req.setHeader("get-foo-interceptor", "true");
-       ctx.set("last-interceptor", "get-foo-interceptor");
-       return ctx.next();
+        req.setHeader("get-foo-interceptor", "true");
+        ctx.set("last-interceptor", "get-foo-interceptor");
+        return ctx.next();
     }
 }
 
@@ -280,9 +280,9 @@ service class PostRequestInterceptor {
     *http:RequestInterceptor;
 
     resource function post [string... path](http:RequestContext ctx, http:Request req) returns http:NextService|error? {
-       req.setHeader("post-interceptor", "true");
-       ctx.set("last-interceptor", "post-interceptor");
-       return ctx.next();
+        req.setHeader("post-interceptor", "true");
+        ctx.set("last-interceptor", "post-interceptor");
+        return ctx.next();
     }
 }
 
@@ -290,9 +290,9 @@ service class DefaultRequestInterceptorBasePath {
     *http:RequestInterceptor;
 
     resource function 'default foo(http:RequestContext ctx, http:Request req) returns http:NextService|error? {
-       req.setHeader("default-base-path-interceptor", "true");
-       ctx.set("last-interceptor", "default-base-path-interceptor");
-       return ctx.next();
+        req.setHeader("default-base-path-interceptor", "true");
+        ctx.set("last-interceptor", "default-base-path-interceptor");
+        return ctx.next();
     }
 }
 
@@ -300,9 +300,9 @@ service class GetRequestInterceptorBasePath {
     *http:RequestInterceptor;
 
     resource function get bar(http:RequestContext ctx, http:Request req) returns http:NextService|error? {
-       req.setHeader("default-base-path-interceptor", "true");
-       ctx.set("last-interceptor", "get-base-path-interceptor");
-       return ctx.next();
+        req.setHeader("default-base-path-interceptor", "true");
+        ctx.set("last-interceptor", "get-base-path-interceptor");
+        return ctx.next();
     }
 }
 
@@ -310,13 +310,13 @@ service class RequestInterceptorSkip {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:RequestContext ctx, http:Request req) returns http:NextService|error? {
-       req.setHeader("skip-interceptor", "true");
-       ctx.set("last-interceptor", "skip-interceptor");
-       http:NextService|error? nextService = ctx.next();
-       if (nextService is error) {
-           return nextService;
-       }
-       return ctx.next();
+        req.setHeader("skip-interceptor", "true");
+        ctx.set("last-interceptor", "skip-interceptor");
+        http:NextService|error? nextService = ctx.next();
+        if (nextService is error) {
+            return nextService;
+        }
+        return ctx.next();
     }
 }
 
@@ -324,12 +324,12 @@ service class RequestInterceptorCtxNext {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:RequestContext ctx, http:Request req) returns error? {
-       req.setHeader("request-interceptor-ctx-next", "true");
-       ctx.set("last-interceptor", "request-interceptor-ctx-next");
-       http:NextService|error? nextService = ctx.next();
-       if (nextService is error) {
-           return nextService;
-       }
+        req.setHeader("request-interceptor-ctx-next", "true");
+        ctx.set("last-interceptor", "request-interceptor-ctx-next");
+        http:NextService|error? nextService = ctx.next();
+        if (nextService is error) {
+            return nextService;
+        }
     }
 }
 
@@ -337,11 +337,11 @@ service class RequestInterceptorWithQueryParam {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](string q1, int q2, http:RequestContext ctx, http:Request req) returns http:NextService|error? {
-       req.setHeader("request-interceptor-query-param", "true");
-       req.setHeader("q1", q1);
-       req.setHeader("q2", q2.toString());
-       ctx.set("last-interceptor", "request-interceptor-query-param");
-       return ctx.next();
+        req.setHeader("request-interceptor-query-param", "true");
+        req.setHeader("q1", q1);
+        req.setHeader("q2", q2.toString());
+        ctx.set("last-interceptor", "request-interceptor-query-param");
+        return ctx.next();
     }
 }
 
@@ -358,9 +358,9 @@ service class RequestInterceptorWithVariable {
     }
 
     resource function 'default [string... path](http:RequestContext ctx, http:Request req) returns http:NextService|error? {
-       req.setHeader(self.getName(), "true");
-       ctx.set("last-interceptor", self.getName());
-       return ctx.next();
+        req.setHeader(self.getName(), "true");
+        ctx.set("last-interceptor", self.getName());
+        return ctx.next();
     }
 }
 
@@ -378,10 +378,10 @@ service class RequestInterceptorNegative1 {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:Request req) returns http:NextService|error? {
-       req.setHeader("request-interceptor-negative1", "true");
-       http:RequestContext ctx = new();
-       ctx.set("last-interceptor", "request-interceptor-negative1");
-       return ctx.next();
+        req.setHeader("request-interceptor-negative1", "true");
+        http:RequestContext ctx = new ();
+        ctx.set("last-interceptor", "request-interceptor-negative1");
+        return ctx.next();
     }
 }
 
@@ -389,8 +389,8 @@ service class RequestInterceptorNegative2 {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:Request req) returns http:RequestInterceptor {
-       req.setHeader("request-interceptor-negative2", "true");
-       return new DefaultRequestInterceptor();
+        req.setHeader("request-interceptor-negative2", "true");
+        return new DefaultRequestInterceptor();
     }
 }
 
@@ -398,12 +398,12 @@ service class RequestInterceptorNegative3 {
     *http:RequestInterceptor;
 
     resource function 'default [string... path](http:Request req, http:RequestContext ctx) returns http:NextService|error? {
-       req.setHeader("request-interceptor-negative3", "true");
-       http:NextService|error? nextService = ctx.next();
-       if nextService is error {
-          return nextService;
-       }
-       return new DefaultRequestInterceptor();
+        req.setHeader("request-interceptor-negative3", "true");
+        http:NextService|error? nextService = ctx.next();
+        if nextService is error {
+            return nextService;
+        }
+        return new DefaultRequestInterceptor();
     }
 }
 
@@ -435,9 +435,9 @@ service class DefaultResponseInterceptor {
     *http:ResponseInterceptor;
 
     remote function interceptResponse(http:RequestContext ctx, http:Response res) returns http:NextService|error? {
-       res.setHeader("default-response-interceptor", "true");
-       ctx.set("last-interceptor", "default-response-interceptor");
-       return ctx.next();
+        res.setHeader("default-response-interceptor", "true");
+        ctx.set("last-interceptor", "default-response-interceptor");
+        return ctx.next();
     }
 }
 
@@ -445,10 +445,10 @@ service class ResponseInterceptorSetPayload {
     *http:ResponseInterceptor;
 
     remote function interceptResponse(http:RequestContext ctx, http:Response res) returns http:NextService|error? {
-       res.setHeader("response-interceptor-setpayload", "true");
-       res.setTextPayload("Text payload from response interceptor");
-       ctx.set("last-interceptor", "response-interceptor-setpayload");
-       return ctx.next();
+        res.setHeader("response-interceptor-setpayload", "true");
+        res.setTextPayload("Text payload from response interceptor");
+        ctx.set("last-interceptor", "response-interceptor-setpayload");
+        return ctx.next();
     }
 }
 
@@ -456,9 +456,9 @@ service class ResponseInterceptorWithoutCtxNext {
     *http:ResponseInterceptor;
 
     remote function interceptResponse(http:Response res) {
-       res.setHeader("response-interceptor-without-ctx-next", "true");
-       res.setHeader("last-interceptor", "response-interceptor-without-ctx-next");
-       res.setTextPayload("Response from response interceptor");
+        res.setHeader("response-interceptor-without-ctx-next", "true");
+        res.setHeader("last-interceptor", "response-interceptor-without-ctx-next");
+        res.setTextPayload("Response from response interceptor");
     }
 }
 
@@ -496,9 +496,9 @@ service class ResponseInterceptorReturnsError {
     *http:ResponseInterceptor;
 
     remote function interceptResponse(http:RequestContext ctx, http:Response res) returns error {
-       res.setHeader("response-interceptor-error", "true");
-       ctx.set("last-interceptor", "response-interceptor-error");
-       return error("Response interceptor returns an error");
+        res.setHeader("response-interceptor-error", "true");
+        ctx.set("last-interceptor", "response-interceptor-error");
+        return error("Response interceptor returns an error");
     }
 }
 
@@ -506,13 +506,13 @@ service class ResponseInterceptorSkip {
     *http:ResponseInterceptor;
 
     remote function interceptResponse(http:RequestContext ctx, http:Response res) returns http:NextService|error? {
-       res.setHeader("skip-interceptor", "true");
-       ctx.set("last-interceptor", "skip-interceptor");
-       http:NextService|error? nextService = ctx.next();
-       if nextService is error {
-           return nextService;
-       }
-       return ctx.next();
+        res.setHeader("skip-interceptor", "true");
+        ctx.set("last-interceptor", "skip-interceptor");
+        http:NextService|error? nextService = ctx.next();
+        if nextService is error {
+            return nextService;
+        }
+        return ctx.next();
     }
 }
 
@@ -529,9 +529,9 @@ service class ResponseInterceptorWithVariable {
     }
 
     remote function interceptResponse(http:RequestContext ctx, http:Response res) returns http:NextService|error? {
-       res.setHeader(self.getName(), "true");
-       ctx.set("last-interceptor", self.getName());
-       return ctx.next();
+        res.setHeader(self.getName(), "true");
+        ctx.set("last-interceptor", self.getName());
+        return ctx.next();
     }
 }
 
@@ -539,15 +539,15 @@ service class LastResponseInterceptor {
     *http:ResponseInterceptor;
 
     remote function interceptResponse(http:RequestContext ctx, http:Response res) returns http:NextService|error? {
-       string|error val = trap ctx.get("last-interceptor").ensureType(string);
-       string header = val is string ? val : "last-response-interceptor";
-       res.setHeader("last-response-interceptor", "true");
-       res.setHeader("last-interceptor", header);
-       val = trap ctx.get("error-type").ensureType(string);
-       if val is string {
-           res.setHeader("error-type", val);
-       }
-       return ctx.next();
+        string|error val = trap ctx.get("last-interceptor").ensureType(string);
+        string header = val is string ? val : "last-response-interceptor";
+        res.setHeader("last-response-interceptor", "true");
+        res.setHeader("last-interceptor", header);
+        val = trap ctx.get("error-type").ensureType(string);
+        if val is string {
+            res.setHeader("error-type", val);
+        }
+        return ctx.next();
     }
 }
 
@@ -555,12 +555,12 @@ service class ResponseInterceptorReturnsResponse {
     *http:ResponseInterceptor;
 
     remote function interceptResponse(http:RequestContext ctx, http:Response res) returns http:Response {
-       res.setHeader("response-interceptor-returns-response", "true");
-       ctx.set("last-interceptor", "response-interceptor-returns-response");
-       string|error payloadVal = res.getTextPayload();
-       string payload = payloadVal is string ? payloadVal : "";
-       res.setTextPayload("Response from Interceptor : " + payload);
-       return res;
+        res.setHeader("response-interceptor-returns-response", "true");
+        ctx.set("last-interceptor", "response-interceptor-returns-response");
+        string|error payloadVal = res.getTextPayload();
+        string payload = payloadVal is string ? payloadVal : "";
+        res.setTextPayload("Response from Interceptor : " + payload);
+        return res;
     }
 }
 
@@ -568,21 +568,21 @@ service class ResponseInterceptorReturnsStatusCodeResponse {
     *http:ResponseInterceptor;
 
     remote function interceptResponse(http:Response res) returns http:NotFound|http:Ok {
-       boolean isHeaderPresent = res.getHeader("header") is string ? true : false;
-       if isHeaderPresent {
-           http:Ok ok = {
-               body: "Response from Response Interceptor",
-               headers: {
-                   "last-interceptor" : "response-interceptor-returns-status"
-               }
-           };
-           return ok;
-       } else {
-           http:NotFound nf = {
-               body: "Header not found in response"
-           };
-           return nf;
-       }
+        boolean isHeaderPresent = res.getHeader("header") is string ? true : false;
+        if isHeaderPresent {
+            http:Ok ok = {
+                body: "Response from Response Interceptor",
+                headers: {
+                    "last-interceptor": "response-interceptor-returns-status"
+                }
+            };
+            return ok;
+        } else {
+            http:NotFound nf = {
+                body: "Header not found in response"
+            };
+            return nf;
+        }
     }
 }
 
@@ -590,11 +590,11 @@ service class DefaultResponseErrorInterceptor {
     *http:ResponseErrorInterceptor;
 
     remote function interceptResponseError(error err, http:RequestContext ctx, http:Response res) returns http:NextService|error? {
-       res.setHeader("default-response-error-interceptor", "true");
-       res.setTextPayload(err.message());
-       ctx.set("last-interceptor", "default-response-error-interceptor");
-       ctx.set("error-type", getErrorType(err));
-       return ctx.next();
+        res.setHeader("default-response-error-interceptor", "true");
+        res.setTextPayload(err.message());
+        ctx.set("last-interceptor", "default-response-error-interceptor");
+        ctx.set("error-type", getErrorType(err));
+        return ctx.next();
     }
 }
 
@@ -646,7 +646,7 @@ service class ResponseInterceptorNegative1 {
     *http:ResponseInterceptor;
 
     remote function interceptResponse(http:Response res) returns http:ResponseInterceptor {
-       return new DefaultResponseInterceptor();
+        return new DefaultResponseInterceptor();
     }
 }
 

--- a/ballerina-tests/http-misc-tests/Dependencies.toml
+++ b/ballerina-tests/http-misc-tests/Dependencies.toml
@@ -286,20 +286,21 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.6.0"
+version = "2.6.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
-	{org = "ballerina", name = "time"}
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "url"}
 ]
 
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.6"
+version = "1.0.7"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina-tests/http-misc-tests/tests/http_status_code_test.bal
+++ b/ballerina-tests/http-misc-tests/tests/http_status_code_test.bal
@@ -156,11 +156,11 @@ service /differentStatusCodes on httpStatusCodeListenerEP {
         return {body: "It's PreconditionRequired"};
     }
 
-    resource function get statusUnavailableForLegalReasons/[boolean constReq]() returns http:UnavailableForLegalReasons {
+    resource function get statusUnavailableDueToLegalReasons/[boolean constReq]() returns http:UnavailableDueToLegalReasons {
         if constReq {
             return http:UNAVAILABLE_DUE_TO_LEGAL_REASONS;
         }
-        return {body: "It's UnavailableForLegalReasons"};
+        return {body: "It's UnavailableDueToLegalReasons"};
     }
 
     resource function get statusVariantAlsoNegotiates/[boolean constReq]() returns http:VariantAlsoNegotiates {
@@ -191,7 +191,7 @@ service /differentStatusCodes on httpStatusCodeListenerEP {
         return {body: "It's NotExtended"};
     }
 
-    resource function get NetworkAuthenticationRequired/[boolean constReq]() returns http:NetworkAuthenticationRequired {
+    resource function get networkAuthorizationRequired/[boolean constReq]() returns http:NetworkAuthorizationRequired {
         if constReq {
             return http:NETWORK_AUTHORIZATION_REQUIRED;
         }
@@ -664,17 +664,17 @@ function testStatusPreconditionRequired() {
 }
 
 @test:Config {}
-function testStatusUnavailableForLegalReasons() {
-    http:Response|error response = httpStatusCodeClient->get("/differentStatusCodes/statusUnavailableForLegalReasons/false");
+function testStatusUnavailableDueToLegalReasons() {
+    http:Response|error response = httpStatusCodeClient->get("/differentStatusCodes/statusUnavailableDueToLegalReasons/false");
     if response is http:Response {
         test:assertEquals(response.statusCode, 451, msg = "Found unexpected output");
         test:assertEquals(response.reasonPhrase, "Client Error (451)", msg = "Found unexpected output");
-        common:assertTextPayload(response.getTextPayload(), "It's UnavailableForLegalReasons");
+        common:assertTextPayload(response.getTextPayload(), "It's UnavailableDueToLegalReasons");
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }
 
-    response = httpStatusCodeClient->get("/differentStatusCodes/statusUnavailableForLegalReasons/true");
+    response = httpStatusCodeClient->get("/differentStatusCodes/statusUnavailableDueToLegalReasons/true");
     if response is http:Response {
         test:assertEquals(response.statusCode, 451, msg = "Found unexpected output");
         test:assertEquals(response.reasonPhrase, "Client Error (451)", msg = "Found unexpected output");
@@ -764,8 +764,8 @@ function testStatusNotExtended() {
 }
 
 @test:Config {}
-function testNetworkAuthenticationRequired() {
-    http:Response|error response = httpStatusCodeClient->get("/differentStatusCodes/NetworkAuthenticationRequired/false");
+function testNetworkAuthorizationRequired() {
+    http:Response|error response = httpStatusCodeClient->get("/differentStatusCodes/networkAuthorizationRequired/false");
     if response is http:Response {
         test:assertEquals(response.statusCode, 511, msg = "Found unexpected output");
         test:assertEquals(response.reasonPhrase, "Network Authentication Required", msg = "Found unexpected output");
@@ -774,7 +774,7 @@ function testNetworkAuthenticationRequired() {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }
 
-    response = httpStatusCodeClient->get("/differentStatusCodes/NetworkAuthenticationRequired/true");
+    response = httpStatusCodeClient->get("/differentStatusCodes/networkAuthorizationRequired/true");
     if response is http:Response {
         test:assertEquals(response.statusCode, 511, msg = "Found unexpected output");
         test:assertEquals(response.reasonPhrase, "Network Authentication Required", msg = "Found unexpected output");

--- a/ballerina-tests/http-misc-tests/tests/http_status_code_test.bal
+++ b/ballerina-tests/http-misc-tests/tests/http_status_code_test.bal
@@ -156,11 +156,11 @@ service /differentStatusCodes on httpStatusCodeListenerEP {
         return {body: "It's PreconditionRequired"};
     }
 
-    resource function get statusUnavailableDueToLegalReasons/[boolean constReq]() returns http:UnavailableDueToLegalReasons {
+    resource function get statusUnavailableForLegalReasons/[boolean constReq]() returns http:UnavailableForLegalReasons {
         if constReq {
             return http:UNAVAILABLE_DUE_TO_LEGAL_REASONS;
         }
-        return {body: "It's UnavailableDueToLegalReasons"};
+        return {body: "It's UnavailableForLegalReasons"};
     }
 
     resource function get statusVariantAlsoNegotiates/[boolean constReq]() returns http:VariantAlsoNegotiates {
@@ -191,7 +191,7 @@ service /differentStatusCodes on httpStatusCodeListenerEP {
         return {body: "It's NotExtended"};
     }
 
-    resource function get networkAuthorizationRequired/[boolean constReq]() returns http:NetworkAuthorizationRequired {
+    resource function get NetworkAuthenticationRequired/[boolean constReq]() returns http:NetworkAuthenticationRequired {
         if constReq {
             return http:NETWORK_AUTHORIZATION_REQUIRED;
         }
@@ -664,17 +664,17 @@ function testStatusPreconditionRequired() {
 }
 
 @test:Config {}
-function testStatusUnavailableDueToLegalReasons() {
-    http:Response|error response = httpStatusCodeClient->get("/differentStatusCodes/statusUnavailableDueToLegalReasons/false");
+function testStatusUnavailableForLegalReasons() {
+    http:Response|error response = httpStatusCodeClient->get("/differentStatusCodes/statusUnavailableForLegalReasons/false");
     if response is http:Response {
         test:assertEquals(response.statusCode, 451, msg = "Found unexpected output");
         test:assertEquals(response.reasonPhrase, "Client Error (451)", msg = "Found unexpected output");
-        common:assertTextPayload(response.getTextPayload(), "It's UnavailableDueToLegalReasons");
+        common:assertTextPayload(response.getTextPayload(), "It's UnavailableForLegalReasons");
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }
 
-    response = httpStatusCodeClient->get("/differentStatusCodes/statusUnavailableDueToLegalReasons/true");
+    response = httpStatusCodeClient->get("/differentStatusCodes/statusUnavailableForLegalReasons/true");
     if response is http:Response {
         test:assertEquals(response.statusCode, 451, msg = "Found unexpected output");
         test:assertEquals(response.reasonPhrase, "Client Error (451)", msg = "Found unexpected output");
@@ -764,8 +764,8 @@ function testStatusNotExtended() {
 }
 
 @test:Config {}
-function testNetworkAuthorizationRequired() {
-    http:Response|error response = httpStatusCodeClient->get("/differentStatusCodes/networkAuthorizationRequired/false");
+function testNetworkAuthenticationRequired() {
+    http:Response|error response = httpStatusCodeClient->get("/differentStatusCodes/NetworkAuthenticationRequired/false");
     if response is http:Response {
         test:assertEquals(response.statusCode, 511, msg = "Found unexpected output");
         test:assertEquals(response.reasonPhrase, "Network Authentication Required", msg = "Found unexpected output");
@@ -774,7 +774,7 @@ function testNetworkAuthorizationRequired() {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }
 
-    response = httpStatusCodeClient->get("/differentStatusCodes/networkAuthorizationRequired/true");
+    response = httpStatusCodeClient->get("/differentStatusCodes/NetworkAuthenticationRequired/true");
     if response is http:Response {
         test:assertEquals(response.statusCode, 511, msg = "Found unexpected output");
         test:assertEquals(response.reasonPhrase, "Network Authentication Required", msg = "Found unexpected output");

--- a/ballerina-tests/http-resiliency-tests/Dependencies.toml
+++ b/ballerina-tests/http-resiliency-tests/Dependencies.toml
@@ -281,20 +281,21 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.6.0"
+version = "2.6.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
-	{org = "ballerina", name = "time"}
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "url"}
 ]
 
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.6"
+version = "1.0.7"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina-tests/http-security-tests/Dependencies.toml
+++ b/ballerina-tests/http-security-tests/Dependencies.toml
@@ -108,7 +108,6 @@ dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jwt"},
 	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "oauth2"},
@@ -144,9 +143,6 @@ scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
-]
-modules = [
-	{org = "ballerina", packageName = "io", moduleName = "io"}
 ]
 
 [[package]]

--- a/ballerina-tests/http-service-tests/Dependencies.toml
+++ b/ballerina-tests/http-service-tests/Dependencies.toml
@@ -286,20 +286,21 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.6.0"
+version = "2.6.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
-	{org = "ballerina", name = "time"}
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "url"}
 ]
 
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.6"
+version = "1.0.7"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina-tests/http2-tests/Dependencies.toml
+++ b/ballerina-tests/http2-tests/Dependencies.toml
@@ -286,20 +286,21 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.6.0"
+version = "2.6.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
-	{org = "ballerina", name = "time"}
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "url"}
 ]
 
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.6"
+version = "1.0.7"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina/auth_desugar.bal
+++ b/ballerina/auth_desugar.bal
@@ -42,12 +42,12 @@ public isolated function authenticateResource(Service serviceRef, string methodN
     if header is string {
         Unauthorized|Forbidden? result = tryAuthenticate(<ListenerAuthConfig[]>authConfig, header);
         if result is Unauthorized {
-            panic error InternalListenerAuthnError("");
+            panic error ListenerAuthnError("");
         } else if result is Forbidden {
-            panic error InternalListenerAuthzError("");
+            panic error ListenerAuthzError("");
         }
     } else {
-        panic error InternalListenerAuthnError("");
+        panic error ListenerAuthnError("");
     }
 }
 

--- a/ballerina/http_connection.bal
+++ b/ballerina/http_connection.bal
@@ -191,7 +191,7 @@ public isolated client class Caller {
         return nativeRespond(self, response);
     }
 
-    private isolated function returnErrorResponse(error errorResponse, string? returnMediaType = (), int? statusCode = ()) returns ListenerError? {
+    private isolated function returnErrorResponse(error errorResponse, string? returnMediaType = ()) returns ListenerError? {
         Response response = new;
         if errorResponse is ApplicationResponseError {
             InternalServerError err = {
@@ -200,13 +200,12 @@ public isolated client class Caller {
             };
             response = createStatusCodeResponse(err, returnMediaType);
             response.statusCode = errorResponse.detail().statusCode;
-        } else {
-            response.statusCode = statusCode is () ? STATUS_INTERNAL_SERVER_ERROR : statusCode;
-            response.setTextPayload(errorResponse.message());
-        }
-        if errorResponse is StatusCodeError {
+        } else if errorResponse is StatusCodeError {
             response = createStatusCodeResponse(getResponseFromStatusCodeError(errorResponse), returnMediaType);
-        }
+        } else {
+            response.statusCode = STATUS_INTERNAL_SERVER_ERROR;
+            response.setTextPayload(errorResponse.message());
+        } 
         return nativeRespondError(self, response, errorResponse);
     }
 }

--- a/ballerina/http_connection.bal
+++ b/ballerina/http_connection.bal
@@ -193,15 +193,8 @@ public isolated client class Caller {
 
     private isolated function returnErrorResponse(error errorResponse, string? returnMediaType = ()) returns ListenerError? {
         Response response = new;
-        if errorResponse is ApplicationResponseError {
-            InternalServerError err = {
-                headers: errorResponse.detail().headers,
-                body: errorResponse.detail().body
-            };
-            response = createStatusCodeResponse(err, returnMediaType);
-            response.statusCode = errorResponse.detail().statusCode;
-        } else if errorResponse is StatusCodeError {
-            response = createStatusCodeResponse(getResponseFromStatusCodeError(errorResponse), returnMediaType);
+        if errorResponse is StatusCodeError {
+            response = getErrorResponse(errorResponse, returnMediaType);
         } else {
             response.statusCode = STATUS_INTERNAL_SERVER_ERROR;
             response.setTextPayload(errorResponse.message());

--- a/ballerina/http_connection.bal
+++ b/ballerina/http_connection.bal
@@ -204,6 +204,9 @@ public isolated client class Caller {
             response.statusCode = statusCode is () ? STATUS_INTERNAL_SERVER_ERROR : statusCode;
             response.setTextPayload(errorResponse.message());
         }
+        if errorResponse is StatusCodeError {
+            response = createStatusCodeResponse(getResponseFromStatusCodeError(errorResponse), returnMediaType);
+        }
         return nativeRespondError(self, response, errorResponse);
     }
 }

--- a/ballerina/http_errors.bal
+++ b/ballerina/http_errors.bal
@@ -60,30 +60,30 @@ public type OutboundResponseError distinct ListenerError;
 public type GenericListenerError distinct ListenerError;
 
 # Represents an error, which occurred due to a failure in interceptor return.
-public type InterceptorReturnError distinct ListenerError;
+public type InterceptorReturnError distinct ListenerError & ServerError;
 
 # Represents an error, which occurred due to a header binding.
-public type HeaderBindingError distinct ListenerError;
+public type HeaderBindingError distinct ListenerError & BadRequestError;
 
 # Represents an error, which occurred due to the absence of the payload.
 public type NoContentError distinct ClientError;
 
 type PayloadBindingClientError ClientError & PayloadBindingError; 
 
-type PayloadBindingListenerError ListenerError & PayloadBindingError;
+type PayloadBindingListenerError distinct ListenerError & PayloadBindingError & BadRequestError;
 
 # Represents an error, which occurred due to payload constraint validation.
 public type PayloadValidationError distinct PayloadBindingError;
 
 type PayloadValidationClientError ClientError & PayloadValidationError;
 
-type PayloadValidationListenerError ListenerError & PayloadValidationError;
+type PayloadValidationListenerError distinct ListenerError & PayloadValidationError & BadRequestError;
 
 # Represents an error, which occurred due to a query parameter binding.
-public type QueryParameterBindingError distinct ListenerError;
+public type QueryParameterBindingError distinct ListenerError & BadRequestError;
 
 # Represents an error, which occurred due to a path parameter binding.
-public type PathParameterBindingError distinct ListenerError;
+public type PathParameterBindingError distinct ListenerError & BadRequestError;
 
 # Represents an error, which occurred during the request dispatching.
 public type RequestDispatchingError distinct ListenerError;
@@ -98,16 +98,10 @@ public type ResourceDispatchingError distinct RequestDispatchingError;
 public type ListenerAuthError distinct ListenerError;
 
 # Defines the authentication error types that returned from listener.
-public type ListenerAuthnError distinct ListenerAuthError;
+public type ListenerAuthnError distinct UnauthorizedError & ListenerAuthError;
 
 # Defines the authorization error types that returned from listener.
-public type ListenerAuthzError distinct ListenerAuthError;
-
-# Defined for internal use when panicing from the auth_desugar
-type InternalListenerAuthnError distinct ListenerAuthError;
-
-# Defined for internal use when panicing from the auth_desugar
-type InternalListenerAuthzError distinct ListenerAuthError;
+public type ListenerAuthzError distinct ForbiddenError & ListenerAuthError;
 
 # Defines the client error types that returned while sending outbound request.
 public type OutboundRequestError distinct ClientError;

--- a/ballerina/http_interceptors.bal
+++ b/ballerina/http_interceptors.bal
@@ -44,33 +44,7 @@ public type Interceptor RequestInterceptor|ResponseInterceptor|RequestErrorInter
 service class DefaultErrorInterceptor {
     *ResponseErrorInterceptor;
 
-    remote function interceptResponseError(error err) returns StatusCodeResponse|Response {
-        if err is StatusCodeError {
-            return getResponseFromStatusCodeError(err);
-        } else if err is ApplicationResponseError {
-            InternalServerError errorResponse = {
-                headers: err.detail().headers,
-                body: err.detail().body
-            };
-            Response response = createStatusCodeResponse(errorResponse);
-            response.statusCode = err.detail().statusCode;
-            return response;
-        } else {
-            return <InternalServerError> {body: err.message()};
-        }
+    remote function interceptResponseError(error err) returns Response {
+        return getErrorResponse(err);
     }
-}
-
-isolated function getResponseFromStatusCodeError(StatusCodeError err) returns StatusCodeResponse {
-    StatusCodeResponse response = getErrorStatusCodeResponse(err);
-    if response !is NoContent {
-        // TODO: Change after this fix: https://github.com/ballerina-platform/ballerina-lang/issues/39669
-        // response.body = err.detail()?.body ?: err.message();
-        response.body = err.detail()?.body is () ? err.message() : err.detail()?.body;
-    }
-    map<string>? headers = err.detail().headers;
-    if headers !is () {
-        response.headers = headers;
-    }
-    return response;
 }

--- a/ballerina/http_interceptors.bal
+++ b/ballerina/http_interceptors.bal
@@ -44,10 +44,24 @@ public type Interceptor RequestInterceptor|ResponseInterceptor|RequestErrorInter
 service class DefaultErrorInterceptor {
     *ResponseErrorInterceptor;
 
-    remote function interceptResponseError(error err, Response alreadyBuiltErrorResponse) returns Response {
-        // Returning the already built response for simplicity. This has been built with proper 
-        // status code and headers (for `ApplicationResponseError` types)
-        // For any other custom responses the `err` object can be used with type check
-        return alreadyBuiltErrorResponse;
+    remote function interceptResponseError(error err) returns StatusCodeResponse {
+        if err is StatusCodeError {
+            return getResponseFromStatusCodeError(err);
+        }
+        return <InternalServerError> {body: err.message()};
     }
+}
+
+isolated function getResponseFromStatusCodeError(StatusCodeError err) returns StatusCodeResponse {
+    StatusCodeResponse response = getErrorStatusCodeResponse(err);
+    if response !is NoContent {
+        // TODO: Change after this fix: https://github.com/ballerina-platform/ballerina-lang/issues/39669
+        // response.body = err.detail()?.body ?: err.message();
+        response.body = err.detail()?.body is () ? err.message() : err.detail()?.body;
+    }
+    map<string>? headers = err.detail().headers;
+    if headers !is () {
+        response.headers = headers;
+    }
+    return response;
 }

--- a/ballerina/http_status_code_errors.bal
+++ b/ballerina/http_status_code_errors.bal
@@ -15,12 +15,20 @@
 // under the License.
 
 # Represents the details of an HTTP error.
-# 
+#
 # + headers - The error response headers
 # + body - The error response body
 public type ErrorDetail record {
-    map<string> headers?;
+    map<string|string[]> headers?;
     anydata body?;
+};
+
+# Represents the details of an HTTP error.
+# 
+# + statusCode - The inbound error response status code
+public type DefaultErrorDetail record {
+    *ErrorDetail;
+    int statusCode?;
 };
 
 # Represents the HTTP status code error.
@@ -28,183 +36,274 @@ public type StatusCodeError distinct error<ErrorDetail>;
 
 # Represents 4XX HTTP status code errors.
 public type '4XXStatusCodeError distinct StatusCodeError;
+
 # Represents 5XX HTTP status code errors.
 public type '5XXStatusCodeError distinct StatusCodeError;
+
 # Represents the default HTTP status code error.
-public type DefaultStatusCodeError distinct StatusCodeError;
+public type DefaultStatusCodeError distinct StatusCodeError & error<DefaultErrorDetail>;
 
 # Represents the HTTP 400 Bad Request error.
 public type BadRequestError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 401 Unauthorized error.
 public type UnauthorizedError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 402 Payment Required error.
 public type PaymentRequiredError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 403 Forbidden error.
 public type ForbiddenError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 404 Not Found error.
 public type NotFoundError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 405 Method Not Allowed error.
 public type MethodNotAllowedError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 406 Not Acceptable error.
 public type NotAcceptableError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 407 Proxy Authentication Required error.
 public type ProxyAuthenticationRequiredError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 408 Request Timeout error.
 public type RequestTimeoutError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 409 Conflict error.
 public type ConflictError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 410 Gone error.
 public type GoneError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 411 Length Required error.
 public type LengthRequiredError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 412 Precondition Failed error.
 public type PreconditionFailedError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 413 Payload Too Large error.
 public type PayloadTooLargeError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 414 URI Too Long error.
 public type URITooLongError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 415 Unsupported Media Type error.
 public type UnsupportedMediaTypeError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 416 Range Not Satisfiable error.
 public type RangeNotSatisfiableError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 417 Expectation Failed error.
 public type ExpectationFailedError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 421 Misdirected Request error.
 public type MisdirectedRequestError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 422 Unprocessable Entity error.
 public type UnprocessableEntityError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 423 Locked error.
 public type LockedError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 424 Failed Dependency error.
 public type FailedDependencyError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 426 Upgrade Required error.
 public type UpgradeRequiredError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 428 Precondition Required error.
 public type PreconditionRequiredError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 429 Too Many Requests error.
 public type TooManyRequestsError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 431 Request Header Fields Too Large error.
 public type RequestHeaderFieldsTooLargeError distinct '4XXStatusCodeError;
+
 # Represents the HTTP 451 Unavailable For Legal Reasons error.
 public type UnavailableForLegalReasonsError distinct '4XXStatusCodeError;
 
 # Represents the HTTP 500 Internal Server Error error.
 public type ServerError distinct '5XXStatusCodeError;
+
 # Represents the HTTP 501 Not Implemented error.
 public type NotImplementedError distinct '5XXStatusCodeError;
+
 # Represents the HTTP 502 Bad Gateway error.
 public type BadGatewayError distinct '5XXStatusCodeError;
+
 # Represents the HTTP 503 Service Unavailable error.
 public type ServiceUnavailableError distinct '5XXStatusCodeError;
+
 # Represents the HTTP 504 Gateway Timeout error.
 public type GatewayTimeoutError distinct '5XXStatusCodeError;
+
 # Represents the HTTP 505 HTTP Version Not Supported error.
 public type HTTPVersionNotSupportedError distinct '5XXStatusCodeError;
+
 # Represents the HTTP 506 Variant Also Negotiates error.
 public type VariantAlsoNegotiatesError distinct '5XXStatusCodeError;
+
 # Represents the HTTP 507 Insufficient Storage error.
 public type InsufficientStorageError distinct '5XXStatusCodeError;
+
 # Represents the HTTP 508 Loop Detected error.
 public type LoopDetectedError distinct '5XXStatusCodeError;
+
 # Represents the HTTP 510 Not Extended error.
 public type NotExtendedError distinct '5XXStatusCodeError;
+
 # Represents the HTTP 511 Network Authentication Required error.
 public type NetworkAuthenticationRequiredError distinct '5XXStatusCodeError;
 
 
 # Represents Service Not Found error.
 public type ServiceNotFoundError NotFoundError & ServiceDispatchingError;
+
 # Represents Bad Matrix Parameter in the request error.
 public type BadMatrixParamError BadRequestError & ServiceDispatchingError;
 
 # Represents an error, which occurred when the resource is not found during dispatching.
 public type ResourceNotFoundError NotFoundError & ResourceDispatchingError;
+
 # Represents an error, which occurred when the resource method is not allowed during dispatching.
 public type ResourceMethodNotAllowedError MethodNotAllowedError & ResourceDispatchingError;
+
 # Represents an error, which occurred when the media type is not supported during dispatching.
 public type UnsupportedRequestMediaTypeError UnsupportedMediaTypeError & ResourceDispatchingError;
+
 # Represents an error, which occurred when the payload is not acceptable during dispatching.
 public type RequestNotAcceptableError NotAcceptableError & ResourceDispatchingError;
+
 # Represents other internal server errors during dispatching.
 public type ResourceDispatchingServerError ServerError & ResourceDispatchingError;
 
-isolated function getErrorStatusCodeResponse(StatusCodeError err) returns StatusCodeResponse {
-    if err is BadRequestError {
-        return <BadRequest>{};
-    } else if err is UnauthorizedError {
-        return <Unauthorized>{};
-    } else if err is PaymentRequiredError {
-        return <PaymentRequired>{};
-    } else if err is ForbiddenError {
-        return <Forbidden>{};
-    } else if err is NotFoundError {
-        return <NotFound>{};
-    } else if err is MethodNotAllowedError {
-        return <MethodNotAllowed>{};
-    } else if err is NotAcceptableError {
-        return <NotAcceptable>{};
-    } else if err is ProxyAuthenticationRequiredError {
-        return <ProxyAuthenticationRequired>{};
-    } else if err is RequestTimeoutError {
-        return <RequestTimeout>{};
-    } else if err is ConflictError {
-        return <Conflict>{};
-    } else if err is GoneError {
-        return <Gone>{};
-    } else if err is LengthRequiredError {
-        return <LengthRequired>{};
-    } else if err is PreconditionFailedError {
-        return <PreconditionFailed>{};
-    } else if err is PayloadTooLargeError {
-        return <PayloadTooLarge>{};
-    } else if err is URITooLongError {
-        return <UriTooLong>{};
-    } else if err is UnsupportedMediaTypeError {
-        return <UnsupportedMediaType>{};
-    } else if err is RangeNotSatisfiableError {
-        return <RangeNotSatisfiable>{};
-    } else if err is ExpectationFailedError {
-        return <ExpectationFailed>{};
-    } else if err is MisdirectedRequestError {
-        return <MisdirectedRequest>{};
-    } else if err is UnprocessableEntityError {
-        return <UnprocessableEntity>{};
-    } else if err is LockedError {
-        return <Locked>{};
-    } else if err is FailedDependencyError {
-        return <FailedDependency>{};
-    } else if err is UpgradeRequiredError {
-        return <UpgradeRequired>{};
-    } else if err is PreconditionRequiredError {
-        return <PreconditionRequired>{};
-    } else if err is TooManyRequestsError {
-        return <TooManyRequests>{};
-    } else if err is RequestHeaderFieldsTooLargeError {
-        return <RequestHeaderFieldsTooLarge>{};
-    } else if err is UnavailableForLegalReasonsError {
-        return <UnavailableForLegalReasons>{};
-    } else if err is ServerError {
-        return <InternalServerError>{};
-    } else if err is NotImplementedError {
-        return <NotImplemented>{};
-    } else if err is BadGatewayError {
-        return <BadGateway>{};
-    } else if err is ServiceUnavailableError {
-        return <ServiceUnavailable>{};
-    } else if err is GatewayTimeoutError {
-        return <GatewayTimeout>{};
-    } else if err is HTTPVersionNotSupportedError {
-        return <HttpVersionNotSupported>{};
-    } else if err is VariantAlsoNegotiatesError {
-        return <VariantAlsoNegotiates>{};
-    } else if err is InsufficientStorageError {
-        return <InsufficientStorage>{};
-    } else if err is LoopDetectedError {
-        return <LoopDetected>{};
-    } else if err is NotExtendedError {
-        return <NotExtended>{};
-    } else if err is NetworkAuthenticationRequiredError {
-        return <NetworkAuthenticationRequired>{};
+isolated function getErrorResponse(error err, string? returnMediaType = ()) returns Response {
+    Response response = new;
+    
+    // Handling the client errors
+    if err is ApplicationResponseError {
+        response.statusCode = err.detail().statusCode;
+        setPayload(err.detail().body, response, returnMediaType);
+        setHeaders(err.detail().headers, response);
+        return response;
     }
-    return <InternalServerError>{};
+
+    // Handling the server errors
+    setStatusCode(err, response);
+
+    if err !is StatusCodeError {
+        setPayload(err.message(), response, returnMediaType);
+        return response;
+    }
+
+    if err !is NoContentError {
+        // TODO: Change after this fix: https://github.com/ballerina-platform/ballerina-lang/issues/39669
+        // response.body = err.detail()?.body ?: err.message();
+        anydata body = err.detail()?.body is () ? err.message() : err.detail()?.body;
+        setPayload(body, response, returnMediaType);
+    }
+
+    map<string|string[]> headers = err.detail().headers ?: {};
+    setHeaders(headers, response);
+
+    return response;
+}
+
+isolated function setHeaders(map<string|string[]> headers, Response response) {
+    foreach var [key, values] in headers.entries() {
+        if values is string[] {
+            foreach var value in values {
+                response.addHeader(key, value);
+            }
+            continue;
+        }
+        response.setHeader(key, values);
+    }
+}
+
+isolated function setStatusCode(error err, Response response) {
+    if err is BadRequestError {
+        response.statusCode = 400;
+    } else if err is UnauthorizedError {
+        response.statusCode = 401;
+    } else if err is PaymentRequiredError {
+        response.statusCode = 402;
+    } else if err is ForbiddenError {
+        response.statusCode = 403;
+    } else if err is NotFoundError {
+        response.statusCode = 404;
+    } else if err is MethodNotAllowedError {
+        response.statusCode = 405;
+    } else if err is NotAcceptableError {
+        response.statusCode = 406;
+    } else if err is ProxyAuthenticationRequiredError {
+        response.statusCode = 407;
+    } else if err is RequestTimeoutError {
+        response.statusCode = 408;
+    } else if err is ConflictError {
+        response.statusCode = 409;
+    } else if err is GoneError {
+        response.statusCode = 410;
+    } else if err is LengthRequiredError {
+        response.statusCode = 411;
+    } else if err is PreconditionFailedError {
+        response.statusCode = 412;
+    } else if err is PayloadTooLargeError {
+        response.statusCode = 413;
+    } else if err is URITooLongError {
+        response.statusCode = 414;
+    } else if err is UnsupportedMediaTypeError {
+        response.statusCode = 415;
+    } else if err is RangeNotSatisfiableError {
+        response.statusCode = 416;
+    } else if err is ExpectationFailedError {
+        response.statusCode = 417;
+    } else if err is MisdirectedRequestError {
+        response.statusCode = 421;
+    } else if err is UnprocessableEntityError {
+        response.statusCode = 422;
+    } else if err is LockedError {
+        response.statusCode = 423;
+    } else if err is FailedDependencyError {
+        response.statusCode = 424;
+    } else if err is UpgradeRequiredError {
+        response.statusCode = 426;
+    } else if err is PreconditionRequiredError {
+        response.statusCode = 428;
+    } else if err is TooManyRequestsError {
+        response.statusCode = 429;
+    } else if err is RequestHeaderFieldsTooLargeError {
+        response.statusCode = 431;
+    } else if err is UnavailableForLegalReasonsError {
+        response.statusCode = 451;
+    } else if err is ServerError {
+        response.statusCode = 500;
+    } else if err is NotImplementedError {
+        response.statusCode = 501;
+    } else if err is BadGatewayError {
+        response.statusCode = 502;
+    } else if err is ServiceUnavailableError {
+        response.statusCode = 503;
+    } else if err is GatewayTimeoutError {
+        response.statusCode = 504;
+    } else if err is HTTPVersionNotSupportedError {
+        response.statusCode = 505;
+    } else if err is VariantAlsoNegotiatesError {
+        response.statusCode = 506;
+    } else if err is InsufficientStorageError {
+        response.statusCode = 507;
+    } else if err is LoopDetectedError {
+        response.statusCode = 508;
+    } else if err is NotExtendedError {
+        response.statusCode = 510;
+    } else if err is NetworkAuthenticationRequiredError {
+        response.statusCode = 511;
+    } else if err is DefaultStatusCodeError {
+        response.statusCode = err.detail().statusCode ?: 500;
+    } else {
+        // All other errors are default to InternalServerError
+        response.statusCode = 500;
+    }
 }

--- a/ballerina/http_status_code_errors.bal
+++ b/ballerina/http_status_code_errors.bal
@@ -1,0 +1,210 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Represents the details of an HTTP error.
+# 
+# + headers - The error response headers
+# + body - The error response body
+public type ErrorDetail record {
+    map<string> headers?;
+    anydata body?;
+};
+
+# Represents the HTTP status code error.
+public type StatusCodeError distinct error<ErrorDetail>;
+
+# Represents 4XX HTTP status code errors.
+public type '4XXStatusCodeError distinct StatusCodeError;
+# Represents 5XX HTTP status code errors.
+public type '5XXStatusCodeError distinct StatusCodeError;
+# Represents the default HTTP status code error.
+public type DefaultStatusCodeError distinct StatusCodeError;
+
+# Represents the HTTP 400 Bad Request error.
+public type BadRequestError distinct '4XXStatusCodeError;
+# Represents the HTTP 401 Unauthorized error.
+public type UnauthorizedError distinct '4XXStatusCodeError;
+# Represents the HTTP 402 Payment Required error.
+public type PaymentRequiredError distinct '4XXStatusCodeError;
+# Represents the HTTP 403 Forbidden error.
+public type ForbiddenError distinct '4XXStatusCodeError;
+# Represents the HTTP 404 Not Found error.
+public type NotFoundError distinct '4XXStatusCodeError;
+# Represents the HTTP 405 Method Not Allowed error.
+public type MethodNotAllowedError distinct '4XXStatusCodeError;
+# Represents the HTTP 406 Not Acceptable error.
+public type NotAcceptableError distinct '4XXStatusCodeError;
+# Represents the HTTP 407 Proxy Authentication Required error.
+public type ProxyAuthenticationRequiredError distinct '4XXStatusCodeError;
+# Represents the HTTP 408 Request Timeout error.
+public type RequestTimeoutError distinct '4XXStatusCodeError;
+# Represents the HTTP 409 Conflict error.
+public type ConflictError distinct '4XXStatusCodeError;
+# Represents the HTTP 410 Gone error.
+public type GoneError distinct '4XXStatusCodeError;
+# Represents the HTTP 411 Length Required error.
+public type LengthRequiredError distinct '4XXStatusCodeError;
+# Represents the HTTP 412 Precondition Failed error.
+public type PreconditionFailedError distinct '4XXStatusCodeError;
+# Represents the HTTP 413 Payload Too Large error.
+public type PayloadTooLargeError distinct '4XXStatusCodeError;
+# Represents the HTTP 414 URI Too Long error.
+public type URITooLongError distinct '4XXStatusCodeError;
+# Represents the HTTP 415 Unsupported Media Type error.
+public type UnsupportedMediaTypeError distinct '4XXStatusCodeError;
+# Represents the HTTP 416 Range Not Satisfiable error.
+public type RangeNotSatisfiableError distinct '4XXStatusCodeError;
+# Represents the HTTP 417 Expectation Failed error.
+public type ExpectationFailedError distinct '4XXStatusCodeError;
+# Represents the HTTP 421 Misdirected Request error.
+public type MisdirectedRequestError distinct '4XXStatusCodeError;
+# Represents the HTTP 422 Unprocessable Entity error.
+public type UnprocessableEntityError distinct '4XXStatusCodeError;
+# Represents the HTTP 423 Locked error.
+public type LockedError distinct '4XXStatusCodeError;
+# Represents the HTTP 424 Failed Dependency error.
+public type FailedDependencyError distinct '4XXStatusCodeError;
+# Represents the HTTP 426 Upgrade Required error.
+public type UpgradeRequiredError distinct '4XXStatusCodeError;
+# Represents the HTTP 428 Precondition Required error.
+public type PreconditionRequiredError distinct '4XXStatusCodeError;
+# Represents the HTTP 429 Too Many Requests error.
+public type TooManyRequestsError distinct '4XXStatusCodeError;
+# Represents the HTTP 431 Request Header Fields Too Large error.
+public type RequestHeaderFieldsTooLargeError distinct '4XXStatusCodeError;
+# Represents the HTTP 451 Unavailable For Legal Reasons error.
+public type UnavailableForLegalReasonsError distinct '4XXStatusCodeError;
+
+# Represents the HTTP 500 Internal Server Error error.
+public type ServerError distinct '5XXStatusCodeError;
+# Represents the HTTP 501 Not Implemented error.
+public type NotImplementedError distinct '5XXStatusCodeError;
+# Represents the HTTP 502 Bad Gateway error.
+public type BadGatewayError distinct '5XXStatusCodeError;
+# Represents the HTTP 503 Service Unavailable error.
+public type ServiceUnavailableError distinct '5XXStatusCodeError;
+# Represents the HTTP 504 Gateway Timeout error.
+public type GatewayTimeoutError distinct '5XXStatusCodeError;
+# Represents the HTTP 505 HTTP Version Not Supported error.
+public type HTTPVersionNotSupportedError distinct '5XXStatusCodeError;
+# Represents the HTTP 506 Variant Also Negotiates error.
+public type VariantAlsoNegotiatesError distinct '5XXStatusCodeError;
+# Represents the HTTP 507 Insufficient Storage error.
+public type InsufficientStorageError distinct '5XXStatusCodeError;
+# Represents the HTTP 508 Loop Detected error.
+public type LoopDetectedError distinct '5XXStatusCodeError;
+# Represents the HTTP 510 Not Extended error.
+public type NotExtendedError distinct '5XXStatusCodeError;
+# Represents the HTTP 511 Network Authentication Required error.
+public type NetworkAuthenticationRequiredError distinct '5XXStatusCodeError;
+
+
+# Represents Service Not Found error.
+public type ServiceNotFoundError NotFoundError & ServiceDispatchingError;
+# Represents Bad Matrix Parameter in the request error.
+public type BadMatrixParamError BadRequestError & ServiceDispatchingError;
+
+# Represents an error, which occurred when the resource is not found during dispatching.
+public type ResourceNotFoundError NotFoundError & ResourceDispatchingError;
+# Represents an error, which occurred when the resource method is not allowed during dispatching.
+public type ResourceMethodNotAllowedError MethodNotAllowedError & ResourceDispatchingError;
+# Represents an error, which occurred when the media type is not supported during dispatching.
+public type UnsupportedRequestMediaTypeError UnsupportedMediaTypeError & ResourceDispatchingError;
+# Represents an error, which occurred when the payload is not acceptable during dispatching.
+public type RequestNotAcceptableError NotAcceptableError & ResourceDispatchingError;
+# Represents other internal server errors during dispatching.
+public type ResourceDispatchingServerError ServerError & ResourceDispatchingError;
+
+isolated function getErrorStatusCodeResponse(StatusCodeError err) returns StatusCodeResponse {
+    if err is BadRequestError {
+        return <BadRequest>{};
+    } else if err is UnauthorizedError {
+        return <Unauthorized>{};
+    } else if err is PaymentRequiredError {
+        return <PaymentRequired>{};
+    } else if err is ForbiddenError {
+        return <Forbidden>{};
+    } else if err is NotFoundError {
+        return <NotFound>{};
+    } else if err is MethodNotAllowedError {
+        return <MethodNotAllowed>{};
+    } else if err is NotAcceptableError {
+        return <NotAcceptable>{};
+    } else if err is ProxyAuthenticationRequiredError {
+        return <ProxyAuthenticationRequired>{};
+    } else if err is RequestTimeoutError {
+        return <RequestTimeout>{};
+    } else if err is ConflictError {
+        return <Conflict>{};
+    } else if err is GoneError {
+        return <Gone>{};
+    } else if err is LengthRequiredError {
+        return <LengthRequired>{};
+    } else if err is PreconditionFailedError {
+        return <PreconditionFailed>{};
+    } else if err is PayloadTooLargeError {
+        return <PayloadTooLarge>{};
+    } else if err is URITooLongError {
+        return <UriTooLong>{};
+    } else if err is UnsupportedMediaTypeError {
+        return <UnsupportedMediaType>{};
+    } else if err is RangeNotSatisfiableError {
+        return <RangeNotSatisfiable>{};
+    } else if err is ExpectationFailedError {
+        return <ExpectationFailed>{};
+    } else if err is MisdirectedRequestError {
+        return <MisdirectedRequest>{};
+    } else if err is UnprocessableEntityError {
+        return <UnprocessableEntity>{};
+    } else if err is LockedError {
+        return <Locked>{};
+    } else if err is FailedDependencyError {
+        return <FailedDependency>{};
+    } else if err is UpgradeRequiredError {
+        return <UpgradeRequired>{};
+    } else if err is PreconditionRequiredError {
+        return <PreconditionRequired>{};
+    } else if err is TooManyRequestsError {
+        return <TooManyRequests>{};
+    } else if err is RequestHeaderFieldsTooLargeError {
+        return <RequestHeaderFieldsTooLarge>{};
+    } else if err is UnavailableForLegalReasonsError {
+        return <UnavailableForLegalReasons>{};
+    } else if err is ServerError {
+        return <InternalServerError>{};
+    } else if err is NotImplementedError {
+        return <NotImplemented>{};
+    } else if err is BadGatewayError {
+        return <BadGateway>{};
+    } else if err is ServiceUnavailableError {
+        return <ServiceUnavailable>{};
+    } else if err is GatewayTimeoutError {
+        return <GatewayTimeout>{};
+    } else if err is HTTPVersionNotSupportedError {
+        return <HttpVersionNotSupported>{};
+    } else if err is VariantAlsoNegotiatesError {
+        return <VariantAlsoNegotiates>{};
+    } else if err is InsufficientStorageError {
+        return <InsufficientStorage>{};
+    } else if err is LoopDetectedError {
+        return <LoopDetected>{};
+    } else if err is NotExtendedError {
+        return <NotExtended>{};
+    } else if err is NetworkAuthenticationRequiredError {
+        return <NetworkAuthenticationRequired>{};
+    }
+    return <InternalServerError>{};
+}

--- a/ballerina/http_status_code_types.bal
+++ b/ballerina/http_status_code_types.bal
@@ -22,10 +22,10 @@ public type StatusCodeResponse Continue|SwitchingProtocols|Processing|EarlyHints
     BadRequest|Unauthorized|PaymentRequired|Forbidden|NotFound|MethodNotAllowed|NotAcceptable|
     ProxyAuthenticationRequired|RequestTimeout|Conflict|Gone|LengthRequired|PreconditionFailed|PayloadTooLarge|
     UriTooLong|UnsupportedMediaType|RangeNotSatisfiable|ExpectationFailed|MisdirectedRequest|UnprocessableEntity|
-    Locked|FailedDependency|TooEarly|PreconditionRequired|UnavailableForLegalReasons|UpgradeRequired|TooManyRequests|
+    Locked|FailedDependency|TooEarly|PreconditionRequired|UnavailableDueToLegalReasons|UpgradeRequired|TooManyRequests|
     RequestHeaderFieldsTooLarge|InternalServerError|NotImplemented|BadGateway|ServiceUnavailable|GatewayTimeout|
     HttpVersionNotSupported|VariantAlsoNegotiates|InsufficientStorage|LoopDetected|NotExtended|
-    NetworkAuthenticationRequired;
+    NetworkAuthorizationRequired;
 
 # Defines the possible success status code response record types.
 type SuccessStatusCodeResponse Ok|Created|Accepted|NonAuthoritativeInformation|NoContent|ResetContent|
@@ -418,12 +418,12 @@ public readonly class StatusUpgradeRequired {
     public STATUS_UPGRADE_REQUIRED code = STATUS_UPGRADE_REQUIRED;
 }
 
-# Represents the status code of `STATUS_PRECONDITION_REQUIRED`.
+# Represents the status code of `STATUS_PREDICTION_REQUIRED`.
 #
 # + code - The response status code
 public readonly class StatusPreconditionRequired {
     *Status;
-    public STATUS_PRECONDITION_REQUIRED code = STATUS_PRECONDITION_REQUIRED;
+    public STATUS_PREDICTION_REQUIRED code = STATUS_PREDICTION_REQUIRED;
 }
 
 # Represents the status code of `STATUS_TOO_MANY_REQUESTS`.
@@ -445,7 +445,7 @@ public readonly class StatusRequestHeaderFieldsTooLarge {
 # Represents the status code of `STATUS_UNAVAILABLE_DUE_TO_LEGAL_REASONS`.
 #
 # + code - The response status code
-public readonly class StatusUnavailableForLegalReasons {
+public readonly class StatusUnavailableDueToLegalReasons {
     *Status;
     public STATUS_UNAVAILABLE_DUE_TO_LEGAL_REASONS code = STATUS_UNAVAILABLE_DUE_TO_LEGAL_REASONS;
 }
@@ -533,7 +533,7 @@ public readonly class StatusNotExtended {
 # Represents the status code of `STATUS_NETWORK_AUTHORIZATION_REQUIRED`.
 #
 # + code - The response status code
-public readonly class StatusNetworkAuthenticationRequired {
+public readonly class StatusNetworkAuthorizationRequired {
     *Status;
     public STATUS_NETWORK_AUTHORIZATION_REQUIRED code = STATUS_NETWORK_AUTHORIZATION_REQUIRED;
 }
@@ -584,8 +584,8 @@ final StatusUnprocessableEntity STATUS_UNPROCESSABLE_ENTITY_OBJ = new;
 final StatusLocked STATUS_LOCKED_OBJ = new;
 final StatusFailedDependency STATUS_FAILED_DEPENDENCY_OBJ = new;
 final StatusTooEarly STATUS_TOO_EARLY_OBJ = new;
-final StatusPreconditionRequired STATUS_PRECONDITION_REQUIRED_OBJ = new;
-final StatusUnavailableForLegalReasons STATUS_UNAVAILABLE_DUE_TO_LEGAL_REASONS_OBJ = new;
+final StatusPreconditionRequired STATUS_PREDICTION_REQUIRED_OBJ = new;
+final StatusUnavailableDueToLegalReasons STATUS_UNAVAILABLE_DUE_TO_LEGAL_REASONS_OBJ = new;
 final StatusUpgradeRequired STATUS_UPGRADE_REQUIRED_OBJ = new;
 final StatusTooManyRequests STATUS_TOO_MANY_REQUESTS_OBJ = new;
 final StatusRequestHeaderFieldsTooLarge STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE_OBJ = new;
@@ -599,7 +599,7 @@ final StatusVariantAlsoNegotiates STATUS_VARIANT_ALSO_NEGOTIATES_OBJ = new;
 final StatusInsufficientStorage STATUS_INSUFFICIENT_STORAGE_OBJ = new;
 final StatusLoopDetected STATUS_LOOP_DETECTED_OBJ = new;
 final StatusNotExtended STATUS_NOT_EXTENDED_OBJ = new;
-final StatusNetworkAuthenticationRequired STATUS_NETWORK_AUTHORIZATION_REQUIRED_OBJ = new;
+final StatusNetworkAuthorizationRequired STATUS_NETWORK_AUTHORIZATION_REQUIRED_OBJ = new;
 
 // Status code record types
 # The status code response record of `Continue`.
@@ -968,15 +968,15 @@ public type TooEarly record {|
 # + status - The response status code obj
 public type PreconditionRequired record {|
     *CommonResponse;
-    readonly StatusPreconditionRequired status = STATUS_PRECONDITION_REQUIRED_OBJ;
+    readonly StatusPreconditionRequired status = STATUS_PREDICTION_REQUIRED_OBJ;
 |};
 
-# The status code response record of `UnavailableForLegalReasons`.
+# The status code response record of `UnavailableDueToLegalReasons`.
 #
 # + status - The response status code obj
-public type UnavailableForLegalReasons record {|
+public type UnavailableDueToLegalReasons record {|
     *CommonResponse;
-    readonly StatusUnavailableForLegalReasons status = STATUS_UNAVAILABLE_DUE_TO_LEGAL_REASONS_OBJ;
+    readonly StatusUnavailableDueToLegalReasons status = STATUS_UNAVAILABLE_DUE_TO_LEGAL_REASONS_OBJ;
 |};
 
 # The status code response record of `UpgradeRequired`.
@@ -1083,12 +1083,12 @@ public type NotExtended record {|
     readonly StatusNotExtended status = STATUS_NOT_EXTENDED_OBJ;
 |};
 
-# The status code response record of `NetworkAuthenticationRequired`.
+# The status code response record of `NetworkAuthorizationRequired`.
 #
 # + status - The response status code obj
-public type NetworkAuthenticationRequired record {|
+public type NetworkAuthorizationRequired record {|
     *CommonResponse;
-    readonly StatusNetworkAuthenticationRequired status = STATUS_NETWORK_AUTHORIZATION_REQUIRED_OBJ;
+    readonly StatusNetworkAuthorizationRequired status = STATUS_NETWORK_AUTHORIZATION_REQUIRED_OBJ;
 |};
 
 # The common status code response constant of `Continue`.
@@ -1229,8 +1229,8 @@ public final readonly & TooEarly TOO_EARLY = {};
 # The common status code response constant of `PreconditionRequired`.
 public final readonly & PreconditionRequired PREDICTION_REQUIRED = {};
 
-# The common status code response constant of `UnavailableForLegalReasons`.
-public final readonly & UnavailableForLegalReasons UNAVAILABLE_DUE_TO_LEGAL_REASONS = {};
+# The common status code response constant of `UnavailableDueToLegalReasons`.
+public final readonly & UnavailableDueToLegalReasons UNAVAILABLE_DUE_TO_LEGAL_REASONS = {};
 
 # The common status code response constant of `UpgradeRequired`.
 public final readonly & UpgradeRequired UPGRADE_REQUIRED = {};
@@ -1271,5 +1271,5 @@ public final readonly & LoopDetected LOOP_DETECTED = {};
 # The common status code response constant of `NotExtended`.
 public final readonly & NotExtended NOT_EXTENDED = {};
 
-# The common status code response constant of `NetworkAuthenticationRequired`.
-public final readonly & NetworkAuthenticationRequired NETWORK_AUTHORIZATION_REQUIRED = {};
+# The common status code response constant of `NetworkAuthorizationRequired`.
+public final readonly & NetworkAuthorizationRequired NETWORK_AUTHORIZATION_REQUIRED = {};

--- a/ballerina/http_status_code_types.bal
+++ b/ballerina/http_status_code_types.bal
@@ -22,10 +22,10 @@ public type StatusCodeResponse Continue|SwitchingProtocols|Processing|EarlyHints
     BadRequest|Unauthorized|PaymentRequired|Forbidden|NotFound|MethodNotAllowed|NotAcceptable|
     ProxyAuthenticationRequired|RequestTimeout|Conflict|Gone|LengthRequired|PreconditionFailed|PayloadTooLarge|
     UriTooLong|UnsupportedMediaType|RangeNotSatisfiable|ExpectationFailed|MisdirectedRequest|UnprocessableEntity|
-    Locked|FailedDependency|TooEarly|PreconditionRequired|UnavailableDueToLegalReasons|UpgradeRequired|TooManyRequests|
+    Locked|FailedDependency|TooEarly|PreconditionRequired|UnavailableForLegalReasons|UpgradeRequired|TooManyRequests|
     RequestHeaderFieldsTooLarge|InternalServerError|NotImplemented|BadGateway|ServiceUnavailable|GatewayTimeout|
     HttpVersionNotSupported|VariantAlsoNegotiates|InsufficientStorage|LoopDetected|NotExtended|
-    NetworkAuthorizationRequired;
+    NetworkAuthenticationRequired;
 
 # Defines the possible success status code response record types.
 type SuccessStatusCodeResponse Ok|Created|Accepted|NonAuthoritativeInformation|NoContent|ResetContent|
@@ -418,12 +418,12 @@ public readonly class StatusUpgradeRequired {
     public STATUS_UPGRADE_REQUIRED code = STATUS_UPGRADE_REQUIRED;
 }
 
-# Represents the status code of `STATUS_PREDICTION_REQUIRED`.
+# Represents the status code of `STATUS_PRECONDITION_REQUIRED`.
 #
 # + code - The response status code
 public readonly class StatusPreconditionRequired {
     *Status;
-    public STATUS_PREDICTION_REQUIRED code = STATUS_PREDICTION_REQUIRED;
+    public STATUS_PRECONDITION_REQUIRED code = STATUS_PRECONDITION_REQUIRED;
 }
 
 # Represents the status code of `STATUS_TOO_MANY_REQUESTS`.
@@ -445,7 +445,7 @@ public readonly class StatusRequestHeaderFieldsTooLarge {
 # Represents the status code of `STATUS_UNAVAILABLE_DUE_TO_LEGAL_REASONS`.
 #
 # + code - The response status code
-public readonly class StatusUnavailableDueToLegalReasons {
+public readonly class StatusUnavailableForLegalReasons {
     *Status;
     public STATUS_UNAVAILABLE_DUE_TO_LEGAL_REASONS code = STATUS_UNAVAILABLE_DUE_TO_LEGAL_REASONS;
 }
@@ -533,7 +533,7 @@ public readonly class StatusNotExtended {
 # Represents the status code of `STATUS_NETWORK_AUTHORIZATION_REQUIRED`.
 #
 # + code - The response status code
-public readonly class StatusNetworkAuthorizationRequired {
+public readonly class StatusNetworkAuthenticationRequired {
     *Status;
     public STATUS_NETWORK_AUTHORIZATION_REQUIRED code = STATUS_NETWORK_AUTHORIZATION_REQUIRED;
 }
@@ -584,8 +584,8 @@ final StatusUnprocessableEntity STATUS_UNPROCESSABLE_ENTITY_OBJ = new;
 final StatusLocked STATUS_LOCKED_OBJ = new;
 final StatusFailedDependency STATUS_FAILED_DEPENDENCY_OBJ = new;
 final StatusTooEarly STATUS_TOO_EARLY_OBJ = new;
-final StatusPreconditionRequired STATUS_PREDICTION_REQUIRED_OBJ = new;
-final StatusUnavailableDueToLegalReasons STATUS_UNAVAILABLE_DUE_TO_LEGAL_REASONS_OBJ = new;
+final StatusPreconditionRequired STATUS_PRECONDITION_REQUIRED_OBJ = new;
+final StatusUnavailableForLegalReasons STATUS_UNAVAILABLE_DUE_TO_LEGAL_REASONS_OBJ = new;
 final StatusUpgradeRequired STATUS_UPGRADE_REQUIRED_OBJ = new;
 final StatusTooManyRequests STATUS_TOO_MANY_REQUESTS_OBJ = new;
 final StatusRequestHeaderFieldsTooLarge STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE_OBJ = new;
@@ -599,7 +599,7 @@ final StatusVariantAlsoNegotiates STATUS_VARIANT_ALSO_NEGOTIATES_OBJ = new;
 final StatusInsufficientStorage STATUS_INSUFFICIENT_STORAGE_OBJ = new;
 final StatusLoopDetected STATUS_LOOP_DETECTED_OBJ = new;
 final StatusNotExtended STATUS_NOT_EXTENDED_OBJ = new;
-final StatusNetworkAuthorizationRequired STATUS_NETWORK_AUTHORIZATION_REQUIRED_OBJ = new;
+final StatusNetworkAuthenticationRequired STATUS_NETWORK_AUTHORIZATION_REQUIRED_OBJ = new;
 
 // Status code record types
 # The status code response record of `Continue`.
@@ -968,15 +968,15 @@ public type TooEarly record {|
 # + status - The response status code obj
 public type PreconditionRequired record {|
     *CommonResponse;
-    readonly StatusPreconditionRequired status = STATUS_PREDICTION_REQUIRED_OBJ;
+    readonly StatusPreconditionRequired status = STATUS_PRECONDITION_REQUIRED_OBJ;
 |};
 
-# The status code response record of `UnavailableDueToLegalReasons`.
+# The status code response record of `UnavailableForLegalReasons`.
 #
 # + status - The response status code obj
-public type UnavailableDueToLegalReasons record {|
+public type UnavailableForLegalReasons record {|
     *CommonResponse;
-    readonly StatusUnavailableDueToLegalReasons status = STATUS_UNAVAILABLE_DUE_TO_LEGAL_REASONS_OBJ;
+    readonly StatusUnavailableForLegalReasons status = STATUS_UNAVAILABLE_DUE_TO_LEGAL_REASONS_OBJ;
 |};
 
 # The status code response record of `UpgradeRequired`.
@@ -1083,12 +1083,12 @@ public type NotExtended record {|
     readonly StatusNotExtended status = STATUS_NOT_EXTENDED_OBJ;
 |};
 
-# The status code response record of `NetworkAuthorizationRequired`.
+# The status code response record of `NetworkAuthenticationRequired`.
 #
 # + status - The response status code obj
-public type NetworkAuthorizationRequired record {|
+public type NetworkAuthenticationRequired record {|
     *CommonResponse;
-    readonly StatusNetworkAuthorizationRequired status = STATUS_NETWORK_AUTHORIZATION_REQUIRED_OBJ;
+    readonly StatusNetworkAuthenticationRequired status = STATUS_NETWORK_AUTHORIZATION_REQUIRED_OBJ;
 |};
 
 # The common status code response constant of `Continue`.
@@ -1229,8 +1229,8 @@ public final readonly & TooEarly TOO_EARLY = {};
 # The common status code response constant of `PreconditionRequired`.
 public final readonly & PreconditionRequired PREDICTION_REQUIRED = {};
 
-# The common status code response constant of `UnavailableDueToLegalReasons`.
-public final readonly & UnavailableDueToLegalReasons UNAVAILABLE_DUE_TO_LEGAL_REASONS = {};
+# The common status code response constant of `UnavailableForLegalReasons`.
+public final readonly & UnavailableForLegalReasons UNAVAILABLE_DUE_TO_LEGAL_REASONS = {};
 
 # The common status code response constant of `UpgradeRequired`.
 public final readonly & UpgradeRequired UPGRADE_REQUIRED = {};
@@ -1271,5 +1271,5 @@ public final readonly & LoopDetected LOOP_DETECTED = {};
 # The common status code response constant of `NotExtended`.
 public final readonly & NotExtended NOT_EXTENDED = {};
 
-# The common status code response constant of `NetworkAuthorizationRequired`.
-public final readonly & NetworkAuthorizationRequired NETWORK_AUTHORIZATION_REQUIRED = {};
+# The common status code response constant of `NetworkAuthenticationRequired`.
+public final readonly & NetworkAuthenticationRequired NETWORK_AUTHORIZATION_REQUIRED = {};

--- a/ballerina/http_status_codes.bal
+++ b/ballerina/http_status_codes.bal
@@ -110,7 +110,7 @@ public const int STATUS_TOO_EARLY = 425;
 # The HTTP response status code: 426 Upgrade Required
 public const int STATUS_UPGRADE_REQUIRED = 426;
 # The HTTP response status code: 428 Precondition Required
-public const int STATUS_PREDICTION_REQUIRED = 428;
+public const int STATUS_PRECONDITION_REQUIRED = 428;
 # The HTTP response status code: 429 Too Many Requests
 public const int STATUS_TOO_MANY_REQUESTS = 429;
 # The HTTP response status code: 431 Request Header Fields Too Large

--- a/ballerina/http_status_codes.bal
+++ b/ballerina/http_status_codes.bal
@@ -110,7 +110,7 @@ public const int STATUS_TOO_EARLY = 425;
 # The HTTP response status code: 426 Upgrade Required
 public const int STATUS_UPGRADE_REQUIRED = 426;
 # The HTTP response status code: 428 Precondition Required
-public const int STATUS_PRECONDITION_REQUIRED = 428;
+public const int STATUS_PREDICTION_REQUIRED = 428;
 # The HTTP response status code: 429 Too Many Requests
 public const int STATUS_TOO_MANY_REQUESTS = 429;
 # The HTTP response status code: 431 Request Header Fields Too Large

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- [Introduce new HTTP status code error structure](https://github.com/ballerina-platform/ballerina-standard-library/issues/4101)
+
 ### Fixed
 
 - [Fix server push not working with nghttp2 HTTP/2 client](https://github.com/ballerina-platform/ballerina-standard-library/issues/3077)

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
@@ -156,12 +156,9 @@ public class HttpCallableUnitCallback implements Callback {
     @Override
     public void notifyFailure(BError error) { // handles panic and check_panic
         cleanupRequestMessage();
-        // This check is added to update the status code with respect to the auth errors.
-        if (error.getType().getName().equals(HttpErrorType.INTERNAL_LISTENER_AUTHN_ERROR.getErrorName())) {
-            requestMessage.setHttpStatusCode(401);
-        } else if (error.getType().getName().equals(HttpErrorType.INTERNAL_LISTENER_AUTHZ_ERROR.getErrorName())) {
-            requestMessage.setHttpStatusCode(403);
-        } else {
+        // Skipping the panics from internal authentication/authorization.
+        if (!error.getType().getName().equals(HttpErrorType.LISTENER_AUTHN_ERROR.getErrorName())
+                && !error.getType().getName().equals(HttpErrorType.LISTENER_AUTHZ_ERROR.getErrorName())) {
             requestMessage.setProperty(HttpConstants.INTERCEPTOR_SERVICE_PANIC_ERROR, true);
         }
         if (alreadyResponded(error)) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
@@ -110,13 +110,11 @@ public class HttpCallableUnitCallback implements Callback {
     }
 
     private void returnErrorResponse(BError error) {
-        Object[] paramFeed = new Object[6];
+        Object[] paramFeed = new Object[4];
         paramFeed[0] = error;
         paramFeed[1] = true;
         paramFeed[2] = returnMediaType != null ? StringUtils.fromString(returnMediaType) : null;
         paramFeed[3] = true;
-        paramFeed[4] = requestMessage.getHttpStatusCode();
-        paramFeed[5] = true;
 
         invokeBalMethod(paramFeed, "returnErrorResponse");
     }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -222,6 +222,8 @@ public class HttpConstants {
     public static final String RESPONSE_CACHE_CONTROL = "ResponseCacheControl";
     public static final String REQUEST_CACHE_CONTROL = "RequestCacheControl";
     public static final String STRUCT_GENERIC_ERROR = "error";
+    public static final String ERROR_DETAIL_RECORD = "ErrorDetail";
+    public static final BString ERROR_DETAIL_BODY = StringUtils.fromString("body");
     public static final String TYPE_STRING = "string";
     public static final String TRANSPORT_MESSAGE = "transport_message";
     public static final String QUERY_PARAM_MAP = "queryParamMap";

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
@@ -57,6 +57,7 @@ import static io.ballerina.stdlib.http.api.HttpConstants.EXTRA_PATH_INDEX;
 import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_SCHEME;
 import static io.ballerina.stdlib.http.api.HttpConstants.SCHEME_SEPARATOR;
 import static io.ballerina.stdlib.http.api.HttpConstants.WHITESPACE;
+import static io.ballerina.stdlib.http.api.HttpErrorType.SERVICE_NOT_FOUND_ERROR;
 import static io.ballerina.stdlib.http.api.HttpUtil.getParameterTypes;
 import static io.ballerina.stdlib.http.api.service.signature.ParamUtils.castParam;
 import static io.ballerina.stdlib.http.api.service.signature.ParamUtils.castParamArray;
@@ -82,10 +83,9 @@ public class HttpDispatcher {
                 servicesOnInterface = servicesRegistry.getServicesByHost(DEFAULT_HOST);
                 sortedServiceURIs = servicesRegistry.getSortedServiceURIsByHost(DEFAULT_HOST);
             } else {
-                inboundReqMsg.setHttpStatusCode(404);
                 String localAddress = inboundReqMsg.getProperty(HttpConstants.LOCAL_ADDRESS).toString();
-                throw HttpUtil.createHttpError("no service has registered for listener : " + localAddress,
-                                               HttpErrorType.SERVICE_DISPATCHING_ERROR);
+                String message = "no service has registered for listener : " + localAddress;
+                throw HttpUtil.createHttpStatusCodeError(SERVICE_NOT_FOUND_ERROR, message);
             }
 
             String rawUri = (String) inboundReqMsg.getProperty(HttpConstants.TO);
@@ -98,9 +98,8 @@ public class HttpDispatcher {
                                                                            servicesOnInterface, sortedServiceURIs);
 
             if (basePath == null) {
-                inboundReqMsg.setHttpStatusCode(404);
-                throw HttpUtil.createHttpError("no matching service found for path : " + validatedUri.getRawPath(),
-                                               HttpErrorType.SERVICE_DISPATCHING_ERROR);
+                String message = "no matching service found for path : " + validatedUri.getRawPath();
+                throw HttpUtil.createHttpStatusCodeError(SERVICE_NOT_FOUND_ERROR, message);
             }
 
             HttpService service = servicesOnInterface.get(basePath);
@@ -112,7 +111,10 @@ public class HttpDispatcher {
             }
             return service;
         } catch (Exception e) {
-            throw HttpUtil.createHttpError(e.getMessage(), HttpErrorType.SERVICE_DISPATCHING_ERROR);
+            if (!(e instanceof BError)) {
+                throw HttpUtil.createHttpStatusCodeError(SERVICE_NOT_FOUND_ERROR, e.getMessage());
+            }
+            throw e;
         }
     }
 
@@ -132,10 +134,9 @@ public class HttpDispatcher {
                 servicesOnInterface = servicesRegistry.getServicesByHost(DEFAULT_HOST);
                 sortedServiceURIs = servicesRegistry.getSortedServiceURIsByHost(DEFAULT_HOST);
             } else {
-                inboundReqMsg.setHttpStatusCode(404);
                 String localAddress = inboundReqMsg.getProperty(HttpConstants.LOCAL_ADDRESS).toString();
-                throw HttpUtil.createHttpError("no service has registered for listener : " + localAddress,
-                                               HttpErrorType.SERVICE_DISPATCHING_ERROR);
+                String message = "no service has registered for listener : " + localAddress;
+                throw HttpUtil.createHttpStatusCodeError(SERVICE_NOT_FOUND_ERROR, message);
             }
 
             if (isResponsePath) {
@@ -158,16 +159,18 @@ public class HttpDispatcher {
                                                                            servicesOnInterface, sortedServiceURIs);
 
             if (basePath == null) {
-                inboundReqMsg.setHttpStatusCode(404);
-                throw HttpUtil.createHttpError("no matching service found for path : " + validatedUri.getRawPath(),
-                                               HttpErrorType.SERVICE_DISPATCHING_ERROR);
+                String message = "no matching service found for path : " + validatedUri.getRawPath();
+                throw HttpUtil.createHttpStatusCodeError(SERVICE_NOT_FOUND_ERROR, message);
             }
 
             InterceptorService service = servicesOnInterface.get(basePath);
             setInboundReqProperties(inboundReqMsg, validatedUri, basePath);
             return service;
         } catch (Exception e) {
-            throw HttpUtil.createHttpError(e.getMessage(), HttpErrorType.SERVICE_DISPATCHING_ERROR);
+            if (!(e instanceof BError)) {
+                throw HttpUtil.createHttpStatusCodeError(SERVICE_NOT_FOUND_ERROR, e.getMessage());
+            }
+            throw e;
         }
     }
 
@@ -308,8 +311,8 @@ public class HttpDispatcher {
             HttpResourceArguments resourceArgumentValues =
                     (HttpResourceArguments) httpCarbonMessage.getProperty(HttpConstants.RESOURCE_ARGS);
             updateWildcardToken(resource.getWildcardToken(), pathParamCount - 1, resourceArgumentValues.getMap());
-            populatePathParams(resource, paramFeed, resourceArgumentValues, pathParamCount, httpCarbonMessage,
-                               parameterTypes);
+            populatePathParams(resource, paramFeed, resourceArgumentValues, pathParamCount,
+                    parameterTypes);
         }
         // Following was written assuming that they are validated
         for (Parameter param : paramHandler.getOtherParamList()) {
@@ -444,7 +447,6 @@ public class HttpDispatcher {
 
     private static void populatePathParams(Resource resource, Object[] paramFeed,
                                            HttpResourceArguments resourceArgumentValues, int pathParamCount,
-                                           HttpCarbonMessage inboundRequest,
                                            Type[] parameterTypes) {
 
         String[] pathParamTokens = Arrays.copyOfRange(resource.getBalResource().getParamNames(), 0, pathParamCount);
@@ -470,9 +472,9 @@ public class HttpDispatcher {
                 }
                 paramFeed[paramIndex] = true;
             } catch (Exception ex) {
-                inboundRequest.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
-                throw HttpUtil.createHttpError("error in casting path parameter : '" + paramName + "'",
-                                               HttpErrorType.PATH_PARAM_BINDING_ERROR, HttpUtil.createError(ex));
+                String message = "error in casting path parameter : '" + paramName + "'";
+                throw HttpUtil.createHttpStatusCodeError(HttpErrorType.PATH_PARAM_BINDING_ERROR, message,
+                        null, HttpUtil.createError(ex));
             }
         }
     }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpErrorType.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpErrorType.java
@@ -70,10 +70,15 @@ public enum HttpErrorType {
     PATH_PARAM_BINDING_ERROR("PathParameterBindingError"),
     INTERCEPTOR_RETURN_ERROR("InterceptorReturnError"),
     REQ_DISPATCHING_ERROR("RequestDispatchingError"),
-    SERVICE_DISPATCHING_ERROR("ServiceDispatchingError"),
-    RESOURCE_DISPATCHING_ERROR("ResourceDispatchingError"),
-    INTERNAL_LISTENER_AUTHZ_ERROR("InternalListenerAuthzError"),
-    INTERNAL_LISTENER_AUTHN_ERROR("InternalListenerAuthnError");
+    RESOURCE_NOT_FOUND_ERROR("ResourceNotFoundError"),
+    RESOURCE_METHOD_NOT_ALLOWED_ERROR("ResourceMethodNotAllowedError"),
+    UNSUPPORTED_REQUEST_MEDIA_TYPE_ERROR("UnsupportedRequestMediaTypeError"),
+    REQUEST_NOT_ACCEPTABLE_ERROR("RequestNotAcceptableError"),
+    SERVICE_NOT_FOUND_ERROR("ServiceNotFoundError"),
+    BAD_MATRIX_PARAMS_ERROR("BadMatrixParamError"),
+    RESOURCE_DISPATCHING_SERVER_ERROR("ResourceDispatchingServerError"),
+    LISTENER_AUTHZ_ERROR("ListenerAuthzError"),
+    LISTENER_AUTHN_ERROR("ListenerAuthnError");
 
     private final String errorName;
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpRequestInterceptorUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpRequestInterceptorUnitCallback.java
@@ -28,6 +28,8 @@ import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.stdlib.http.api.nativeimpl.ModuleUtils;
 import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
 
+import static io.ballerina.stdlib.http.api.HttpErrorType.INTERCEPTOR_RETURN_ERROR;
+
 /**
  * {@code HttpRequestInterceptorUnitCallback} is the responsible for acting on notifications received from Ballerina
  * side when a request interceptor service is invoked.
@@ -156,9 +158,8 @@ public class HttpRequestInterceptorUnitCallback implements Callback {
                 if (result.equals(interceptor)) {
                     sendRequestToNextService();
                 } else {
-                    BError err = HttpUtil.createHttpError("next interceptor service did not match with the " +
-                                                          "configuration", HttpErrorType.INTERCEPTOR_RETURN_ERROR);
-                    requestMessage.setHttpStatusCode(500);
+                    String message = "next interceptor service did not match with the configuration";
+                    BError err = HttpUtil.createHttpStatusCodeError(INTERCEPTOR_RETURN_ERROR, message);
                     invokeErrorInterceptors(err, true);
                 }
             } else {
@@ -166,9 +167,8 @@ public class HttpRequestInterceptorUnitCallback implements Callback {
                 if (result.equals(targetService)) {
                     sendRequestToNextService();
                 } else {
-                    BError err = HttpUtil.createHttpError("target service did not match with the configuration",
-                                                          HttpErrorType.INTERCEPTOR_RETURN_ERROR);
-                    requestMessage.setHttpStatusCode(500);
+                    String message = "target service did not match with the configuration";
+                    BError err = HttpUtil.createHttpStatusCodeError(INTERCEPTOR_RETURN_ERROR, message);
                     invokeErrorInterceptors(err, true);
                 }
             }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpRequestInterceptorUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpRequestInterceptorUnitCallback.java
@@ -84,13 +84,11 @@ public class HttpRequestInterceptorUnitCallback implements Callback {
     public void returnErrorResponse(Object error) {
         cleanupRequestMessage();
 
-        Object[] paramFeed = new Object[6];
+        Object[] paramFeed = new Object[4];
         paramFeed[0] = error;
         paramFeed[1] = true;
         paramFeed[2] = null;
         paramFeed[3] = true;
-        paramFeed[4] = requestMessage.getHttpStatusCode();
-        paramFeed[5] = true;
 
         invokeBalMethod(paramFeed, "returnErrorResponse");
     }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpResponseInterceptorUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpResponseInterceptorUnitCallback.java
@@ -139,9 +139,8 @@ public class HttpResponseInterceptorUnitCallback extends HttpCallableUnitCallbac
                 if (result.equals(interceptor)) {
                     sendResponseToNextService();
                 } else {
-                    BError err = HttpUtil.createHttpError("next interceptor service did not match with the " +
-                                                          "configuration", HttpErrorType.INTERCEPTOR_RETURN_ERROR);
-                    requestMessage.setHttpStatusCode(500);
+                    String message = "next interceptor service did not match with the configuration";
+                    BError err = HttpUtil.createHttpStatusCodeError(HttpErrorType.INTERCEPTOR_RETURN_ERROR, message);
                     invokeErrorInterceptors(err, true);
                 }
             }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpResponseInterceptorUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpResponseInterceptorUnitCallback.java
@@ -192,13 +192,11 @@ public class HttpResponseInterceptorUnitCallback extends HttpCallableUnitCallbac
     }
 
     public void returnErrorResponse(BError error) {
-        Object[] paramFeed = new Object[6];
+        Object[] paramFeed = new Object[4];
         paramFeed[0] = error;
         paramFeed[1] = true;
         paramFeed[2] = null;
         paramFeed[3] = true;
-        paramFeed[4] = requestMessage.getHttpStatusCode();
-        paramFeed[5] = true;
 
         invokeBalMethod(paramFeed, "returnErrorResponse");
     }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -23,6 +23,7 @@ import io.ballerina.runtime.api.Module;
 import io.ballerina.runtime.api.Runtime;
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.creators.ErrorCreator;
+import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.Field;
 import io.ballerina.runtime.api.types.FunctionType;
 import io.ballerina.runtime.api.types.MethodType;
@@ -598,6 +599,20 @@ public class HttpUtil {
                                          BMap<BString, Object> detail) {
         return ErrorCreator.createError(ModuleUtils.getHttpPackage(), errorType.getErrorName(), fromString(message),
                                         cause, detail);
+    }
+
+    public static BError createHttpStatusCodeError(HttpErrorType errorType, String message) {
+        return createHttpStatusCodeError(errorType, message, null, null);
+    }
+
+    public static BError createHttpStatusCodeError(HttpErrorType errorType, String message, String body,
+                                                   BError cause) {
+        BMap<BString, Object> detail = ValueCreator.createRecordValue(ModuleUtils.getHttpPackage(),
+                HttpConstants.ERROR_DETAIL_RECORD);
+        if (body != null) {
+            detail.put(HttpConstants.ERROR_DETAIL_BODY, fromString(body));
+        }
+        return createHttpError(errorType, message, cause, detail);
     }
 
     // TODO: Find a better way to get the error type than String matching.

--- a/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDataElement.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDataElement.java
@@ -31,7 +31,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static io.ballerina.stdlib.http.api.HttpErrorType.GENERIC_LISTENER_ERROR;
-import static io.ballerina.stdlib.http.api.HttpErrorType.RESOURCE_DISPATCHING_ERROR;
+import static io.ballerina.stdlib.http.api.HttpErrorType.REQUEST_NOT_ACCEPTABLE_ERROR;
+import static io.ballerina.stdlib.http.api.HttpErrorType.RESOURCE_METHOD_NOT_ALLOWED_ERROR;
+import static io.ballerina.stdlib.http.api.HttpErrorType.UNSUPPORTED_REQUEST_MEDIA_TYPE_ERROR;
 
 /**
  * Http Node Item for URI template tree.
@@ -134,8 +136,8 @@ public class ResourceDataElement implements DataElement<Resource, HttpCarbonMess
             return httpResource;
         }
         if (!isOptionsRequest) {
-            carbonMessage.setHttpStatusCode(405);
-            throw HttpUtil.createHttpError("Method not allowed", RESOURCE_DISPATCHING_ERROR);
+            String message = "Method not allowed";
+            throw HttpUtil.createHttpStatusCodeError(RESOURCE_METHOD_NOT_ALLOWED_ERROR, message);
         }
         return null;
     }
@@ -186,9 +188,8 @@ public class ResourceDataElement implements DataElement<Resource, HttpCarbonMess
                 return;
             }
         }
-        cMsg.setHttpStatusCode(415);
-        throw HttpUtil.createHttpError("content-type : " + contentMediaType + " is not supported",
-                                       RESOURCE_DISPATCHING_ERROR);
+        String message = "content-type : " + contentMediaType + " is not supported";
+        throw HttpUtil.createHttpStatusCodeError(UNSUPPORTED_REQUEST_MEDIA_TYPE_ERROR, message);
     }
 
     private String extractContentMediaType(String header) {
@@ -230,8 +231,7 @@ public class ResourceDataElement implements DataElement<Resource, HttpCarbonMess
                 return;
             }
         }
-        cMsg.setHttpStatusCode(406);
-        throw HttpUtil.createHttpError("", RESOURCE_DISPATCHING_ERROR);
+        throw HttpUtil.createHttpStatusCodeError(REQUEST_NOT_ACCEPTABLE_ERROR, "");
     }
 
     private List<String> extractAcceptMediaTypes(String header) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDispatcher.java
@@ -27,6 +27,9 @@ import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 
+import static io.ballerina.stdlib.http.api.HttpErrorType.RESOURCE_DISPATCHING_SERVER_ERROR;
+import static io.ballerina.stdlib.http.api.HttpErrorType.RESOURCE_NOT_FOUND_ERROR;
+
 /**
  * Resource level dispatchers handler for HTTP protocol.
  */
@@ -52,15 +55,14 @@ public class ResourceDispatcher {
                 if (method.equals(HttpConstants.HTTP_METHOD_OPTIONS)) {
                     handleOptionsRequest(inboundRequest, service);
                 } else {
-                    inboundRequest.setHttpStatusCode(404);
-                    throw HttpUtil.createHttpError("no matching resource found for path : " +
-                                                   inboundRequest.getProperty(HttpConstants.TO) + " , method : " +
-                                                   method, HttpErrorType.RESOURCE_DISPATCHING_ERROR);
+                    String message = "no matching resource found for path : " +
+                            inboundRequest.getProperty(HttpConstants.TO) + " , method : " + method;
+                    throw HttpUtil.createHttpStatusCodeError(RESOURCE_NOT_FOUND_ERROR, message);
                 }
                 return null;
             }
         } catch (URITemplateException e) {
-            throw HttpUtil.createHttpError(e.getMessage(), HttpErrorType.RESOURCE_DISPATCHING_ERROR);
+            throw HttpUtil.createHttpStatusCodeError(RESOURCE_DISPATCHING_SERVER_ERROR, e.getMessage());
         }
     }
 
@@ -84,9 +86,9 @@ public class ResourceDispatcher {
             response.setHeader(HttpHeaderNames.ALLOW.toString(),
                                DispatcherUtil.concatValues(service.getAllAllowedMethods(), false));
         } else {
-            cMsg.setHttpStatusCode(404);
-            throw HttpUtil.createHttpError("no matching resource found for path : " + cMsg.getProperty(HttpConstants.TO)
-                                           + " , method : " + "OPTIONS", HttpErrorType.RESOURCE_DISPATCHING_ERROR);
+            String message = "no matching resource found for path : " + cMsg.getProperty(HttpConstants.TO)
+                    + " , method : OPTIONS";
+            throw HttpUtil.createHttpStatusCodeError(RESOURCE_NOT_FOUND_ERROR, message);
         }
         CorsHeaderGenerator.process(cMsg, response, false);
         String introspectionResourcePathHeaderValue = service.getIntrospectionResourcePathHeaderValue();

--- a/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternRequestContext.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternRequestContext.java
@@ -30,6 +30,8 @@ import org.ballerinalang.langlib.value.EnsureType;
 
 import java.util.Objects;
 
+import static io.ballerina.stdlib.http.api.HttpErrorType.INTERCEPTOR_RETURN_ERROR;
+
 /**
  * Utilities related to HTTP request context.
  */
@@ -39,7 +41,13 @@ public class ExternRequestContext {
         BMap members = requestCtx.getMapValue(HttpConstants.REQUEST_CTX_MEMBERS);
         try {
             Object value = members.getOrThrow(key);
-            return EnsureType.ensureType(value, targetType);
+            Object convertedType = EnsureType.ensureType(value, targetType);
+            if (convertedType instanceof BError) {
+                return HttpUtil.createHttpError("type conversion failed for value of key: " + key.getValue(),
+                                                HttpErrorType.GENERIC_LISTENER_ERROR,
+                                                (BError) convertedType);
+            }
+            return convertedType;
         } catch (Exception exp) {
             return HttpUtil.createHttpError("no member found for key: " + key.getValue(),
                                             HttpErrorType.GENERIC_LISTENER_ERROR,
@@ -53,14 +61,13 @@ public class ExternRequestContext {
             if (!isInterceptorService(requestCtx)) {
                 // TODO : After introducing response interceptors, calling ctx.next() should return "illegal function
                 //  invocation : next()" if there is a response interceptor service in the pipeline
-                return HttpUtil.createHttpError("no next service to be returned",
-                                                HttpErrorType.INTERCEPTOR_RETURN_ERROR);
+                return HttpUtil.createHttpStatusCodeError(INTERCEPTOR_RETURN_ERROR, "no next service to be returned");
             }
             requestCtx.addNativeData(HttpConstants.REQUEST_CONTEXT_NEXT, true);
             return getNextInterceptor(requestCtx, interceptors);
         } else {
-            return HttpUtil.createHttpError("request context object does not contain the configured interceptors",
-                                            HttpErrorType.INTERCEPTOR_RETURN_ERROR);
+            String message = "request context object does not contain the configured interceptors";
+            return HttpUtil.createHttpStatusCodeError(INTERCEPTOR_RETURN_ERROR, message);
         }
     }
 
@@ -91,8 +98,7 @@ public class ExternRequestContext {
             }
         }
         if (interceptorIndex > interceptors.size()) {
-            return HttpUtil.createHttpError("no next service to be returned",
-                                            HttpErrorType.INTERCEPTOR_RETURN_ERROR);
+            return HttpUtil.createHttpStatusCodeError(INTERCEPTOR_RETURN_ERROR, "no next service to be returned");
         }
         if (interceptorIndex < 0) {
             return null;

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllHeaderParams.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllHeaderParams.java
@@ -173,9 +173,9 @@ public class AllHeaderParams implements Parameter {
                     recordValue.put(StringUtils.fromString(key), castParam(fieldType.getTag(), headerValues.get(0)));
                 }
             } catch (Exception ex) {
-                httpCarbonMessage.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
-                throw HttpUtil.createHttpError("header binding failed for parameter: '" + key + "'",
-                        HttpErrorType.HEADER_BINDING_ERROR, HttpUtil.createError(ex));
+                String message = "header binding failed for parameter: '" + key + "'";
+                throw HttpUtil.createHttpStatusCodeError(HEADER_BINDING_ERROR, message, null,
+                        HttpUtil.createError(ex));
             }
         }
         if (headerParam.isReadonly()) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllHeaderParams.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllHeaderParams.java
@@ -27,7 +27,6 @@ import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.stdlib.http.api.HttpConstants;
-import io.ballerina.stdlib.http.api.HttpErrorType;
 import io.ballerina.stdlib.http.api.HttpUtil;
 import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -36,6 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static io.ballerina.runtime.api.TypeTags.ARRAY_TAG;
+import static io.ballerina.stdlib.http.api.HttpErrorType.HEADER_BINDING_ERROR;
 import static io.ballerina.stdlib.http.api.service.signature.ParamUtils.castParam;
 import static io.ballerina.stdlib.http.api.service.signature.ParamUtils.castParamArray;
 
@@ -80,7 +80,7 @@ public class AllHeaderParams implements Parameter {
             int index = headerParam.getIndex();
             if (headerParam.isRecord()) {
                 BMap<BString, Object> recordValue = processHeaderRecord(headerParam, httpHeaders,
-                                                                        treatNilableAsOptional, httpCarbonMessage);
+                                                                        treatNilableAsOptional);
                 paramFeed[index++] = recordValue;
                 paramFeed[index] = true;
                 continue;
@@ -93,9 +93,8 @@ public class AllHeaderParams implements Parameter {
                     paramFeed[index] = true;
                     continue;
                 } else {
-                    httpCarbonMessage.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
-                    throw HttpUtil.createHttpError("no header value found for '" + token + "'",
-                                                   HttpErrorType.HEADER_BINDING_ERROR);
+                    String message = "no header value found for '" + token + "'";
+                    throw HttpUtil.createHttpStatusCodeError(HEADER_BINDING_ERROR, message);
                 }
             }
             if (headerValues.size() == 1 && headerValues.get(0).isEmpty()) {
@@ -104,9 +103,8 @@ public class AllHeaderParams implements Parameter {
                     paramFeed[index] = true;
                     continue;
                 } else {
-                    httpCarbonMessage.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
-                    throw HttpUtil.createHttpError("no header value found for '" + token + "'",
-                                                   HttpErrorType.HEADER_BINDING_ERROR);
+                    String message = "no header value found for '" + token + "'";
+                    throw HttpUtil.createHttpStatusCodeError(HEADER_BINDING_ERROR, message);
                 }
             }
             int typeTag = headerParam.getType().getTag();
@@ -122,17 +120,16 @@ public class AllHeaderParams implements Parameter {
                     paramFeed[index++] = castParam(typeTag, headerValues.get(0));
                 }
             } catch (Exception ex) {
-                httpCarbonMessage.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
-                throw HttpUtil.createHttpError("header binding failed for parameter: '" + token + "'",
-                                               HttpErrorType.HEADER_BINDING_ERROR, HttpUtil.createError(ex));
+                String message = "header binding failed for parameter: '" + token + "'";
+                throw HttpUtil.createHttpStatusCodeError(HEADER_BINDING_ERROR, message, null,
+                        HttpUtil.createError(ex));
             }
             paramFeed[index] = true;
         }
     }
 
     private BMap<BString, Object> processHeaderRecord(HeaderParam headerParam, HttpHeaders httpHeaders,
-                                                      boolean treatNilableAsOptional,
-                                                      HttpCarbonMessage httpCarbonMessage) {
+                                                      boolean treatNilableAsOptional) {
         HeaderRecordParam headerRecordParam = headerParam.getRecordParam();
         RecordType recordType = headerRecordParam.getType();
         BMap<BString, Object> recordValue = ValueCreator.createRecordValue(recordType);
@@ -149,9 +146,8 @@ public class AllHeaderParams implements Parameter {
                 } else if (headerParam.isNilable()) {
                     return null;
                 } else {
-                    httpCarbonMessage.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
-                    throw HttpUtil.createHttpError("no header value found for '" + key + "'",
-                                                   HttpErrorType.HEADER_BINDING_ERROR);
+                    String message = "no header value found for '" + key + "'";
+                    throw HttpUtil.createHttpStatusCodeError(HEADER_BINDING_ERROR, message);
                 }
             }
             if (headerValues.size() == 1 && headerValues.get(0).isEmpty()) {
@@ -161,9 +157,8 @@ public class AllHeaderParams implements Parameter {
                 } else if (headerParam.isNilable()) {
                     return null;
                 } else {
-                    httpCarbonMessage.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
-                    throw HttpUtil.createHttpError("no header value found for '" + key + "'",
-                                                   HttpErrorType.HEADER_BINDING_ERROR);
+                    String message = "no header value found for '" + key + "'";
+                    throw HttpUtil.createHttpStatusCodeError(HEADER_BINDING_ERROR, message);
                 }
             }
             try {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllQueryParams.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllQueryParams.java
@@ -34,7 +34,6 @@ import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.stdlib.http.api.HttpConstants;
-import io.ballerina.stdlib.http.api.HttpErrorType;
 import io.ballerina.stdlib.http.api.HttpUtil;
 import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
 
@@ -44,6 +43,7 @@ import java.util.List;
 import static io.ballerina.runtime.api.TypeTags.ARRAY_TAG;
 import static io.ballerina.runtime.api.TypeTags.MAP_TAG;
 import static io.ballerina.runtime.api.TypeTags.UNION_TAG;
+import static io.ballerina.stdlib.http.api.HttpErrorType.QUERY_PARAM_BINDING_ERROR;
 import static io.ballerina.stdlib.http.api.service.signature.ParamUtils.castParam;
 
 /**
@@ -92,9 +92,8 @@ public class AllQueryParams implements Parameter {
                     paramFeed[index] = true;
                     continue;
                 } else {
-                    httpCarbonMessage.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
-                    throw HttpUtil.createHttpError("no query param value found for '" + token + "'",
-                                                   HttpErrorType.QUERY_PARAM_BINDING_ERROR);
+                    String message = "no query param value found for '" + token + "'";
+                    throw HttpUtil.createHttpStatusCodeError(QUERY_PARAM_BINDING_ERROR, message);
                 }
             }
 
@@ -134,9 +133,9 @@ public class AllQueryParams implements Parameter {
                 }
                 paramFeed[index] = true;
             } catch (Exception ex) {
-                httpCarbonMessage.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
-                throw HttpUtil.createHttpError("error in casting query param : '" + token + "'",
-                                               HttpErrorType.QUERY_PARAM_BINDING_ERROR, HttpUtil.createError(ex));
+                String message = "error in casting query param : '" + token + "'";
+                throw HttpUtil.createHttpStatusCodeError(QUERY_PARAM_BINDING_ERROR, message, null,
+                        HttpUtil.createError(ex));
             }
         }
     }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/PayloadParam.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/PayloadParam.java
@@ -29,7 +29,6 @@ import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.stdlib.constraint.Constraints;
 import io.ballerina.stdlib.http.api.HttpConstants;
-import io.ballerina.stdlib.http.api.HttpErrorType;
 import io.ballerina.stdlib.http.api.HttpUtil;
 import io.ballerina.stdlib.http.api.service.signature.builder.AbstractPayloadBuilder;
 import io.ballerina.stdlib.http.api.service.signature.converter.JsonToRecordConverter;
@@ -41,6 +40,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static io.ballerina.runtime.api.TypeTags.ARRAY_TAG;
+import static io.ballerina.stdlib.http.api.HttpErrorType.PAYLOAD_BINDING_LISTENER_ERROR;
+import static io.ballerina.stdlib.http.api.HttpErrorType.PAYLOAD_VALIDATION_LISTENER_ERROR;
 import static io.ballerina.stdlib.http.api.service.signature.builder.AbstractPayloadBuilder.getBuilder;
 import static io.ballerina.stdlib.mime.util.MimeConstants.REQUEST_ENTITY_FIELD;
 
@@ -135,16 +136,14 @@ public class PayloadParam implements Parameter {
         // Check if datasource is already available from interceptor service read
         // TODO : Validate the dataSource type with payload type and populate
         if (dataSource != null) {
-            index = populateFeedWithAlreadyBuiltPayload(httpCarbonMessage, paramFeed, inRequestEntity, index,
-                                                        payloadType, dataSource);
+            index = populateFeedWithAlreadyBuiltPayload(paramFeed, inRequestEntity, index, payloadType, dataSource);
         } else {
             index = populateFeedWithFreshPayload(httpCarbonMessage, paramFeed, inRequestEntity, index, payloadType);
         }
         paramFeed[index] = true;
     }
 
-    private int populateFeedWithAlreadyBuiltPayload(HttpCarbonMessage httpCarbonMessage, Object[] paramFeed,
-                                                    BObject inRequestEntity, int index,
+    private int populateFeedWithAlreadyBuiltPayload(Object[] paramFeed, BObject inRequestEntity, int index,
                                                     Type payloadType, Object dataSource) {
         try {
             switch (payloadType.getTag()) {
@@ -168,9 +167,8 @@ public class PayloadParam implements Parameter {
                     paramFeed[index++] = constraintValidation(dataSource);
             }
         } catch (BError ex) {
-            httpCarbonMessage.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
-            throw HttpUtil.createHttpError("data binding failed: " + HttpUtil.getPrintableErrorMsg(ex),
-                                           HttpErrorType.PAYLOAD_BINDING_LISTENER_ERROR);
+            String message = "data binding failed: " + HttpUtil.getPrintableErrorMsg(ex);
+            throw HttpUtil.createHttpStatusCodeError(PAYLOAD_BINDING_LISTENER_ERROR, message);
         }
         return index;
     }
@@ -190,12 +188,11 @@ public class PayloadParam implements Parameter {
                 paramFeed[index] = null;
                 return ++index;
             }
-            inboundMessage.setHttpStatusCode(Integer.parseInt(HttpConstants.HTTP_BAD_REQUEST));
-            if (HttpErrorType.PAYLOAD_VALIDATION_LISTENER_ERROR.getErrorName().equals(typeName)) {
+            if (PAYLOAD_VALIDATION_LISTENER_ERROR.getErrorName().equals(typeName)) {
                 throw ex;
             }
-            throw HttpUtil.createHttpError("data binding failed: " + HttpUtil.getPrintableErrorMsg(ex),
-                                           HttpErrorType.PAYLOAD_BINDING_LISTENER_ERROR);
+            String message = "data binding failed: " + HttpUtil.getPrintableErrorMsg(ex);
+            throw HttpUtil.createHttpStatusCodeError(PAYLOAD_BINDING_LISTENER_ERROR, message);
         }
     }
 
@@ -204,9 +201,8 @@ public class PayloadParam implements Parameter {
             Object result = Constraints.validate(payloadBuilderValue,
                                                  ValueCreator.createTypedescValue(this.customParameterType));
             if (result instanceof BError) {
-                throw HttpUtil.createHttpError(
-                        "payload validation failed: " + HttpUtil.getPrintableErrorMsg((BError) result),
-                        HttpErrorType.PAYLOAD_VALIDATION_LISTENER_ERROR);
+                String message = "payload validation failed: " + HttpUtil.getPrintableErrorMsg((BError) result);
+                throw HttpUtil.createHttpStatusCodeError(PAYLOAD_VALIDATION_LISTENER_ERROR, message);
             }
         }
         return payloadBuilderValue;

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/builder/BinaryPayloadBuilder.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/builder/BinaryPayloadBuilder.java
@@ -61,8 +61,8 @@ public class BinaryPayloadBuilder extends AbstractPayloadBuilder {
                 }
             }
         }
-        throw HttpUtil.createHttpError("incompatible type found: '" + payloadType.toString() + "'",
-                                       HttpErrorType.PAYLOAD_BINDING_LISTENER_ERROR);
+        String message = "incompatible type found: '" + payloadType.toString() + "'";
+        throw HttpUtil.createHttpStatusCodeError(HttpErrorType.PAYLOAD_BINDING_LISTENER_ERROR, message);
     }
 
     private Object createValue(BObject entity, boolean readonly) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/builder/StringPayloadBuilder.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/builder/StringPayloadBuilder.java
@@ -71,7 +71,7 @@ public class StringPayloadBuilder extends AbstractPayloadBuilder {
                 }
             }
         }
-        throw HttpUtil.createHttpError("incompatible type found: '" + payloadType.toString() + "'",
-                                       HttpErrorType.PAYLOAD_BINDING_LISTENER_ERROR);
+        String message = "incompatible type found: '" + payloadType.toString() + "'";
+        throw HttpUtil.createHttpStatusCodeError(HttpErrorType.PAYLOAD_BINDING_LISTENER_ERROR, message);
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/builder/XmlPayloadBuilder.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/builder/XmlPayloadBuilder.java
@@ -54,7 +54,7 @@ public class XmlPayloadBuilder extends AbstractPayloadBuilder {
             }
             return bxml;
         }
-        throw HttpUtil.createHttpError("incompatible type found: '" + payloadType.toString() + "'",
-                                       HttpErrorType.PAYLOAD_BINDING_LISTENER_ERROR);
+        String message = "incompatible type found: '" + payloadType.toString() + "'";
+        throw HttpUtil.createHttpStatusCodeError(HttpErrorType.PAYLOAD_BINDING_LISTENER_ERROR, message);
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/converter/StringToByteArrayConverter.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/converter/StringToByteArrayConverter.java
@@ -43,8 +43,8 @@ public class StringToByteArrayConverter {
             byte[] values = dataSource.getValue().getBytes(StandardCharsets.UTF_8);
             return readonly ? createReadonlyArrayValue(values) : createArrayValue(values);
         }
-        throw HttpUtil.createHttpError("incompatible array element type found: '" + elementType.toString() + "'",
-                                       HttpErrorType.PAYLOAD_BINDING_LISTENER_ERROR);
+        String message = "incompatible array element type found: '" + elementType.toString() + "'";
+        throw HttpUtil.createHttpStatusCodeError(HttpErrorType.PAYLOAD_BINDING_LISTENER_ERROR, message);
     }
 
     private StringToByteArrayConverter() {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/converter/UrlEncodedStringToMapConverter.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/converter/UrlEncodedStringToMapConverter.java
@@ -56,8 +56,8 @@ public class UrlEncodedStringToMapConverter {
             }
             return formParamMap;
         }
-        throw HttpUtil.createHttpError("incompatible type found: '" + type.toString() + "'",
-                                       HttpErrorType.PAYLOAD_BINDING_LISTENER_ERROR);
+        String message = "incompatible type found: '" + type.toString() + "'";
+        throw HttpUtil.createHttpStatusCodeError(HttpErrorType.PAYLOAD_BINDING_LISTENER_ERROR, message);
     }
 
     private static BMap<BString, Object> getFormParamMap(Object stringDataSource) {

--- a/native/src/main/java/io/ballerina/stdlib/http/uri/URIUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/uri/URIUtil.java
@@ -125,9 +125,9 @@ public class URIUtil {
             for (int i = 1; i < splitPathSegment.length; i++) {
                 String[] splitMatrixParam = splitPathSegment[i].split("=");
                 if (splitMatrixParam.length != 2) {
-                    inboundReqMsg.setHttpStatusCode(400);
-                    throw HttpUtil.createHttpError(String.format("found non-matrix parameter '%s' in path '%s'",
-                                                   splitPathSegment[i], path), HttpErrorType.SERVICE_DISPATCHING_ERROR);
+                    String message = String.format("found non-matrix parameter '%s' in path '%s'",
+                            splitPathSegment[i], path);
+                    throw HttpUtil.createHttpStatusCodeError(HttpErrorType.BAD_MATRIX_PARAMS_ERROR, message);
                 }
                 segmentMatrixParams.put(splitMatrixParam[0], splitMatrixParam[1]);
             }


### PR DESCRIPTION
## Purpose

> $Subject

Related to [`Rethink/Reorganising HTTP error structure #4101`](https://github.com/ballerina-platform/ballerina-standard-library/issues/4101)

## Examples

```bal
type Error distinct error;

type ErrorInfo record {|
    string timeStamp;
    string message;
|};

type ErrorDetails record {|
    *http:ErrorDetail;
    ErrorInfo body;
|};

type UserNotFoundError Error & http:NotFoundError & error<ErrorDetails>;

type UserNameAlreadyExistError Error & http:ConflictError & error<ErrorDetails>;

type BadUserError Error & http:BadRequestError & error<ErrorDetails>;


service on new http:Listener(9090) {

    resource function get users/[int id]() returns User|UserNotFoundError {

        return getUser(id);
    }

    resource function post users(@http:Payload readonly & UserWithoutId user)
            returns User|UserNameAlreadyExistError|BadUserError {

        return addUser(user);
    }

    resource function 'default [string... path]() returns http:NotFoundError {

        return error http:NotFoundError("Resource not found", body = {
            timeStamp: getCurrentTimeStamp(),
            message: string `Resource not found for path: /${string:'join("/", ...path)}`
        });
    }
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] <s>Checked native-image compatibility</s>
