### PR TITLE
Add new properties to the build scripts

### DIFF
--- a/.github/workflows/build-with-bal-test-native.yml
+++ b/.github/workflows/build-with-bal-test-native.yml
@@ -15,6 +15,11 @@ on:
                 description: Default native-image options
                 required: false
                 default: ''
+            build_properties:
+                description: Additional build properties
+                required: false
+                default: ''
+
     schedule:
         -   cron: '30 18 * * *'
 
@@ -27,8 +32,6 @@ jobs:
             lang_tag: ${{ inputs.lang_tag }}
             lang_version: ${{ inputs.lang_version }}
             native_image_options: '-J-Xmx7G ${{ inputs.native_image_options }}'
-            additional_ubuntu_build_flags: '-x :http-native:test -x :http-compiler-plugin-tests:test'
-            # additional_windows_build_flags: '-x :http-native:test -x :http-compiler-plugin-tests:test'
-            # TODO : Enable after fixing this issue : https://github.com/ballerina-platform/ballerina-lang/issues/38882
-            additional_windows_build_flags: '-x test'
+            additional_ubuntu_build_flags: '-x :http-native:test -x :http-compiler-plugin-tests:test ${{ inputs.build_properties }}'
+            additional_windows_build_flags: '-x :http-native:test -x :http-compiler-plugin-tests:test ${{ inputs.build_properties }}'
             java_tool_options: '-Dfile.encoding=UTF8'

--- a/ballerina-tests/build.gradle
+++ b/ballerina-tests/build.gradle
@@ -283,15 +283,18 @@ task stopLdapServer() {
     }
 }
 
-ballerinaTest.finalizedBy stopLdapServer
-ballerinaTest.dependsOn startLdapServer
-test.dependsOn ballerinaTest
-build.dependsOn test
+task deleteDependencyTomlFile {
+    if (project.hasProperty("deleteDependencies")) {
+        delete "${project.projectDir}/${testCommonPackage}/Dependencies.toml"
 
-tasks.register('cleanDependencies') {
-    delete "${project.projectDir}/${testCommonPackage}/Dependencies.toml"
-
-    testPackages.each { testPackage ->
-        delete "${project.projectDir}/${testPackage}/Dependencies.toml"
+        testPackages.each { testPackage ->
+            delete "${project.projectDir}/${testPackage}/Dependencies.toml"
+        }
     }
 }
+
+ballerinaTest.finalizedBy stopLdapServer
+ballerinaTest.dependsOn startLdapServer
+ballerinaTest.dependsOn deleteDependencyTomlFile
+test.dependsOn ballerinaTest
+build.dependsOn test

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -216,12 +216,19 @@ publishing {
     }
 }
 
+task deleteDependencyTomlFiles {
+    if (project.hasProperty("deleteDependencies")) {
+        delete "${project.projectDir}/Dependencies.toml"
+    }
+}
+
 updateTomlFiles.dependsOn copyStdlibs
 
 build.dependsOn "generatePomFileForMavenPublication"
 build.dependsOn ":${packageName}-native:build"
 build.dependsOn ":${packageName}-test-utils:build"
 build.dependsOn ":${packageName}-compiler-plugin:build"
+build.dependsOn deleteDependencyTomlFiles
 build.finalizedBy ":http-ballerina-tests:build"
 test.dependsOn ":${packageName}-native:build"
 test.dependsOn ":${packageName}-compiler-plugin:build"


### PR DESCRIPTION
## Purpose

1. Introduce a property in the gradle build to delete all the `Dependencies.toml` files in the module. This would be useful when updating the minor versions of the dependencies.
   - Usage: `./gradlew build -PdeleteDependencies `

2. Add support for running particular test package with `GraalVM Check` by introducing a new optional argument in the workflow.
    - Usage: set the value for `Additional build properties` with `-PbalTests=<>` or `-PskipBalTests=<>`

## Examples

N/A

## Checklist
- [ ] ~Linked to an issue~
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
