### PR TITLE
Fix query param issue when the request contain `{`, `}` characters

### DIFF
--- a/ballerina-tests/http-dispatching-tests/tests/query_params_binding_test.bal
+++ b/ballerina-tests/http-dispatching-tests/tests/query_params_binding_test.bal
@@ -217,3 +217,16 @@ function testQueryParamBindingCase15() returns error? {
     res = check resourceQueryParamBindingClient->/query/case15(query1 = "abc", query2 = 500000);
     test:assertEquals(res.statusCode, 400, "Status code mismatched");
 }
+
+@test:Config {}
+function testQueryParamBindingCase9WithCurlyBracesUnencoded() returns error? {
+    map<json> resPayload = check resourceQueryParamBindingClient->/query/case9(query = string`{"name":"John"%2C "age":37}`);
+    test:assertEquals(resPayload, {"name": "John", "age": 37, "type": "map<json>"});
+}
+
+@test:Config {}
+function testQueryParamBindingCase16() returns error? {
+    string[] strVals = ["Hi", "Hello", "Bye"];
+    [map<json>, string[]] resPayload = check resourceQueryParamBindingClient->/query/case16(query1 = string`{"name":"John"%2C "age":37}`, query2 = strVals);
+    test:assertEquals(resPayload, [{"name":"John", "age":37}, strVals]);
+}

--- a/ballerina-tests/http-dispatching-tests/tests/resource_params_binding_test_common.bal
+++ b/ballerina-tests/http-dispatching-tests/tests/resource_params_binding_test_common.bal
@@ -219,6 +219,10 @@ service /query on resourceParamBindingListener {
     resource function get case15(StringCharacter query1, SmallInt query2) returns [StringCharacter, SmallInt] {
         return [query1, query2];
     }
+
+    resource function get case16(map<json> query1, string[] query2) returns [map<json>, string[]] {
+        return [query1, query2];
+    }
 }
 
 service /header on resourceParamBindingListener {

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -165,6 +165,6 @@ path = "./lib/protobuf-java-3.20.3.jar"
 [[platform.java11.dependency]]
 groupId = "com.squareup.okhttp3"
 artifactId = "okhttp"
-version = "4.5.0"
-path = "./lib/okhttp-4.5.0.jar"
+version = "3.14.0"
+path = "./lib/okhttp-3.14.0.jar"
 

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -167,3 +167,4 @@ groupId = "com.squareup.okhttp3"
 artifactId = "okhttp"
 version = "4.5.0"
 path = "./lib/okhttp-4.5.0.jar"
+

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -167,4 +167,3 @@ groupId = "com.squareup.okhttp3"
 artifactId = "okhttp"
 version = "3.14.0"
 path = "./lib/okhttp-3.14.0.jar"
-

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -161,15 +161,3 @@ groupId = "com.google.protobufl"
 artifactId = "protobuf-java"
 version = "3.20.3"
 path = "./lib/protobuf-java-3.20.3.jar"
-
-[[platform.java11.dependency]]
-groupId = "com.squareup.okhttp3"
-artifactId = "okhttp"
-version = "3.14.0"
-path = "./lib/okhttp-3.14.0.jar"
-
-[[platform.java11.dependency]]
-groupId = "com.squareup.okio"
-artifactId = "okio"
-version = "2.2.2"
-path = "./lib/okio-2.2.2.jar"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -161,3 +161,9 @@ groupId = "com.google.protobufl"
 artifactId = "protobuf-java"
 version = "3.20.3"
 path = "./lib/protobuf-java-3.20.3.jar"
+
+[[platform.java11.dependency]]
+groupId = "com.squareup.okhttp3"
+artifactId = "okhttp"
+version = "4.5.0"
+path = "./lib/okhttp-4.5.0.jar"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -167,3 +167,9 @@ groupId = "com.squareup.okhttp3"
 artifactId = "okhttp"
 version = "3.14.0"
 path = "./lib/okhttp-3.14.0.jar"
+
+[[platform.java11.dependency]]
+groupId = "com.squareup.okio"
+artifactId = "okio"
+version = "2.2.2"
+path = "./lib/okio-2.2.2.jar"

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Add query,header and path parameter runtime support for Ballerina builtin types](https://github.com/ballerina-platform/ballerina-standard-library/issues/4526)
 
+### Fixed
+
+- [Fix parsing query parameters fail when curly braces are provided](https://github.com/ballerina-platform/ballerina-standard-library/issues/4565)
+
 ## [2.8.0] - 2023-06-01
 
 ### Added

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -48,12 +48,12 @@ public class HttpConstants {
     public static final String RAW_URI = "RAW_URI";
     public static final String RESOURCE_ARGS = "RESOURCE_ARGS";
     public static final String MATRIX_PARAMS = "MATRIX_PARAMS";
-    public static final String QUERY_STR = "QUERY_STR";
     public static final String RAW_QUERY_STR = "RAW_QUERY_STR";
 
     public static final String DEFAULT_INTERFACE = "0.0.0.0:8080";
     public static final String DEFAULT_BASE_PATH = "/";
     public static final String DEFAULT_SUB_PATH = "/*";
+    public static final String QUERY_STRING_SEPARATOR = "\\?";
 
     public static final String PROTOCOL_HTTP = "http";
     public static final String HTTP_MOCK_SERVER_ENDPOINT_NAME = "Tballerina/http:MockListener;";

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
@@ -55,9 +55,11 @@ import java.util.concurrent.CountDownLatch;
 import static io.ballerina.stdlib.http.api.HttpConstants.AUTHORIZATION_HEADER;
 import static io.ballerina.stdlib.http.api.HttpConstants.BEARER_AUTHORIZATION_HEADER;
 import static io.ballerina.stdlib.http.api.HttpConstants.DEFAULT_HOST;
+import static io.ballerina.stdlib.http.api.HttpConstants.EMPTY;
 import static io.ballerina.stdlib.http.api.HttpConstants.JWT_DECODER_CLASS_NAME;
 import static io.ballerina.stdlib.http.api.HttpConstants.JWT_DECODE_METHOD_NAME;
 import static io.ballerina.stdlib.http.api.HttpConstants.JWT_INFORMATION;
+import static io.ballerina.stdlib.http.api.HttpConstants.QUERY_STRING_SEPARATOR;
 import static io.ballerina.stdlib.http.api.HttpConstants.REQUEST_CTX_MEMBERS;
 import static io.ballerina.stdlib.http.api.HttpConstants.WHITESPACE;
 import static io.ballerina.stdlib.http.api.HttpErrorType.SERVICE_NOT_FOUND_ERROR;
@@ -179,9 +181,9 @@ public class HttpDispatcher {
 
     private static String[] extractRawPathAndQuery(String uriWithoutMatrixParams) {
         String[] rawPathAndQuery = new String[2];
-        String[] splittedUri = uriWithoutMatrixParams.split("\\?");
+        String[] splittedUri = uriWithoutMatrixParams.split(QUERY_STRING_SEPARATOR);
         rawPathAndQuery[0] = splittedUri[0];
-        rawPathAndQuery[1] = splittedUri.length > 1 ? splittedUri[1] : "";
+        rawPathAndQuery[1] = splittedUri.length > 1 ? splittedUri[1] : EMPTY;
         return rawPathAndQuery;
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
@@ -45,7 +45,6 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -56,12 +55,10 @@ import java.util.concurrent.CountDownLatch;
 import static io.ballerina.stdlib.http.api.HttpConstants.AUTHORIZATION_HEADER;
 import static io.ballerina.stdlib.http.api.HttpConstants.BEARER_AUTHORIZATION_HEADER;
 import static io.ballerina.stdlib.http.api.HttpConstants.DEFAULT_HOST;
-import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_SCHEME;
 import static io.ballerina.stdlib.http.api.HttpConstants.JWT_DECODER_CLASS_NAME;
 import static io.ballerina.stdlib.http.api.HttpConstants.JWT_DECODE_METHOD_NAME;
 import static io.ballerina.stdlib.http.api.HttpConstants.JWT_INFORMATION;
 import static io.ballerina.stdlib.http.api.HttpConstants.REQUEST_CTX_MEMBERS;
-import static io.ballerina.stdlib.http.api.HttpConstants.SCHEME_SEPARATOR;
 import static io.ballerina.stdlib.http.api.HttpConstants.WHITESPACE;
 import static io.ballerina.stdlib.http.api.HttpErrorType.SERVICE_NOT_FOUND_ERROR;
 import static io.ballerina.stdlib.http.api.HttpUtil.getParameterTypes;
@@ -98,19 +95,21 @@ public class HttpDispatcher {
             Map<String, Map<String, String>> matrixParams = new HashMap<>();
             String uriWithoutMatrixParams = URIUtil.extractMatrixParams(rawUri, matrixParams, inboundReqMsg);
 
-            URI validatedUri = getValidatedURI(HTTP_SCHEME + SCHEME_SEPARATOR + uriWithoutMatrixParams);
+            String[] splittedUri = uriWithoutMatrixParams.split("\\?");
+            String queryString = splittedUri.length > 1 ? splittedUri[1] : "";
+            String rawPath = splittedUri[0];
 
-            String basePath = servicesRegistry.findTheMostSpecificBasePath(validatedUri.getRawPath(),
+            String basePath = servicesRegistry.findTheMostSpecificBasePath(rawPath,
                                                                            servicesOnInterface, sortedServiceURIs);
 
             if (basePath == null) {
-                String message = "no matching service found for path : " + validatedUri.getRawPath();
+                String message = "no matching service found for path : " + rawPath;
                 throw HttpUtil.createHttpStatusCodeError(SERVICE_NOT_FOUND_ERROR, message);
             }
 
             HttpService service = servicesOnInterface.get(basePath);
             if (!forInterceptors) {
-                setInboundReqProperties(inboundReqMsg, validatedUri, basePath);
+                setInboundReqProperties(inboundReqMsg, rawPath, basePath, queryString);
                 inboundReqMsg.setProperty(HttpConstants.RAW_URI, rawUri);
                 inboundReqMsg.setProperty(HttpConstants.TO, uriWithoutMatrixParams);
                 inboundReqMsg.setProperty(HttpConstants.MATRIX_PARAMS, matrixParams);
@@ -159,18 +158,20 @@ public class HttpDispatcher {
             inboundReqMsg.setProperty(HttpConstants.TO, uriWithoutMatrixParams);
             inboundReqMsg.setProperty(HttpConstants.MATRIX_PARAMS, matrixParams);
 
-            URI validatedUri = getValidatedURI(HTTP_SCHEME + SCHEME_SEPARATOR + uriWithoutMatrixParams);
+            String[] splittedUri = uriWithoutMatrixParams.split("\\?");
+            String queryString = splittedUri.length > 1 ? splittedUri[1] : "";
+            String rawPath = splittedUri[0];
 
-            String basePath = servicesRegistry.findTheMostSpecificBasePath(validatedUri.getRawPath(),
+            String basePath = servicesRegistry.findTheMostSpecificBasePath(rawPath,
                                                                            servicesOnInterface, sortedServiceURIs);
 
             if (basePath == null) {
-                String message = "no matching service found for path : " + validatedUri.getRawPath();
+                String message = "no matching service found for path : " + rawPath;
                 throw HttpUtil.createHttpStatusCodeError(SERVICE_NOT_FOUND_ERROR, message);
             }
 
             InterceptorService service = servicesOnInterface.get(basePath);
-            setInboundReqProperties(inboundReqMsg, validatedUri, basePath);
+            setInboundReqProperties(inboundReqMsg, rawPath, basePath, queryString);
             return service;
         } catch (Exception e) {
             if (!(e instanceof BError)) {
@@ -180,23 +181,13 @@ public class HttpDispatcher {
         }
     }
 
-    private static void setInboundReqProperties(HttpCarbonMessage inboundReqMsg, URI requestUri, String basePath) {
-        String subPath = URIUtil.getSubPath(requestUri.getRawPath(), basePath);
+    private static void setInboundReqProperties(HttpCarbonMessage inboundReqMsg, String rawPath,
+                                                String basePath, String rawQuery) {
+        String subPath = URIUtil.getSubPath(rawPath, basePath);
         inboundReqMsg.setProperty(HttpConstants.BASE_PATH, basePath);
         inboundReqMsg.setProperty(HttpConstants.SUB_PATH, subPath);
-        inboundReqMsg.setProperty(HttpConstants.QUERY_STR, requestUri.getQuery());
         //store query params comes with request as it is
-        inboundReqMsg.setProperty(HttpConstants.RAW_QUERY_STR, requestUri.getRawQuery());
-    }
-
-    public static URI getValidatedURI(String uriStr) {
-        URI requestUri;
-        try {
-            requestUri = URI.create(uriStr);
-        } catch (IllegalArgumentException e) {
-            throw new BallerinaConnectorException(e.getMessage());
-        }
-        return requestUri;
+        inboundReqMsg.setProperty(HttpConstants.RAW_QUERY_STR, rawQuery);
     }
 
     /**

--- a/native/src/main/java/io/ballerina/stdlib/http/uri/URIUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/uri/URIUtil.java
@@ -111,8 +111,7 @@ public class URIUtil {
     }
 
 
-    public static String extractMatrixParams(String path, Map<String, Map<String, String>> matrixParams,
-                                             HttpCarbonMessage inboundReqMsg) {
+    public static String extractMatrixParams(String path, Map<String, Map<String, String>> matrixParams) {
         if (path.startsWith("/")) {
             path = path.substring(1);
         }

--- a/native/src/main/java/io/ballerina/stdlib/http/uri/URIUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/uri/URIUtil.java
@@ -29,6 +29,7 @@ import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -70,7 +71,7 @@ public class URIUtil {
             List<String> values = new ArrayList<>();
             Set<String> uniqueValues = new HashSet<>();
             for (String val : queryParamValue.split(",")) {
-                String decodedValue = URLDecoder.decode(val, "UTF-8");
+                String decodedValue = URLDecoder.decode(val, StandardCharsets.UTF_8);
                 if (uniqueValues.add(decodedValue)) {
                     values.add(decodedValue);
                 }


### PR DESCRIPTION
## Purpose
Related to https://github.com/wso2-enterprise/internal-support-ballerina/issues/350
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/4565

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [x] Checked native-image compatibility
