### PR TITLE
Change `testGetXmlPayloadReturnParserError` test

### DIFF
--- a/ballerina-tests/http-misc-tests/tests/http_payload_test.bal
+++ b/ballerina-tests/http-misc-tests/tests/http_payload_test.bal
@@ -116,8 +116,9 @@ function testGetXmlPayloadReturnParserError() returns error? {
     if response is http:Response {
         test:assertEquals(response.statusCode, 200, msg = "Found unexpected output");
         common:assertHeaderValue(check response.getHeader(common:CONTENT_TYPE), common:TEXT_PLAIN);
-        common:assertTrueTextPayload(response.getTextPayload(),
-                "Error occurred while extracting xml data from entity: error(\"failed to create xml");
+        common:assertTrueTextPayloadWithMutipleOptions(response.getTextPayload(),
+                "Error occurred while extracting xml data from entity: error(\"failed to create xml",
+                "Error occurred while extracting xml data from entity: error(\"failed to parse xml");
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }

--- a/ballerina-tests/http-test-common/utils.bal
+++ b/ballerina-tests/http-test-common/utils.bal
@@ -104,6 +104,18 @@ public isolated function assertTrueTextPayload(string|error payload, string expe
     }
 }
 
+public isolated function assertTrueTextPayloadWithMutipleOptions(string|error payload, string... expectedValues) {
+    if payload is string {
+        foreach var value in expectedValues {
+            if (strings:includes(payload, value)) {
+                return;
+            }
+        }
+        test:assertFail(msg = "Found unexpected output");
+    }
+    test:assertFail(msg = "Found unexpected output type: " + payload.message());
+}
+
 public isolated function assertHeaderValue(string headerKey, string expectValue) {
     test:assertEquals(headerKey, expectValue, msg = "Found unexpected headerValue");
 }


### PR DESCRIPTION
## Purpose

To comply with the change done for the xml parser to throw an error with the same message prefix  https://github.com/ballerina-platform/ballerina-lang/pull/40286#discussion_r1187280634.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
