### PR TITLE
Make panic behaviour consistent in HTTP services

### DIFF
--- a/ballerina/auth_desugar.bal
+++ b/ballerina/auth_desugar.bal
@@ -42,12 +42,12 @@ public isolated function authenticateResource(Service serviceRef, string methodN
     if header is string {
         Unauthorized|Forbidden? result = tryAuthenticate(<ListenerAuthConfig[]>authConfig, header);
         if result is Unauthorized {
-            panic error ListenerAuthnError("");
+            panic error InternalListenerAuthnError("");
         } else if result is Forbidden {
-            panic error ListenerAuthzError("");
+            panic error InternalListenerAuthzError("");
         }
     } else {
-        panic error ListenerAuthnError("");
+        panic error InternalListenerAuthnError("");
     }
 }
 

--- a/ballerina/http_errors.bal
+++ b/ballerina/http_errors.bal
@@ -103,6 +103,12 @@ public type ListenerAuthnError distinct UnauthorizedError & ListenerAuthError;
 # Defines the authorization error types that returned from listener.
 public type ListenerAuthzError distinct ForbiddenError & ListenerAuthError;
 
+# Defined for internal use when panicing from the auth_desugar
+type InternalListenerAuthnError distinct UnauthorizedError & ListenerAuthError;
+
+# Defined for internal use when panicing from the auth_desugar
+type InternalListenerAuthzError distinct ForbiddenError & ListenerAuthError;
+
 # Defines the client error types that returned while sending outbound request.
 public type OutboundRequestError distinct ClientError;
 

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [HTTP compiler does not report error for returning record with object](https://github.com/ballerina-platform/ballerina-standard-library/issues/4045)
 - [Returning 500 when the upstream server is unavailable](https://github.com/ballerina-platform/ballerina-standard-library/issues/2929)
 - [Encoded url path with special characters is not working as expected](https://github.com/ballerina-platform/ballerina-standard-library/issues/4033)
+- [Make panic behavior consistent with interceptor and non-interceptor services](https://github.com/ballerina-platform/ballerina-standard-library/issues/4250)
 
 ### Added
 - [Make @http:Payload annotation optional for post, put and patch](https://github.com/ballerina-platform/ballerina-standard-library/issues/3276)

--- a/native/spotbugs-exclude.xml
+++ b/native/spotbugs-exclude.xml
@@ -50,11 +50,15 @@
         <Bug pattern="UPM_UNCALLED_PRIVATE_METHOD" />
     </Match>
     <Match>
-        <Class name="io.ballerina.stdlib.http.api.HttpCallableUnitCallback$1" />
+        <Class name="io.ballerina.stdlib.http.api.HttpCallableUnitCallback" />
         <Bug pattern="DM_EXIT" />
     </Match>
     <Match>
-        <Class name="io.ballerina.stdlib.http.api.HttpResponseInterceptorUnitCallback$1" />
+        <Class name="io.ballerina.stdlib.http.api.HttpResponseInterceptorUnitCallback" />
+        <Bug pattern="DM_EXIT" />
+    </Match>
+    <Match>
+        <Class name="io.ballerina.stdlib.http.api.HttpRequestInterceptorUnitCallback" />
         <Bug pattern="DM_EXIT" />
     </Match>
     <Match>

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
@@ -125,10 +125,6 @@ public class HttpCallableUnitCallback implements Callback {
             public void notifySuccess(Object result) {
                 stopObserverContext();
                 printStacktraceIfError(result);
-                Object isPanic = requestMessage.getProperty(HttpConstants.INTERCEPTOR_SERVICE_PANIC_ERROR);
-                if (Objects.nonNull(isPanic) && (boolean) isPanic) {
-                    System.exit(1);
-                }
             }
 
             @Override
@@ -154,15 +150,14 @@ public class HttpCallableUnitCallback implements Callback {
     @Override
     public void notifyFailure(BError error) { // handles panic and check_panic
         cleanupRequestMessage();
-        // Skipping the panics from internal authentication/authorization.
-        if (!error.getType().getName().equals(HttpErrorType.INTERNAL_LISTENER_AUTHN_ERROR.getErrorName())
-                && !error.getType().getName().equals(HttpErrorType.INTERNAL_LISTENER_AUTHZ_ERROR.getErrorName())) {
-            requestMessage.setProperty(HttpConstants.INTERCEPTOR_SERVICE_PANIC_ERROR, true);
-        }
-        if (alreadyResponded(error)) {
+        // Allow the panics from internal authentication/authorization to be handled by the interceptors.
+        if (error.getType().getName().equals(HttpErrorType.INTERNAL_LISTENER_AUTHN_ERROR.getErrorName())
+                || error.getType().getName().equals(HttpErrorType.INTERNAL_LISTENER_AUTHZ_ERROR.getErrorName())) {
+            invokeErrorInterceptors(error, true);
             return;
         }
-        invokeErrorInterceptors(error, true);
+        sendFailureResponse(error);
+        System.exit(1);
     }
 
     public void invokeErrorInterceptors(BError error, boolean printError) {
@@ -178,7 +173,7 @@ public class HttpCallableUnitCallback implements Callback {
         HttpUtil.handleFailure(requestMessage, error, true);
     }
 
-    private void cleanupRequestMessage() {
+    public void cleanupRequestMessage() {
         requestMessage.waitAndReleaseAllEntities();
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
@@ -155,8 +155,8 @@ public class HttpCallableUnitCallback implements Callback {
     public void notifyFailure(BError error) { // handles panic and check_panic
         cleanupRequestMessage();
         // Skipping the panics from internal authentication/authorization.
-        if (!error.getType().getName().equals(HttpErrorType.LISTENER_AUTHN_ERROR.getErrorName())
-                && !error.getType().getName().equals(HttpErrorType.LISTENER_AUTHZ_ERROR.getErrorName())) {
+        if (!error.getType().getName().equals(HttpErrorType.INTERNAL_LISTENER_AUTHN_ERROR.getErrorName())
+                && !error.getType().getName().equals(HttpErrorType.INTERNAL_LISTENER_AUTHZ_ERROR.getErrorName())) {
             requestMessage.setProperty(HttpConstants.INTERCEPTOR_SERVICE_PANIC_ERROR, true);
         }
         if (alreadyResponded(error)) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -380,7 +380,6 @@ public class HttpConstants {
     public static final String REQUEST_INTERCEPTOR_INDEX = "REQUEST_INTERCEPTOR_INDEX";
     public static final String RESPONSE_INTERCEPTOR_INDEX = "RESPONSE_INTERCEPTOR_INDEX";
     public static final String INTERCEPTOR_SERVICE_ERROR = "INTERCEPTOR_SERVICE_ERROR";
-    public static final String INTERCEPTOR_SERVICE_PANIC_ERROR = "INTERCEPTOR_SERVICE_PANIC_ERROR";
     public static final String WAIT_FOR_FULL_REQUEST = "WAIT_FOR_FULL_REQUEST";
     public static final String HTTP_NORMAL = "Normal";
     public static final String REQUEST_INTERCEPTOR = "RequestInterceptor";

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpErrorType.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpErrorType.java
@@ -77,8 +77,8 @@ public enum HttpErrorType {
     SERVICE_NOT_FOUND_ERROR("ServiceNotFoundError"),
     BAD_MATRIX_PARAMS_ERROR("BadMatrixParamError"),
     RESOURCE_DISPATCHING_SERVER_ERROR("ResourceDispatchingServerError"),
-    LISTENER_AUTHZ_ERROR("ListenerAuthzError"),
-    LISTENER_AUTHN_ERROR("ListenerAuthnError"),
+    INTERNAL_LISTENER_AUTHZ_ERROR("InternalListenerAuthzError"),
+    INTERNAL_LISTENER_AUTHN_ERROR("InternalListenerAuthnError"),
     CLIENT_CONNECTOR_ERROR("ClientConnectorError");
 
     private final String errorName;

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpResponseInterceptorUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpResponseInterceptorUnitCallback.java
@@ -30,8 +30,6 @@ import io.ballerina.stdlib.http.api.nativeimpl.ModuleUtils;
 import io.ballerina.stdlib.http.api.nativeimpl.connection.Respond;
 import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
 
-import java.util.Objects;
-
 /**
  * {@code HttpResponseInterceptorUnitCallback} is the responsible for acting on notifications received from Ballerina
  * side when a response interceptor service is invoked.
@@ -70,7 +68,9 @@ public class HttpResponseInterceptorUnitCallback extends HttpCallableUnitCallbac
 
     @Override
     public void notifyFailure(BError error) { // handles panic and check_panic
-        invokeErrorInterceptors(error, false);
+        cleanupRequestMessage();
+        sendFailureResponse(error);
+        System.exit(1);
     }
 
     public void invokeErrorInterceptors(BError error, boolean printError) {
@@ -79,10 +79,6 @@ public class HttpResponseInterceptorUnitCallback extends HttpCallableUnitCallbac
             error.printStackTrace();
         }
         returnErrorResponse(error);
-    }
-
-    public void sendFailureResponse(BError error) {
-        HttpUtil.handleFailure(requestMessage, error, false);
     }
 
     private void printStacktraceIfError(Object result) {
@@ -169,10 +165,6 @@ public class HttpResponseInterceptorUnitCallback extends HttpCallableUnitCallbac
                 stopObserverContext();
                 dataContext.notifyOutboundResponseStatus(null);
                 printStacktraceIfError(result);
-                Object isPanic = requestMessage.getProperty(HttpConstants.INTERCEPTOR_SERVICE_PANIC_ERROR);
-                if (Objects.nonNull(isPanic) && (boolean) isPanic) {
-                    System.exit(1);
-                }
             }
 
             @Override


### PR DESCRIPTION
## Purpose

> $Subject

> Fixes : [`[HTTP] Panic behaviour is inconsistent with the interceptors`](https://github.com/ballerina-platform/ballerina-standard-library/issues/4250)

## Examples

N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] ~Added tests~(Tested manually, see the comment below)
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
