### PR TITLE
Rewrite the logic for populating resource parameter

### DIFF
--- a/ballerina-tests/http-dispatching-tests/tests/header_params_binding_test.bal
+++ b/ballerina-tests/http-dispatching-tests/tests/header_params_binding_test.bal
@@ -1,0 +1,123 @@
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+import ballerina/http;
+import ballerina/http_test_common as common;
+
+final http:Client resourceHeaderParamBindingClient = check new("http://localhost:" + resourceParamBindingTestPort.toString());
+
+@test:Config {}
+function testHeaderParamBindingCase1() returns error? {
+    string resPayload = check resourceHeaderParamBindingClient->/header/case1({header: "value1"});
+    test:assertEquals(resPayload, "value1");
+
+    resPayload = check resourceHeaderParamBindingClient->/header/case1({header: "value2"});
+    test:assertEquals(resPayload, "value2");
+
+    http:Response res = check resourceHeaderParamBindingClient->/header/case1({header: "value3"});
+    test:assertEquals(res.statusCode, 400);
+}
+
+@test:Config {}
+function testHeaderParamBindingCase2() returns error? {
+    decimal resPayload = check resourceHeaderParamBindingClient->/header/case2({header: "1.234"});
+    test:assertEquals(resPayload, 1.234d);
+
+    resPayload = check resourceHeaderParamBindingClient->/header/case2;
+    test:assertEquals(resPayload, 0.0d);
+
+    http:Response res = check resourceHeaderParamBindingClient->/header/case2({header: "1.11"});
+    test:assertEquals(res.statusCode, 400);
+}
+
+@test:Config {}
+function testHeaderParamBindingCase3() returns error? {
+    string resPayload = check resourceHeaderParamBindingClient->/header/case3;
+    test:assertEquals(resPayload, "default");
+
+    resPayload = check resourceHeaderParamBindingClient->/header/case3({header: "value1"});
+    test:assertEquals(resPayload, "value1");
+
+    http:Response res = check resourceHeaderParamBindingClient->/header/case3({header: "value5"});
+    test:assertEquals(res.statusCode, 400);
+}
+
+@test:Config {}
+function testHeaderParamBindingCase4() returns error? {
+    string resPayload = check resourceHeaderParamBindingClient->/header/case4({header: "VALUE2"});
+    test:assertEquals(resPayload, "VALUE2");
+
+    http:Response res = check resourceHeaderParamBindingClient->/header/case4({header: "VALUE9"});
+    test:assertEquals(res.statusCode, 400);
+}
+
+@test:Config {}
+function testHeaderParamBindingCase5() returns error? {
+    string resPayload = check resourceHeaderParamBindingClient->/header/case5({header: "VALUE4"});
+    test:assertEquals(resPayload, "VALUE4");
+
+    resPayload = check resourceHeaderParamBindingClient->/header/case5({header: "VALUE1"});
+    test:assertEquals(resPayload, "EnumValue: VALUE1");
+
+    http:Response res = check resourceHeaderParamBindingClient->/header/case5({header: "VALUE9"});
+    test:assertEquals(res.statusCode, 400);
+}
+
+@test:Config {}
+function testHeaderParamBindingCase6() returns error? {
+    http:Response res = check resourceHeaderParamBindingClient->/header/case6({header: ["1", "2", "3", "2", "1"]});
+    test:assertEquals(res.statusCode, 200);
+    common:assertTextPayload(res.getTextPayload(), "[1,2,3,2,1]");
+
+    res = check resourceHeaderParamBindingClient->/header/case6({header: ["1", "2", "5"]});
+    test:assertEquals(res.statusCode, 400);
+}
+
+@test:Config {}
+function testHeaderParamBindingCase7() returns error? {
+    http:Response res = check resourceHeaderParamBindingClient->/header/case7;
+    test:assertEquals(res.statusCode, 200);
+    common:assertTextPayload(res.getTextPayload(), "[\"default\"]");
+
+    res = check resourceHeaderParamBindingClient->/header/case7({header: ["value1", "value2", "value1"]});
+    test:assertEquals(res.statusCode, 200);
+    common:assertTextPayload(res.getTextPayload(), "[\"value1\", \"value2\", \"value1\"]");
+
+    res = check resourceHeaderParamBindingClient->/header/case7({header: ["value1", "value5", "value3"]});
+    test:assertEquals(res.statusCode, 400);
+}
+
+@test:Config {}
+function testHeaderParamBindingCase8() returns error? {
+    http:Response res = check resourceHeaderParamBindingClient->/header/case8({header: ["VALUE1", "value2", "VALUE2", "value1"]});
+    test:assertEquals(res.statusCode, 200);
+    common:assertTextPayload(res.getTextPayload(), "[\"EnumValue: VALUE1\", \"Value: value2\", \"EnumValue: VALUE2\", \"Value: value1\"]");
+
+    res = check resourceHeaderParamBindingClient->/header/case8({header: ["VALUE1", "value5", "VALUE2", "value1"]});
+    test:assertEquals(res.statusCode, 400);
+}
+
+@test:Config {}
+function testHeaderParamBindingCase9() returns error? {
+    map<string|string[]> headers = {header1: "value1", header2: "VALUE3", header3: ["1", "2", "3"], header4: ["VALUE1", "value2"]};
+    map<json> resPayload = check resourceHeaderParamBindingClient->/header/case9(headers);
+    test:assertEquals(resPayload, {header1: "value1", header2: "VALUE3", header3: [1,2,3], header4: ["VALUE1", "value2"]});
+
+    headers = {header1: "value1", header2: "VALUE3", header3: ["1", "2", "3"], header4: ["VALUE1", "value5"]};
+    http:Response res = check resourceHeaderParamBindingClient->/header/case9(headers);
+    test:assertEquals(res.statusCode, 400);
+}

--- a/ballerina-tests/http-dispatching-tests/tests/path_params_binding_test.bal
+++ b/ballerina-tests/http-dispatching-tests/tests/path_params_binding_test.bal
@@ -1,0 +1,147 @@
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+import ballerina/http;
+import ballerina/http_test_common as common;
+
+final http:Client resourcePathParamBindingClient = check new("http://localhost:" + resourceParamBindingTestPort.toString());
+
+@test:Config {}
+function testPathParamBindingCase1() returns error? {
+    string resPayload = check resourcePathParamBindingClient->/path/case1/value1;
+    test:assertEquals(resPayload, "value1", "Payload mismatched");
+
+    "value1"|"value2" value = "value2";
+    resPayload = check resourcePathParamBindingClient->/path/case1/[value];
+    test:assertEquals(resPayload, value, "Payload mismatched");
+
+    http:Response res = check resourcePathParamBindingClient->/path/case1/value3;
+    test:assertEquals(res.statusCode, 404, "Status code mismatched");
+}
+
+@test:Config {}
+function testPathParamBindingCase2() returns error? {
+    string resPayload = check resourcePathParamBindingClient->/path/case2/value1;
+    test:assertEquals(resPayload, "value1", "Payload mismatched");
+
+    Value value = "value2";
+    resPayload = check resourcePathParamBindingClient->/path/case2/[value];
+    test:assertEquals(resPayload, value, "Payload mismatched");
+
+    http:Response res = check resourcePathParamBindingClient->/path/case2/value3;
+    test:assertEquals(res.statusCode, 404, "Status code mismatched");
+}
+
+@test:Config {}
+function testPathParamBindingCase3() returns error? {
+    string resPayload = check resourcePathParamBindingClient->/path/case3/VALUE1;
+    test:assertEquals(resPayload, "VALUE1", "Payload mismatched");
+
+    EnumValue value = "VALUE2";
+    resPayload = check resourcePathParamBindingClient->/path/case3/[value];
+    test:assertEquals(resPayload, value, "Payload mismatched");
+
+    http:Response res = check resourcePathParamBindingClient->/path/case3/value;
+    test:assertEquals(res.statusCode, 404, "Status code mismatched");
+}
+
+@test:Config {}
+function testPathParamBindingCase4() returns error? {
+    http:Response res = check resourcePathParamBindingClient->/path/case4/'1/'2/'1;
+    test:assertEquals(res.statusCode, 200, "Status code mismatched");
+    common:assertTextPayload(res.getTextPayload(), "[1,2,1]");
+
+    (1|2)[] values = [2, 1, 1, 1, 2, 1];
+    res = check resourcePathParamBindingClient->/path/case4/[...values];
+    test:assertEquals(res.statusCode, 200, "Status code mismatched");
+    common:assertTextPayload(res.getTextPayload(), values.toString());
+
+    res = check resourcePathParamBindingClient->/path/case4/'1/'34;
+    test:assertEquals(res.statusCode, 404, "Status code mismatched");
+}
+
+@test:Config {}
+function testPathParamBindingCase5() returns error? {
+    Value[] resPayload = check resourcePathParamBindingClient->/path/case5/value1/value2;
+    test:assertEquals(resPayload, ["value1", "value2"], "Payload mismatched");
+
+    Value[] values = ["value2", "value1", "value1", "value1", "value2", "value1"];
+    resPayload = check resourcePathParamBindingClient->/path/case5/[...values];
+    test:assertEquals(resPayload, values, "Payload mismatched");
+
+    http:Response res = check resourcePathParamBindingClient->/path/case5/value6;
+    test:assertEquals(res.statusCode, 404, "Status code mismatched");
+}
+
+@test:Config {}
+function testPathParamBindingCase6() returns error? {
+    EnumValue[] resPayload = check resourcePathParamBindingClient->/path/case6/VALUE1/VALUE2;
+    test:assertEquals(resPayload, ["VALUE1", "VALUE2"], "Payload mismatched");
+
+    EnumValue[] values = ["VALUE2", "VALUE1", "VALUE3", "VALUE1", "VALUE2", "VALUE1"];
+    resPayload = check resourcePathParamBindingClient->/path/case6/[...values];
+    test:assertEquals(resPayload, values, "Payload mismatched");
+
+    http:Response res = check resourcePathParamBindingClient->/path/case6/VALUE6;
+    test:assertEquals(res.statusCode, 404, "Status code mismatched");
+}
+
+@test:Config {}
+function testPathParamBindingCase7() returns error? {
+    string resPayload = check resourcePathParamBindingClient->/path/case7/value1;
+    test:assertEquals(resPayload, "value1", "Payload mismatched");
+
+    EnumValue value = "VALUE2";
+    resPayload = check resourcePathParamBindingClient->/path/case7/[value];
+    test:assertEquals(resPayload, "EnumValue: " + value, "Payload mismatched");
+}
+
+@test:Config {}
+function testPathParamBindingCase8() returns error? {
+    string resPayload = check resourcePathParamBindingClient->/path/case8/value3;
+    test:assertEquals(resPayload, "value3", "Payload mismatched");
+
+    EnumValue value = "VALUE2";
+    resPayload = check resourcePathParamBindingClient->/path/case8/[value];
+    test:assertEquals(resPayload, "EnumValue: " + value, "Payload mismatched");
+
+    http:Response res = check resourcePathParamBindingClient->/path/case8/value5;
+    test:assertEquals(res.statusCode, 404, "Status code mismatched");
+}
+
+@test:Config {}
+function testPathParamBindingCase9() returns error? {
+    string resPayload = check resourcePathParamBindingClient->/path/case9/value1;
+    test:assertEquals(resPayload, "Value: value1", "Payload mismatched");
+
+    EnumValue value = "VALUE2";
+    resPayload = check resourcePathParamBindingClient->/path/case9/[value];
+    test:assertEquals(resPayload, "EnumValue: " + value, "Payload mismatched");
+
+    http:Response res = check resourcePathParamBindingClient->/path/case9/value5;
+    test:assertEquals(res.statusCode, 404, "Status code mismatched");
+}
+
+
+@test:Config {}
+function testPathParamBindingCase10() returns error? {
+    string[] resPayload = check resourcePathParamBindingClient->/path/case10/VALUE1/value2/VALUE3;
+    test:assertEquals(resPayload, ["EnumValue: VALUE1", "Value: value2", "EnumValue: VALUE3"], "Payload mismatched");
+
+    http:Response res = check resourcePathParamBindingClient->/path/case10/value1/value9/value3;
+    test:assertEquals(res.statusCode, 404, "Status code mismatched");
+}

--- a/ballerina-tests/http-dispatching-tests/tests/query_params_binding_test.bal
+++ b/ballerina-tests/http-dispatching-tests/tests/query_params_binding_test.bal
@@ -1,0 +1,154 @@
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+import ballerina/url;
+import ballerina/http;
+
+final http:Client resourceQueryParamBindingClient = check new("http://localhost:" + resourceParamBindingTestPort.toString());
+
+@test:Config {}
+function testQueryParamBindingCase1() returns error? {
+    "value1"|"value2" value = "value1";
+    string resPayload = check resourceQueryParamBindingClient->/query/case1(query = value);
+    test:assertEquals(resPayload, value);
+
+    resPayload = check resourceQueryParamBindingClient->/query/case1(query = "value2");
+    test:assertEquals(resPayload, "value2");
+
+    http:Response res = check resourceQueryParamBindingClient->/query/case1(query = "value3");
+    test:assertEquals(res.statusCode, 400, "Status code mismatched");
+}
+
+@test:Config {}
+function testQueryParamBindingCase2() returns error? {
+    1.2|2.4 value = 1.2;
+    float resPayload = check resourceQueryParamBindingClient->/query/case2(query = value);
+    test:assertEquals(resPayload, value);
+
+    resPayload = check resourceQueryParamBindingClient->/query/case2;
+    test:assertEquals(resPayload, 0.0);
+
+    resPayload = check resourceQueryParamBindingClient->/query/case2(query = 3.6);
+    test:assertEquals(resPayload, 3.6);
+
+    http:Response res = check resourceQueryParamBindingClient->/query/case2(query = "value3");
+    test:assertEquals(res.statusCode, 400, "Status code mismatched");
+}
+
+@test:Config {}
+function testQueryParamBindingCase3() returns error? {
+    string resPayload = check resourceQueryParamBindingClient->/query/case3;
+    test:assertEquals(resPayload, "value2");
+
+    resPayload = check resourceQueryParamBindingClient->/query/case3(query = "value1");
+    test:assertEquals(resPayload, "value1");
+
+    http:Response res = check resourceQueryParamBindingClient->/query/case3(query = "value");
+    test:assertEquals(res.statusCode, 400, "Status code mismatched");
+}
+
+@test:Config {}
+function testQueryParamBindingCase4() returns error? {
+    string resPayload = check resourceQueryParamBindingClient->/query/case4(query = "VALUE1");
+    test:assertEquals(resPayload, "VALUE1");
+
+    EnumValue value = "VALUE3";
+    resPayload = check resourceQueryParamBindingClient->/query/case4(query = value);
+    test:assertEquals(resPayload, value);
+
+    http:Response res = check resourceQueryParamBindingClient->/query/case4(query = "value");
+    test:assertEquals(res.statusCode, 400, "Status code mismatched");
+}
+
+@test:Config {}
+function testQueryParamBindingCase5() returns error? {
+    string resPayload = check resourceQueryParamBindingClient->/query/case5(query = "VALUE2");
+    test:assertEquals(resPayload, "EnumValue: VALUE2");
+
+    resPayload = check resourceQueryParamBindingClient->/query/case5(query = "VALUE4");
+    test:assertEquals(resPayload, "VALUE4");
+
+    http:Response res = check resourceQueryParamBindingClient->/query/case5(query = "VALUE6");
+    test:assertEquals(res.statusCode, 400, "Status code mismatched");
+}
+
+@test:Config {}
+function testQueryParamBindingCase6() returns error? {
+    string[] resPayload = check resourceQueryParamBindingClient->/query/case6;
+    test:assertEquals(resPayload, ["default"]);
+
+    Value[] values = ["value2", "value1"];
+    resPayload = check resourceQueryParamBindingClient->/query/case6(query = values);
+    test:assertEquals(resPayload, values);
+
+    http:Response res = check resourceQueryParamBindingClient->/query/case6(query = ["value1", "value2", "value3"]);
+    test:assertEquals(res.statusCode, 400, "Status code mismatched");
+}
+
+@test:Config {}
+function testQueryParamBindingCase7() returns error? {
+    EnumValue[] values = ["VALUE2", "VALUE1"];
+    string[] resPayload = check resourceQueryParamBindingClient->/query/case7(query = values);
+    test:assertEquals(resPayload, values);
+
+    http:Response res = check resourceQueryParamBindingClient->/query/case7(query = ["value1", "value2"]);
+    test:assertEquals(res.statusCode, 400, "Status code mismatched");
+}
+
+@test:Config {}
+function testQueryParamBindingCase8() returns error? {
+    UnionFiniteType[] values = ["VALUE2", "value1", "VALUE1", "value2"];
+    string[] resPayload = check resourceQueryParamBindingClient->/query/case8(query = values);
+    test:assertEquals(resPayload, ["EnumValue: VALUE2","Value: value1","EnumValue: VALUE1","Value: value2"]);
+
+    http:Response res = check resourceQueryParamBindingClient->/query/case8(query = ["value1", "value3", "VALUE3"]);
+    test:assertEquals(res.statusCode, 400, "Status code mismatched");
+}
+
+@test:Config {}
+function testQueryParamBindingCase9() returns error? {
+    QueryRecord value1 = {enumValue: "VALUE3", value: "value1"};
+    string encodedValue = check url:encode(value1.toJsonString(), "UTF-8");
+    map<json> resPayload = check resourceQueryParamBindingClient->/query/case9(query = encodedValue);
+    test:assertEquals(resPayload, {...value1, 'type: "QueryRecord"});
+
+    record{|never 'type?; json...;|} value2 = {"enumValue": "VALUE6", "value": "value1"};
+    encodedValue = check url:encode(value2.toJsonString(), "UTF-8");
+    resPayload = check resourceQueryParamBindingClient->/query/case9(query = encodedValue);
+    test:assertEquals(resPayload, {...value2, 'type: "map<json>"});
+
+    resPayload = check resourceQueryParamBindingClient->/query/case9();
+    test:assertEquals(resPayload, {'type: "default"});
+
+    http:Response res = check resourceQueryParamBindingClient->/query/case9(query = "value");
+    test:assertEquals(res.statusCode, 400, "Status code mismatched");
+}
+
+@test:Config {}
+function testQueryParamBindingCase10() returns error? {
+    QueryRecord value1 = {enumValue: "VALUE3", value: "value1"};
+    record{|never 'type?; json...;|} value2 = {"enumValue": "VALUE6", "value": "value1"};
+    string encodedValue1 = check url:encode(value1.toJsonString(), "UTF-8");
+    string encodedValue2 = check url:encode(value2.toJsonString(), "UTF-8");
+    string[] encodedValues = [encodedValue2, encodedValue1];
+    map<json>[] resPayload = check resourceQueryParamBindingClient->/query/case10(query = encodedValues);
+    test:assertEquals(resPayload, [{...value2, 'type: "map<json>"}, {...value1, 'type: "QueryRecord"}]);
+
+    http:Response res = check resourceQueryParamBindingClient->/query/case10(query = "value");
+    test:assertEquals(res.statusCode, 400, "Status code mismatched");
+}
+

--- a/ballerina-tests/http-dispatching-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-dispatching-tests/tests/test_service_ports.bal
@@ -31,3 +31,5 @@ const int headerParamBindingIdealTestPort = 9581;
 
 const int pathParamCheckTestPort = 9565;
 
+const int resourceParamBindingTestPort = 9566;
+

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Expose `http:Request` in the response interceptor path](https://github.com/ballerina-platform/ballerina-standard-library/issues/3964)
 - [Allow configuring an interceptor pipeline with a single interceptor](https://github.com/ballerina-platform/ballerina-standard-library/issues/3969)
+- [Add runtime support for type referenced type in path parameters](https://github.com/ballerina-platform/ballerina-standard-library/issues/4372)
+- [Add finite type support for query, header and path parameters](https://github.com/ballerina-platform/ballerina-standard-library/issues/4374)
 
 ### Changed
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -774,4 +774,12 @@ public class CompilerPluginTest {
                 " 'string','int','float','decimal','boolean' types or a rest parameter with one of the above types",
                 HTTP_145);
     }
+
+    @Test
+    public void testResourceSignatureParamValidations() {
+        Package currentPackage = loadPackage("sample_package_38");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errorCount(), 36);
+    }
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -781,5 +781,101 @@ public class CompilerPluginTest {
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         Assert.assertEquals(diagnosticResult.errorCount(), 36);
+        assertError(diagnosticResult, 0, "invalid union type of header param 'header': expected one of the" +
+                " 'string','int','float','decimal','boolean' types, an array of the above types or a record which " +
+                "consists of the above types can only be union with '()'. Eg: string|() or string[]|()", HTTP_110);
+        assertError(diagnosticResult, 1, "invalid type of header param 'header': expected one of the following" +
+                " types is expected: 'string','int','float','decimal','boolean', an array of the above types or a " +
+                "record which consists of the above types", HTTP_109);
+        assertError(diagnosticResult, 2, "invalid union type of header param 'header': expected one of the" +
+                " 'string','int','float','decimal','boolean' types, an array of the above types or a record which " +
+                "consists of the above types can only be union with '()'. Eg: string|() or string[]|()", HTTP_110);
+        assertError(diagnosticResult, 3, "invalid type of header param 'header': expected one of the following" +
+                " types is expected: 'string','int','float','decimal','boolean', an array of the above types or a " +
+                "record which consists of the above types", HTTP_109);
+        assertError(diagnosticResult, 4, "invalid type of header param 'header': expected one of the following" +
+                " types is expected: 'string','int','float','decimal','boolean', an array of the above types or a " +
+                "record which consists of the above types", HTTP_109);
+        assertError(diagnosticResult, 5, "invalid union type of header param 'header': expected one of the" +
+                " 'string','int','float','decimal','boolean' types, an array of the above types or a record which " +
+                "consists of the above types can only be union with '()'. Eg: string|() or string[]|()", HTTP_110);
+        assertError(diagnosticResult, 6, "invalid type of header param 'header': expected one of the following" +
+                " types is expected: 'string','int','float','decimal','boolean', an array of the above types or a " +
+                "record which consists of the above types", HTTP_109);
+        assertError(diagnosticResult, 7, "invalid type of header param 'header': expected one of the following" +
+                " types is expected: 'string','int','float','decimal','boolean', an array of the above types or a " +
+                "record which consists of the above types", HTTP_109);
+        assertError(diagnosticResult, 8, "invalid type of header param 'header': expected one of the following" +
+                " types is expected: 'string','int','float','decimal','boolean', an array of the above types or a " +
+                "record which consists of the above types", HTTP_109);
+        assertError(diagnosticResult, 9, "invalid type of header param 'header': expected one of the following" +
+                " types is expected: 'string','int','float','decimal','boolean', an array of the above types or a " +
+                "record which consists of the above types", HTTP_109);
+        assertError(diagnosticResult, 10, "invalid union type of header param 'header': expected one of the" +
+                " 'string','int','float','decimal','boolean' types, an array of the above types or a record which " +
+                "consists of the above types can only be union with '()'. Eg: string|() or string[]|()", HTTP_110);
+        assertError(diagnosticResult, 11, "invalid union type of header param 'header1': expected one of the" +
+                " 'string','int','float','decimal','boolean' types, an array of the above types or a record which " +
+                "consists of the above types can only be union with '()'. Eg: string|() or string[]|()", HTTP_110);
+        assertError(diagnosticResult, 12, "invalid type of header param 'header2': expected one of the following" +
+                " types is expected: 'string','int','float','decimal','boolean', an array of the above types or a " +
+                "record which consists of the above types", HTTP_109);
+        assertError(diagnosticResult, 13, "invalid union type of header param 'header3': expected one of the" +
+                " 'string','int','float','decimal','boolean' types, an array of the above types or a record which " +
+                "consists of the above types can only be union with '()'. Eg: string|() or string[]|()", HTTP_110);
+        assertError(diagnosticResult, 14, "invalid type of header param 'header4': expected one of the following" +
+                " types is expected: 'string','int','float','decimal','boolean', an array of the above types or a " +
+                "record which consists of the above types", HTTP_109);
+        assertError(diagnosticResult, 15, "invalid type of header param 'header5': expected one of the following" +
+                " types is expected: 'string','int','float','decimal','boolean', an array of the above types or a " +
+                "record which consists of the above types", HTTP_109);
+        assertError(diagnosticResult, 16, "invalid union type of header param 'header6': expected one of the" +
+                " 'string','int','float','decimal','boolean' types, an array of the above types or a record which " +
+                "consists of the above types can only be union with '()'. Eg: string|() or string[]|()", HTTP_110);
+        assertError(diagnosticResult, 17, "invalid type of header param 'header7': expected one of the following" +
+                " types is expected: 'string','int','float','decimal','boolean', an array of the above types or a " +
+                "record which consists of the above types", HTTP_109);
+        assertError(diagnosticResult, 18, "invalid type of header param 'header9': expected one of the following" +
+                " types is expected: 'string','int','float','decimal','boolean', an array of the above types or a " +
+                "record which consists of the above types", HTTP_109);
+        assertError(diagnosticResult, 19, "invalid type of header param 'header10': expected one of the following" +
+                " types is expected: 'string','int','float','decimal','boolean', an array of the above types or a " +
+                "record which consists of the above types", HTTP_109);
+        assertError(diagnosticResult, 20, "invalid type of header param 'header12': expected one of the following" +
+                " types is expected: 'string','int','float','decimal','boolean', an array of the above types or a " +
+                "record which consists of the above types", HTTP_109);
+        assertError(diagnosticResult, 21, "invalid resource path parameter 'path': expected one of the 'string'," +
+                "'int','float','decimal','boolean' types or a rest parameter with one of the above types", HTTP_145);
+        assertError(diagnosticResult, 22, "invalid resource path parameter 'path': expected one of the 'string'," +
+                "'int','float','decimal','boolean' types or a rest parameter with one of the above types", HTTP_145);
+        assertError(diagnosticResult, 23, "invalid resource path parameter 'path': expected one of the 'string'," +
+                "'int','float','decimal','boolean' types or a rest parameter with one of the above types", HTTP_145);
+        assertError(diagnosticResult, 24, "invalid union type of query param 'query': 'string', 'int', 'float', " +
+                "'boolean', 'decimal', 'map<json>' type or the array types of them can only be union with '()'." +
+                " Eg: string? or int[]?", HTTP_113);
+        assertError(diagnosticResult, 25, "invalid type of query param 'query': expected one of the 'string'," +
+                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
+        assertError(diagnosticResult, 26, "invalid union type of query param 'query': 'string', 'int', 'float'," +
+                " 'boolean', 'decimal', 'map<json>' type or the array types of them can only be union with '()'." +
+                " Eg: string? or int[]?", HTTP_113);
+        assertError(diagnosticResult, 27, "invalid type of query param 'query': expected one of the 'string'," +
+                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
+        assertError(diagnosticResult, 28, "invalid type of query param 'query': expected one of the 'string'," +
+                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
+        assertError(diagnosticResult, 29, "invalid union type of query param 'query': 'string', 'int', 'float'," +
+                " 'boolean', 'decimal', 'map<json>' type or the array types of them can only be union with '()'." +
+                " Eg: string? or int[]?", HTTP_113);
+        assertError(diagnosticResult, 30, "invalid type of query param 'query': expected one of the 'string'," +
+                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
+        assertError(diagnosticResult, 31, "invalid type of query param 'query': expected one of the 'string'," +
+                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
+        assertError(diagnosticResult, 32, "invalid type of query param 'query': expected one of the 'string'," +
+                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
+        assertError(diagnosticResult, 33, "invalid type of query param 'query': expected one of the 'string'," +
+                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
+        assertError(diagnosticResult, 34, "invalid type of query param 'query': expected one of the 'string'," +
+                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
+        assertError(diagnosticResult, 35, "invalid type of query param 'query': expected one of the 'string'," +
+                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_38/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_38/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "http_test"
+name = "sample_38"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_38/header_param.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_38/header_param.bal
@@ -1,0 +1,121 @@
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+type Value "value1"|"value2";
+
+type ValueNilable ("value1"|"value2"|"value3")?;
+
+enum EnumValue {
+    VALUE1,
+    VALUE2,
+    VALUE3
+}
+
+type EnumCombined EnumValue|"VALUE4"|"VALUE5";
+
+type HeaderRecord record {|
+    "value1"|"value2" header1;
+    EnumValue header2;
+    (1|2|3)[] header3;
+    (EnumValue|Value)[] header4;
+|};
+
+type UnionType EnumValue|Value;
+
+service /header/positive on listenerEP {
+
+    resource function get case1(@http:Header "value1"|"value2" header) {}
+
+    resource function get case2(@http:Header (1.234d|12.34d|123.4d)? header) {}
+
+    resource function get case3(@http:Header Value header) {}
+
+    resource function get case4(@http:Header Value? header) {}
+
+    resource function get case5(@http:Header ValueNilable header) {}
+
+    resource function get case6(@http:Header EnumValue header) {}
+
+    resource function get case7(@http:Header EnumValue? header) {}
+
+    resource function get case8(@http:Header EnumCombined header) {}
+
+    resource function get case9(@http:Header EnumValue|"VALUE4"|"VALUE5"? header) {}
+
+    resource function get case10(@http:Header EnumValue|Value? header) {}
+
+    resource function get case11(@http:Header (1|2|3)[] header) {}
+
+    resource function get case12(@http:Header Value[]? header) {}
+
+    resource function get case13(@http:Header EnumValue[] header) {}
+
+    resource function get case14(@http:Header (EnumValue|"VALUE4")[]? header) {}
+
+    resource function get case15(@http:Header UnionType[] header) {}
+
+    resource function get case16(@http:Header (EnumValue|Value)[]? header) {}
+
+    resource function get case17(@http:Header HeaderRecord? header) {}
+}
+
+type MixedValue "value2"|4.56|true;
+
+type MixedValueNilable MixedValue?;
+
+type HeaderInvalidRecord record {|
+    "value1"|"value2"|4 header1;
+    1.2|2.4|3? header2;
+    MixedValue header3;
+    MixedValue? header4;
+    MixedValueNilable header5;
+    EnumValue|4 header6;
+    EnumValue|true? header7;
+    EnumValue|Value? header8;
+    (1|2|3|3.2)[] header9;
+    MixedValue[]? header10;
+    UnionType[] header11;
+    (EnumValue|true)[]? header12;
+    (EnumValue|Value)[]? header13;
+|};
+
+service /header/negative on listenerEP {
+    resource function get case1(@http:Header "value1"|"value2"|4 header) {}
+
+    resource function get case2(@http:Header 1.2|2.4|3? header) {}
+
+    resource function get case3(@http:Header MixedValue header) {}
+
+    resource function get case4(@http:Header MixedValue? header) {}
+
+    resource function get case5(@http:Header MixedValueNilable header) {}
+
+    resource function get case6(@http:Header EnumValue|4 header) {}
+
+    resource function get case7(@http:Header EnumValue|true? header) {}
+
+    resource function get case11(@http:Header (1|2|3|3.2)[] header) {}
+
+    resource function get case12(@http:Header MixedValue[]? header) {}
+
+    resource function get case15(@http:Header (EnumValue|true)[]? header) {}
+
+    resource function get case17(@http:Header HeaderRecord|record {|string header;|} header) {}
+
+    resource function get case18(@http:Header HeaderInvalidRecord header) {}
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_38/path_param.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_38/path_param.bal
@@ -1,0 +1,47 @@
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+service /path/positive on listenerEP {
+
+    resource function get case1/["value1"|"value2" path]() {}
+
+    resource function get case2/[Value path]() {}
+
+    resource function get case3/[EnumValue path]() {}
+
+    resource function get case4/[1|2... paths]() {}
+
+    resource function get case5/[Value... paths]() {}
+
+    resource function get case6/[EnumValue... paths]() {}
+
+    resource function get case7/[EnumValue|string path]() {}
+
+    resource function get case8/[EnumValue|"value3" path]() {}
+
+    resource function get case9/[UnionType path]() {}
+
+    resource function get case10/[(Value|EnumValue)... paths]() {}
+}
+
+service /path/negative on listenerEP {
+
+    resource function get case1/["value1"|4|3.5d path]() {}
+
+    resource function get case2/[MixedValue path]() {}
+
+    resource function get case3/[MixedValue... path]() {}
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_38/query_param.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_38/query_param.bal
@@ -1,0 +1,99 @@
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+type QueryRecord record {|
+    EnumValue enumValue;
+    "value1"|"value2" value;
+|};
+
+type QueryRecordCombined QueryRecord|map<json>;
+
+listener http:Listener listenerEP = new (9090);
+
+service /query/positive on listenerEP {
+
+    resource function get case1("value1"|"value2" query) {}
+
+    resource function get case2((1.2|2.4|3.6)? query) {}
+
+    resource function get case3(Value query) {}
+
+    resource function get case4(Value? query = "value2") {}
+
+    resource function get case5(ValueNilable query) {}
+
+    resource function get case6(EnumValue query) {}
+
+    resource function get case7(EnumValue? query = VALUE2) {}
+
+    resource function get case8(EnumCombined query) {}
+
+    resource function get case9((EnumValue|"VALUE4"|"VALUE5")? query) {}
+
+    resource function get case10(EnumValue|Value? query) {}
+
+    resource function get case11((1|2|3)[] query) {}
+
+    resource function get case12(Value[]? query) {}
+
+    resource function get case13(EnumValue[] query) {}
+
+    resource function get case14(UnionType[] query) {}
+
+    resource function get case15((EnumValue|"VALUE4")[]? query) {}
+
+    resource function get case16((EnumValue|Value)[]? query) {}
+
+    resource function get case17(QueryRecord[]? query) {}
+
+    resource function get case18(QueryRecord|map<json> query) {}
+
+    resource function get case19(QueryRecordCombined? query) {}
+
+    resource function get case20((QueryRecord|map<json>)[] query) {}
+
+}
+
+type QueryRecordCombinedInvalid QueryRecord|map<anydata>;
+
+service /query/negative on listenerEP {
+
+    resource function get case1("value1"|"value2"|4 query) {}
+
+    resource function get case2(1.2|2.4|3? query) {}
+
+    resource function get case3(MixedValue query) {}
+
+    resource function get case4(MixedValue? query = "value2") {}
+
+    resource function get case5(MixedValueNilable query) {}
+
+    resource function get case6(EnumValue|4 query) {}
+
+    resource function get case7(EnumValue|true? query = VALUE2) {}
+
+    resource function get case11((1|2|3|3.2)[] query) {}
+
+    resource function get case12(MixedValue[]? query) {}
+
+    resource function get case14((EnumValue|true)[]? query) {}
+
+    resource function get case15(QueryRecordCombinedInvalid? query) {}
+
+    resource function get case16((QueryRecord|map<anydata>)[]? query) {}
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
@@ -50,6 +50,18 @@ public class Constants {
     public static final String TABLE_OF_ANYDATA_MAP = "table<anydata>";
     public static final String TUPLE_OF_ANYDATA = "[anydata...]";
     public static final String STRUCTURED_ARRAY = "(map<anydata>|table<map<anydata>>|[anydata...])[]";
+    public static final String NILABLE_STRING = "string?";
+    public static final String NILABLE_INT = "int?";
+    public static final String NILABLE_FLOAT = "float?";
+    public static final String NILABLE_DECIMAL = "decimal?";
+    public static final String NILABLE_BOOLEAN = "boolean?";
+    public static final String NILABLE_MAP_OF_JSON = "map<json>?";
+    public static final String NILABLE_STRING_ARRAY = "string[]?";
+    public static final String NILABLE_INT_ARRAY = "int[]?";
+    public static final String NILABLE_FLOAT_ARRAY = "float[]?";
+    public static final String NILABLE_DECIMAL_ARRAY = "decimal[]?";
+    public static final String NILABLE_BOOLEAN_ARRAY = "boolean[]?";
+    public static final String NILABLE_MAP_OF_JSON_ARRAY = "map<json>[]?";
 
     public static final String RESOURCE_RETURN_TYPE = "ResourceReturnType";
     public static final String INTERCEPTOR_RESOURCE_RETURN_TYPE = "InterceptorResourceReturnType";

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
@@ -94,7 +94,18 @@ import static io.ballerina.stdlib.http.compiler.Constants.LINKED_TO;
 import static io.ballerina.stdlib.http.compiler.Constants.MAP_OF_JSON;
 import static io.ballerina.stdlib.http.compiler.Constants.METHOD;
 import static io.ballerina.stdlib.http.compiler.Constants.NAME;
-import static io.ballerina.stdlib.http.compiler.Constants.NIL;
+import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_BOOLEAN;
+import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_BOOLEAN_ARRAY;
+import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_DECIMAL;
+import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_DECIMAL_ARRAY;
+import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_FLOAT;
+import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_FLOAT_ARRAY;
+import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_INT;
+import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_INT_ARRAY;
+import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_MAP_OF_JSON;
+import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_MAP_OF_JSON_ARRAY;
+import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_STRING;
+import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_STRING_ARRAY;
 import static io.ballerina.stdlib.http.compiler.Constants.OBJECT;
 import static io.ballerina.stdlib.http.compiler.Constants.OPTIONS;
 import static io.ballerina.stdlib.http.compiler.Constants.PARAM;
@@ -465,9 +476,7 @@ public class HttpResourceValidator {
             ((PathSegmentList) path).pathParameters().forEach(param -> validatePathParam(ctx, typeSymbols, param));
 
             Optional<PathParameterSymbol> pathRestParam = ((PathSegmentList) path).pathRestParameter();
-            if (pathRestParam.isPresent()) {
-                validatePathParam(ctx, typeSymbols, pathRestParam.get());
-            }
+            pathRestParam.ifPresent(pathParameterSymbol -> validatePathParam(ctx, typeSymbols, pathParameterSymbol));
         }
     }
 
@@ -534,56 +543,98 @@ public class HttpResourceValidator {
     public static void validateHeaderParamType(SyntaxNodeAnalysisContext ctx, ParameterSymbol param,
                                                Location paramLocation, String paramName, TypeSymbol typeSymbol,
                                                Map<String, TypeSymbol> typeSymbols, boolean isRecordField) {
-        typeSymbol = getEffectiveTypeFromNilableSingletonType(typeSymbol, typeSymbols);
-        if (typeSymbol == null) {
+        if (isValidBasicParamType(typeSymbol, typeSymbols) || isValidNilableBasicParamType(typeSymbol, typeSymbols)) {
+            return;
+        }
+        RecordTypeSymbol recordTypeSymbol = getRecordTypeSymbol(typeSymbol);
+        if (!isRecordField && recordTypeSymbol != null) {
+            validateRecordFieldsOfHeaderParam(ctx, param, paramLocation, paramName, recordTypeSymbol, typeSymbols);
+            return;
+        }
+        if (isUnionType(typeSymbol)) {
             reportInvalidUnionHeaderType(ctx, paramLocation, paramName);
-            return;
-        }
-        if (isValidBasicParamType(typeSymbol, typeSymbols)) {
-            return;
-        }
-        typeSymbol = getEffectiveTypeFromTypeReference(typeSymbol);
-        TypeDescKind typeDescKind = typeSymbol.typeKind();
-        if (!isRecordField && typeDescKind == TypeDescKind.RECORD) {
-            validateRecordFieldsOfHeaderParam(ctx, param, paramLocation, paramName, typeSymbol, typeSymbols);
             return;
         }
         reportInvalidHeaderParameterType(ctx, paramLocation, paramName, param);
     }
 
-    private static boolean isNilableType(TypeSymbol typeSymbol, Map<String, TypeSymbol> typeSymbols) {
-        return subtypeOf(typeSymbols, typeSymbol, NIL);
-    }
-
     private static boolean isMapOfJsonType(TypeSymbol typeSymbol, Map<String, TypeSymbol> typeSymbols) {
-        return subtypeOf(typeSymbols, typeSymbol, MAP_OF_JSON);
+        return subtypeOf(typeSymbols, typeSymbol, MAP_OF_JSON) ||
+                subtypeOf(typeSymbols, typeSymbol, NILABLE_MAP_OF_JSON);
     }
 
     private static boolean isArrayOfMapOfJsonType(TypeSymbol typeSymbol, Map<String, TypeSymbol> typeSymbols) {
-        return subtypeOf(typeSymbols, typeSymbol, ARRAY_OF_MAP_OF_JSON);
+        return subtypeOf(typeSymbols, typeSymbol, ARRAY_OF_MAP_OF_JSON) ||
+                subtypeOf(typeSymbols, typeSymbol, NILABLE_MAP_OF_JSON_ARRAY);
     }
 
     private static boolean isValidBasicQueryParameterType(TypeSymbol typeSymbol, Map<String, TypeSymbol> typeSymbols) {
-        return isValidBasicParamType(typeSymbol, typeSymbols) || isMapOfJsonType(typeSymbol, typeSymbols) ||
-                isArrayOfMapOfJsonType(typeSymbol, typeSymbols);
+        return isValidBasicParamType(typeSymbol, typeSymbols) || isValidNilableBasicParamType(typeSymbol, typeSymbols)
+                || isMapOfJsonType(typeSymbol, typeSymbols) || isArrayOfMapOfJsonType(typeSymbol, typeSymbols);
+
     }
 
     public static void validateQueryParamType(SyntaxNodeAnalysisContext ctx, Location paramLocation, String paramName,
                                               TypeSymbol typeSymbol, Map<String, TypeSymbol> typeSymbols) {
-        typeSymbol = getEffectiveTypeFromNilableSingletonType(typeSymbol, typeSymbols);
-        if (typeSymbol == null) {
-            reportInvalidUnionQueryType(ctx, paramLocation, paramName);
-            return;
-        }
         if (isValidBasicQueryParameterType(typeSymbol, typeSymbols)) {
             return;
         }
-        TypeDescKind typeDescKind = typeSymbol.typeKind();
-        if (typeDescKind == TypeDescKind.INTERSECTION) {
+        if (isUnionType(typeSymbol)) {
+            reportInvalidUnionQueryType(ctx, paramLocation, paramName);
+        } else if (isIntersectionType(typeSymbol)) {
             reportInvalidIntersectionType(ctx, paramLocation, paramName);
-            return;
+        } else {
+            reportInvalidQueryParameterType(ctx, paramLocation, paramName);
         }
-        reportInvalidQueryParameterType(ctx, paramLocation, paramName);
+    }
+
+    public static boolean isUnionType(TypeSymbol typeSymbol) {
+        if (typeSymbol.typeKind() == TypeDescKind.UNION) {
+            List<TypeSymbol> memberTypeSymbols = ((UnionTypeSymbol) typeSymbol).memberTypeDescriptors();
+            // Consider the union type as a valid type if all the member types are not nilable
+            return memberTypeSymbols.stream().allMatch(type -> type.typeKind() != TypeDescKind.NIL);
+        } else if (typeSymbol.typeKind() == TypeDescKind.TYPE_REFERENCE) {
+            return isUnionType(((TypeReferenceTypeSymbol) typeSymbol).typeDescriptor());
+        }
+        return false;
+    }
+
+    public static boolean isIntersectionType(TypeSymbol typeSymbol) {
+        if (typeSymbol.typeKind() == TypeDescKind.INTERSECTION) {
+            return true;
+        } else if (typeSymbol.typeKind() == TypeDescKind.TYPE_REFERENCE) {
+            return isIntersectionType(((TypeReferenceTypeSymbol) typeSymbol).typeDescriptor());
+        }
+        return false;
+    }
+
+    public static RecordTypeSymbol getRecordTypeSymbol(TypeSymbol typeSymbol) {
+        if (typeSymbol.typeKind() == TypeDescKind.RECORD) {
+            return (RecordTypeSymbol) typeSymbol;
+        } else if (typeSymbol.typeKind() == TypeDescKind.TYPE_REFERENCE) {
+            return getRecordTypeSymbol(((TypeReferenceTypeSymbol) typeSymbol).typeDescriptor());
+        } else if (typeSymbol.typeKind() == TypeDescKind.INTERSECTION) {
+            // Only readonly record intersection types are supported
+            List<TypeSymbol> memberTypeSymbols = ((IntersectionTypeSymbol) typeSymbol).memberTypeDescriptors();
+            if (memberTypeSymbols.size() == 2) {
+                if (memberTypeSymbols.get(0).typeKind() == TypeDescKind.READONLY) {
+                    return getRecordTypeSymbol(memberTypeSymbols.get(1));
+                } else if (memberTypeSymbols.get(1).typeKind() == TypeDescKind.READONLY) {
+                    return getRecordTypeSymbol(memberTypeSymbols.get(0));
+                }
+            }
+        } else if (typeSymbol.typeKind() == TypeDescKind.UNION) {
+            // Only nilable record union types are supported
+            List<TypeSymbol> memberTypeSymbols = ((UnionTypeSymbol) typeSymbol).memberTypeDescriptors();
+            if (memberTypeSymbols.size() == 2) {
+                if (memberTypeSymbols.get(0).typeKind() == TypeDescKind.NIL) {
+                    return getRecordTypeSymbol(memberTypeSymbols.get(1));
+                } else if (memberTypeSymbols.get(1).typeKind() == TypeDescKind.NIL) {
+                    return getRecordTypeSymbol(memberTypeSymbols.get(0));
+                }
+            }
+        }
+        return null;
     }
 
     public static TypeSymbol getEffectiveType(TypeSymbol typeSymbol) {
@@ -615,6 +666,19 @@ public class HttpResourceValidator {
                 subtypeOf(typeSymbols, typeSymbol, BOOLEAN_ARRAY);
     }
 
+    public static boolean isValidNilableBasicParamType(TypeSymbol typeSymbol, Map<String, TypeSymbol> typeSymbols) {
+        return subtypeOf(typeSymbols, typeSymbol, NILABLE_STRING) ||
+                subtypeOf(typeSymbols, typeSymbol, NILABLE_INT) ||
+                subtypeOf(typeSymbols, typeSymbol, NILABLE_FLOAT) ||
+                subtypeOf(typeSymbols, typeSymbol, NILABLE_DECIMAL) ||
+                subtypeOf(typeSymbols, typeSymbol, NILABLE_BOOLEAN) ||
+                subtypeOf(typeSymbols, typeSymbol, NILABLE_STRING_ARRAY) ||
+                subtypeOf(typeSymbols, typeSymbol, NILABLE_INT_ARRAY) ||
+                subtypeOf(typeSymbols, typeSymbol, NILABLE_FLOAT_ARRAY) ||
+                subtypeOf(typeSymbols, typeSymbol, NILABLE_DECIMAL_ARRAY) ||
+                subtypeOf(typeSymbols, typeSymbol, NILABLE_BOOLEAN_ARRAY);
+    }
+
     private static void validateRecordFieldsOfHeaderParam(SyntaxNodeAnalysisContext ctx, ParameterSymbol param,
                                                           Location paramLocation, String paramName,
                                                           TypeSymbol typeSymbol, Map<String, TypeSymbol> typeSymbols) {
@@ -627,29 +691,6 @@ public class HttpResourceValidator {
             validateHeaderParamType(ctx, param, paramLocation, recordField.getName().orElse(paramName),
                     recordField.typeDescriptor(), typeSymbols, true);
         }
-    }
-
-    private static TypeSymbol getEffectiveTypeFromNilableSingletonType(TypeSymbol typeSymbol,
-                                                                       Map<String, TypeSymbol> typeSymbols) {
-        if (typeSymbol.typeKind() == TypeDescKind.INTERSECTION) {
-            typeSymbol = getEffectiveTypeFromReadonlyIntersection((IntersectionTypeSymbol) typeSymbol);
-        }
-        TypeDescKind typeDescKind = typeSymbol.typeKind();
-        if (typeDescKind == TypeDescKind.UNION) {
-            List<TypeSymbol> symbolList = ((UnionTypeSymbol) typeSymbol).userSpecifiedMemberTypes();
-            int size = symbolList.size();
-            if (size > 2) {
-                return null;
-            }
-            if (isNilableType(symbolList.get(0), typeSymbols)) {
-                typeSymbol = symbolList.get(1);
-            } else if (isNilableType(symbolList.get(1), typeSymbols)) {
-                typeSymbol = symbolList.get(0);
-            } else {
-                return null;
-            }
-        }
-        return typeSymbol;
     }
 
     private static void enableAddPayloadParamCodeAction(SyntaxNodeAnalysisContext ctx, Location location,

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/HttpPayloadParamIdentifier.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/HttpPayloadParamIdentifier.java
@@ -68,6 +68,7 @@ import static io.ballerina.stdlib.http.compiler.HttpCompilerPluginUtil.subtypeOf
 import static io.ballerina.stdlib.http.compiler.HttpCompilerPluginUtil.updateDiagnostic;
 import static io.ballerina.stdlib.http.compiler.HttpResourceValidator.getEffectiveType;
 import static io.ballerina.stdlib.http.compiler.HttpResourceValidator.isValidBasicParamType;
+import static io.ballerina.stdlib.http.compiler.HttpResourceValidator.isValidNilableBasicParamType;
 
 
 /**
@@ -312,7 +313,7 @@ public class HttpPayloadParamIdentifier extends HttpServiceValidator {
         }
 
         // If the type is a basic type or basic array type, then it is not considered as a structured type
-        if (isValidBasicParamType(typeSymbol, typeSymbols)) {
+        if (isValidBasicParamType(typeSymbol, typeSymbols) || isValidNilableBasicParamType(typeSymbol, typeSymbols)) {
             return false;
         }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -202,6 +202,7 @@ public class HttpConstants {
     public static final String QUERY_PARAM = "query";
     public static final String PAYLOAD_PARAM = "payload";
     public static final String HEADER_PARAM = "header";
+    public static final String PATH_PARAM = "path";
 
     /* Annotations */
     public static final String ANNOTATION_NAME_SOURCE = "Source";

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -1935,7 +1935,7 @@ public class HttpUtil {
         return paramTypes;
     }
 
-    public static Type[] getCustomParameterTypes(FunctionType function) {
+    public static Type[] getOriginalParameterTypes(FunctionType function) {
         io.ballerina.runtime.api.types.Parameter[] params = function.getParameters();
         Type[] paramTypes = new Type[params.length];
         for (int i = 0; i < params.length; i++) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllPathParams.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllPathParams.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.api.service.signature;
+
+import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.utils.ValueUtils;
+import io.ballerina.stdlib.http.api.HttpConstants;
+import io.ballerina.stdlib.http.api.HttpErrorType;
+import io.ballerina.stdlib.http.api.HttpResourceArguments;
+import io.ballerina.stdlib.http.api.HttpUtil;
+import io.ballerina.stdlib.http.api.Resource;
+import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static io.ballerina.stdlib.http.api.HttpConstants.EXTRA_PATH_INDEX;
+import static io.ballerina.stdlib.http.api.HttpConstants.PERCENTAGE;
+import static io.ballerina.stdlib.http.api.HttpConstants.PERCENTAGE_ENCODED;
+import static io.ballerina.stdlib.http.api.HttpConstants.PLUS_SIGN;
+import static io.ballerina.stdlib.http.api.HttpConstants.PLUS_SIGN_ENCODED;
+import static io.ballerina.stdlib.http.api.HttpErrorType.RESOURCE_NOT_FOUND_ERROR;
+import static io.ballerina.stdlib.http.api.service.signature.ParamUtils.castParam;
+import static io.ballerina.stdlib.http.api.service.signature.ParamUtils.castParamArray;
+
+/**
+ * {@code {@link AllPathParams }} holds all the path parameters in the resource signature.
+ */
+public class AllPathParams implements Parameter {
+
+    private final List<PathParam> allPathParams = new ArrayList<>();
+
+    @Override
+    public String getTypeName() {
+        return HttpConstants.PATH_PARAM;
+    }
+
+    public void add(PathParam pathParam) {
+        allPathParams.add(pathParam);
+    }
+
+    public boolean isNotEmpty() {
+        return !allPathParams.isEmpty();
+    }
+
+    public void populateFeed(Object[] paramFeed, HttpCarbonMessage httpCarbonMessage, Resource resource) {
+        if (allPathParams.isEmpty()) {
+            return;
+        }
+        HttpResourceArguments resourceArgumentValues =
+                (HttpResourceArguments) httpCarbonMessage.getProperty(HttpConstants.RESOURCE_ARGS);
+        updateWildcardToken(resource.getWildcardToken(), allPathParams.size() - 1, resourceArgumentValues.getMap());
+        for (PathParam pathParam : allPathParams) {
+            String paramToken = pathParam.getToken();
+            Type paramType = pathParam.getOriginalType();
+            int paramTypeTag = pathParam.getEffectiveTypeTag();
+            int index = pathParam.getIndex();
+            String argumentValue = resourceArgumentValues.getMap().get(paramToken).get(index / 2);
+            if (argumentValue.endsWith(PERCENTAGE)) {
+                argumentValue = argumentValue.replaceAll(PERCENTAGE, PERCENTAGE_ENCODED);
+            }
+            argumentValue = URLDecoder.decode(argumentValue.replaceAll(PLUS_SIGN, PLUS_SIGN_ENCODED),
+                    StandardCharsets.UTF_8);
+
+            try {
+                Object parsedValue;
+                if (pathParam.isArray()) {
+                    String[] segments = argumentValue.substring(1).split(HttpConstants.SINGLE_SLASH);
+                    parsedValue = castParamArray(paramTypeTag, segments);
+                } else {
+                    parsedValue = castParam(paramTypeTag, argumentValue);
+                }
+                paramFeed[index++] = ValueUtils.convert(parsedValue, paramType);
+                paramFeed[index] = true;
+            } catch (Exception ex) {
+                String message = "error in casting path parameter : '" + paramToken + "'";
+                if (ParamUtils.isFiniteType(paramType)) {
+                    message = "no matching resource found for path : " +
+                            httpCarbonMessage.getProperty(HttpConstants.TO) +
+                            " , method : " + httpCarbonMessage.getHttpMethod();
+                    throw HttpUtil.createHttpStatusCodeError(RESOURCE_NOT_FOUND_ERROR, message);
+                } else {
+                    throw HttpUtil.createHttpStatusCodeError(HttpErrorType.PATH_PARAM_BINDING_ERROR, message,
+                            null, HttpUtil.createError(ex));
+                }
+            }
+        }
+    }
+
+    private static void updateWildcardToken(String wildcardToken, int wildCardIndex,
+                                            Map<String, Map<Integer, String>> arguments) {
+        if (wildcardToken == null) {
+            return;
+        }
+        String wildcardPathSegment = arguments.get(HttpConstants.EXTRA_PATH_INFO).get(EXTRA_PATH_INDEX);
+        if (arguments.containsKey(wildcardToken)) {
+            Map<Integer, String> indexValueMap = arguments.get(wildcardToken);
+            indexValueMap.put(wildCardIndex, wildcardPathSegment);
+        } else {
+            arguments.put(wildcardToken, Collections.singletonMap(wildCardIndex, wildcardPathSegment));
+        }
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
@@ -19,15 +19,11 @@
 package io.ballerina.stdlib.http.api.service.signature;
 
 import io.ballerina.runtime.api.PredefinedTypes;
-import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
-import io.ballerina.runtime.api.types.ArrayType;
-import io.ballerina.runtime.api.types.IntersectionType;
 import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.types.ResourceMethodType;
 import io.ballerina.runtime.api.types.Type;
-import io.ballerina.runtime.api.types.UnionType;
 import io.ballerina.runtime.api.utils.IdentifierUtils;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.utils.TypeUtils;
@@ -65,17 +61,17 @@ public class ParamHandler {
     private final Type[] paramTypes;
     private final int pathParamCount;
     private Type callerInfoType = null;
-    private ResourceMethodType resource;
-    private String[] pathParamTokens = new String[0];
-    private List<Parameter> otherParamList = new ArrayList<>();
+    private final ResourceMethodType resource;
+    private final List<Parameter> paramList = new ArrayList<>();
     private PayloadParam payloadParam = null;
     private NonRecurringParam callerParam = null;
     private NonRecurringParam requestParam = null;
     private NonRecurringParam headerObjectParam = null;
     private NonRecurringParam requestContextParam = null;
     private NonRecurringParam interceptorErrorParam = null;
-    private AllQueryParams queryParams = new AllQueryParams();
-    private AllHeaderParams headerParams = new AllHeaderParams();
+    private final AllPathParams pathParams = new AllPathParams();
+    private final AllQueryParams queryParams = new AllQueryParams();
+    private final AllHeaderParams headerParams = new AllHeaderParams();
 
     private static final String PARAM_ANNOT_PREFIX = "$param$.";
     private static final MapType MAP_TYPE = TypeCreator.createMapType(
@@ -106,8 +102,12 @@ public class ParamHandler {
         if (pathParamCount == 0) {
             return;
         }
-        this.pathParamTokens = Arrays.copyOfRange(resource.getParamNames(), 0, pathParamCount);
-        validatePathParam(pathParamCount);
+        for (int index = 0; index < pathParamCount; index++) {
+            createPathParam(index, resource);
+        }
+        if (pathParams.isNotEmpty()) {
+            getParamList().add(pathParams);
+        }
     }
 
     private void validateSignatureParams() {
@@ -115,6 +115,7 @@ public class ParamHandler {
             return;
         }
         Type[] customParameterTypes = HttpUtil.getCustomParameterTypes(resource);
+        Type[] originalParameterTypes = HttpUtil.getParameterTypes(resource);
         for (int index = pathParamCount; index < paramTypes.length; index++) {
             Type parameterType = this.paramTypes[index];
 
@@ -123,7 +124,7 @@ public class ParamHandler {
                 case REQUEST_CONTEXT_TYPE:
                     if (this.requestContextParam == null) {
                         this.requestContextParam = new NonRecurringParam(index, HttpConstants.REQUEST_CONTEXT);
-                        getOtherParamList().add(this.requestContextParam);
+                        getParamList().add(this.requestContextParam);
                     } else {
                         throw HttpUtil.createHttpError("invalid multiple '" + REQUEST_CONTEXT_TYPE
                                                                + "' parameter");
@@ -133,7 +134,7 @@ public class ParamHandler {
                     if (this.interceptorErrorParam == null) {
                         this.interceptorErrorParam = new NonRecurringParam(index,
                                                                            HttpConstants.STRUCT_GENERIC_ERROR);
-                        getOtherParamList().add(this.interceptorErrorParam);
+                        getParamList().add(this.interceptorErrorParam);
                     } else {
                         throw HttpUtil.createHttpError("invalid multiple '" +
                                                                HttpConstants.STRUCT_GENERIC_ERROR + "' parameter");
@@ -142,7 +143,7 @@ public class ParamHandler {
                 case CALLER_TYPE:
                     if (this.callerParam == null) {
                         this.callerParam = new NonRecurringParam(index, HttpConstants.CALLER);
-                        getOtherParamList().add(this.callerParam);
+                        getParamList().add(this.callerParam);
                     } else {
                         throw HttpUtil.createHttpError("invalid multiple '" + CALLER_TYPE + "' parameter");
                     }
@@ -150,7 +151,7 @@ public class ParamHandler {
                 case REQ_TYPE:
                     if (this.requestParam == null) {
                         this.requestParam = new NonRecurringParam(index, HttpConstants.REQUEST);
-                        getOtherParamList().add(this.requestParam);
+                        getParamList().add(this.requestParam);
                     } else {
                         throw HttpUtil.createHttpError("invalid multiple '" + REQ_TYPE + "' parameter");
                     }
@@ -158,7 +159,7 @@ public class ParamHandler {
                 case HEADERS_TYPE:
                     if (this.headerObjectParam == null) {
                         this.headerObjectParam = new NonRecurringParam(index, HttpConstants.HEADERS);
-                        getOtherParamList().add(this.headerObjectParam);
+                        getParamList().add(this.headerObjectParam);
                     } else {
                         throw HttpUtil.createHttpError("invalid multiple '" + HEADERS_TYPE + "' parameter");
                     }
@@ -168,19 +169,19 @@ public class ParamHandler {
                     HeaderParam headerParam;
                     if (payloadParam != null && paramName.equals(payloadParam.getToken())) {
                         payloadParam.init(parameterType, customParameterTypes[index], index);
-                        getOtherParamList().add(payloadParam);
+                        getParamList().add(payloadParam);
                     } else if ((headerParam = headerParams.get(paramName)) != null) {
                         headerParam.init(parameterType, index);
                     } else {
-                        validateQueryParam(index, resource, parameterType, false);
+                        createQueryParam(index, resource, originalParameterTypes[index]);
                     }
             }
         }
         if (queryParams.isNotEmpty()) {
-            getOtherParamList().add(this.queryParams);
+            getParamList().add(this.queryParams);
         }
         if (headerParams.isNotEmpty()) {
-            getOtherParamList().add(this.headerParams);
+            getParamList().add(this.headerParams);
         }
     }
 
@@ -248,6 +249,12 @@ public class ParamHandler {
         }
     }
 
+    private void createPathParam(int index, ResourceMethodType balResource) {
+        io.ballerina.runtime.api.types.Parameter parameter = balResource.getParameters()[index];
+        PathParam pathParam = new PathParam(parameter.type, parameter.name, index);
+        this.pathParams.add(pathParam);
+    }
+
     private void createHeaderParam(String paramName, BMap annotations) {
         HeaderParam headerParam = new HeaderParam(paramName);
         BMap mapValue = annotations.getMapValue(StringUtils.fromString(HEADER_ANNOTATION));
@@ -262,85 +269,19 @@ public class ParamHandler {
         this.headerParams.add(headerParam);
     }
 
-    private void validateQueryParam(int index, ResourceMethodType balResource, Type parameterType, boolean readonly) {
-        if (parameterType instanceof UnionType) {
-            List<Type> memberTypes = ((UnionType) parameterType).getMemberTypes();
-            int size = memberTypes.size();
-            if (memberTypes.stream().allMatch(type -> type.getTag() == TypeTags.FINITE_TYPE_TAG)) {
-                createQueryParam(index, balResource, parameterType, false, readonly);
-                return;
-            } else if (size > 2 || !parameterType.isNilable()) {
-                throw HttpUtil.createHttpError(
-                        "invalid query param type '" + parameterType.getName() + "': a basic type or an array " +
-                                "of a basic type can only be union with '()' Eg: string|() or string[]|()");
-            }
-            for (Type type : memberTypes) {
-                if (type.getTag() == TypeTags.NULL_TAG) {
-                    continue;
-                }
-                createQueryParam(index, balResource, type, true, readonly);
-                break;
-            }
-        } else if (parameterType instanceof IntersectionType) {
-            // Assumes that the only intersection type is readonly
-            List<Type> memberTypes = ((IntersectionType) parameterType).getConstituentTypes();
-            int size = memberTypes.size();
-            if (size > 2) {
-                throw HttpUtil.createHttpError(
-                        "invalid query param type '" + parameterType.getName() +
-                                "': only readonly intersection is allowed");
-            }
-            for (Type type : memberTypes) {
-                if (type.getTag() == TypeTags.READONLY_TAG) {
-                    continue;
-                }
-                if (type.getTag() == TypeTags.UNION_TAG) {
-                    validateQueryParam(index, balResource, type, true);
-                    return;
-                }
-                createQueryParam(index, balResource, type, false, true);
-                break;
-            }
-        } else {
-            createQueryParam(index, balResource, parameterType, false, false);
-        }
-    }
-
-    private void createQueryParam(int index, ResourceMethodType balResource, Type type, boolean nilable,
-                                  boolean readonly) {
+    private void createQueryParam(int index, ResourceMethodType balResource, Type originalType) {
         io.ballerina.runtime.api.types.Parameter parameter = balResource.getParameters()[index];
-        QueryParam queryParam = new QueryParam(type, HttpUtil.unescapeAndEncodeValue(parameter.name), index, nilable,
-                                               readonly, parameter.isDefault);
+        QueryParam queryParam = new QueryParam(originalType, HttpUtil.unescapeAndEncodeValue(parameter.name), index,
+                parameter.isDefault);
         this.queryParams.add(queryParam);
-    }
-
-    private void validatePathParam(int pathParamCount) {
-        Arrays.stream(this.paramTypes, 0, pathParamCount).forEach(type -> {
-            int typeTag = type.getTag();
-            if (isValidBasicType(typeTag) || (typeTag == TypeTags.ARRAY_TAG && isValidBasicType(
-                    ((ArrayType) type).getElementType().getTag()))) {
-                return;
-            }
-            throw HttpUtil.createHttpError("incompatible path parameter type: '" + type + "'",
-                                           HttpErrorType.GENERIC_LISTENER_ERROR);
-        });
-    }
-
-    private boolean isValidBasicType(int typeTag) {
-        return typeTag == TypeTags.STRING_TAG || typeTag == TypeTags.INT_TAG || typeTag == TypeTags.FLOAT_TAG ||
-                typeTag == TypeTags.BOOLEAN_TAG || typeTag == TypeTags.DECIMAL_TAG;
     }
 
     public boolean isPayloadBindingRequired() {
         return payloadParam != null;
     }
 
-    public List<Parameter> getOtherParamList() {
-        return this.otherParamList;
-    }
-
-    public int getPathParamTokenLength() {
-        return pathParamTokens.length;
+    public List<Parameter> getParamList() {
+        return this.paramList;
     }
 
     /**

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamHandler.java
@@ -114,8 +114,7 @@ public class ParamHandler {
         if (paramTypes.length == pathParamCount) {
             return;
         }
-        Type[] customParameterTypes = HttpUtil.getCustomParameterTypes(resource);
-        Type[] originalParameterTypes = HttpUtil.getParameterTypes(resource);
+        Type[] originalParameterTypes = HttpUtil.getOriginalParameterTypes(resource);
         for (int index = pathParamCount; index < paramTypes.length; index++) {
             Type parameterType = this.paramTypes[index];
 
@@ -168,10 +167,10 @@ public class ParamHandler {
                     String paramName = HttpUtil.unescapeAndEncodeValue(resource.getParamNames()[index]);
                     HeaderParam headerParam;
                     if (payloadParam != null && paramName.equals(payloadParam.getToken())) {
-                        payloadParam.init(parameterType, customParameterTypes[index], index);
+                        payloadParam.init(parameterType, originalParameterTypes[index], index);
                         getParamList().add(payloadParam);
                     } else if ((headerParam = headerParams.get(paramName)) != null) {
-                        headerParam.init(parameterType, index);
+                        headerParam.init(originalParameterTypes[index], index);
                     } else {
                         createQueryParam(index, resource, originalParameterTypes[index]);
                     }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/ParamUtils.java
@@ -242,8 +242,7 @@ public class ParamUtils {
 
     private static int getEffectiveTypeTagFromArrayType(ArrayType type, Type originalType, String paramType) {
         Type elementType = TypeUtils.getReferredType(type.getElementType());
-        int elementTypeTag = elementType.getTag();
-        if (elementTypeTag == ARRAY_TAG) {
+        if (elementType.getTag() == ARRAY_TAG) {
             throw HttpUtil.createHttpError("invalid " + paramType + " parameter array type '" + originalType + "'");
         } else {
             return getEffectiveTypeTag(elementType, originalType, paramType);

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/PathParam.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/PathParam.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -20,51 +20,37 @@ package io.ballerina.stdlib.http.api.service.signature;
 
 import io.ballerina.runtime.api.types.Type;
 
-import static io.ballerina.stdlib.http.api.HttpConstants.QUERY_PARAM;
+import static io.ballerina.stdlib.http.api.HttpConstants.PATH_PARAM;
 
 /**
- * {@code {@link QueryParam }} represents a query parameter details.
- *
- * @since slp8
+ * {@code {@link PathParam }} represents a path parameter details.
  */
-public class QueryParam {
+public class PathParam {
 
     private final String token;
-    private final boolean nilable;
-    private final boolean defaultable;
     private final int index;
     private final Type originalType;
     private final int effectiveTypeTag;
     private final boolean isArray;
 
-    QueryParam(Type originalType, String token, int index, boolean defaultable) {
+    PathParam(Type originalType, String token, int index) {
         this.originalType = originalType;
         this.token = token;
         this.index = index;
-        this.nilable = originalType.isNilable();
-        this.defaultable = defaultable;
-        this.effectiveTypeTag = ParamUtils.getEffectiveTypeTag(originalType, originalType, QUERY_PARAM);
+        this.effectiveTypeTag = ParamUtils.getEffectiveTypeTag(originalType, originalType, PATH_PARAM);
         this.isArray = ParamUtils.isArrayType(originalType);
     }
 
     public String getToken() {
-        return this.token;
-    }
-
-    public boolean isNilable() {
-        return this.nilable;
+        return token;
     }
 
     public int getIndex() {
-        return this.index * 2;
+        return index * 2;
     }
 
     public Type getOriginalType() {
-        return this.originalType;
-    }
-
-    public boolean isDefaultable() {
-        return defaultable;
+        return originalType;
     }
 
     public int getEffectiveTypeTag() {


### PR DESCRIPTION
## Purpose

> $Subject

Fixes : https://github.com/ballerina-platform/ballerina-standard-library/issues/4372
Fixes : https://github.com/ballerina-platform/ballerina-standard-library/issues/4374

The following issues were found in the previous resource parameter(path, query and header) binding logic:
- We had a logic of verifying the path/query/header parameter based on the type tag of the parameter type
   >Because of this we had some issues when the parameter type is enum or finite. And time-to-time we had updated this logic to support specific types when there is a bug reported. Ideally, we should have verified this logic rather than adding support for specific cases.

- We parsed the path/query/header parameter based on the parameter type.
   >Because of this when we support new types, we ended up changing this parsing logic as well.
  
- After parsing the query parameter to one of this type: `string`, `int`, `float`, `decimal`, `boolean`, `map<json>`, we have returned this raw type to the resource function rather than converting to the type specified in the resource signature.
   >Because of this the type information is loss inside the resource function. And when we have readonly types we have to specifically made these types readonly from our native.
   
Ideally, when we bind a path/query/header parameter we should have done the following:
1. Get the effective type from the parameter type. It can be one of the raw type: `string`, `int`, `float`, `decimal`, `boolean` and `map<json>`(only for query param).
2. In order to parse the path/query/header string we only need this effective type and not the parameter type.
3. After parsing the parameter to one of the raw type, we should convert the value to the parameter type using a runtime API like : `ValueUtils.convert` it handles all the readonly and union resolution and will throw a `BError` when the conversion fails.

So this PR is to rewrite the resource parameter binding logic as described above.

## Examples

With this rewrite, the union types are allowed in as path/query/header parameters only if the effective type is one of the allowed raw type.

```bal

enum EnumValue {
    VALUE1,
    VALUE2,
    VALUE3
}

type FiniteIntTypes 1|2|3|4;

service on new http:Listener(9090) {

    // This is allowed since the effective type is string
    resource function get case1/[EnumValue|"VALUE4"|"VALUE5" path]() {}
    
    // This is allowed since the effective type is integer
    resource function get case2(FiniteIntTypes|5|6|7 query) {}

    // This is not allowed
    resource function get case3/[EnumValue|1|2 path]() {}
    
    // Lets say Record1 and Record2 are effectively map of json types
    // Then this is allowed
    // If the records are structurally same, then it will bind to the first type matched in the union
    resource function get case4(Record1|Record2 query) {}
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
- [x] Checked native-image compatibility
