### PR TITLE
Add removed dispatcher apis

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -48,6 +48,7 @@ public class HttpConstants {
     public static final String RAW_URI = "RAW_URI";
     public static final String RESOURCE_ARGS = "RESOURCE_ARGS";
     public static final String MATRIX_PARAMS = "MATRIX_PARAMS";
+    public static final String QUERY_STR = "QUERY_STR";
     public static final String RAW_QUERY_STR = "RAW_QUERY_STR";
 
     public static final String DEFAULT_INTERFACE = "0.0.0.0:8080";

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
@@ -96,7 +96,7 @@ public class HttpDispatcher {
 
             String rawUri = (String) inboundReqMsg.getProperty(HttpConstants.TO);
             Map<String, Map<String, String>> matrixParams = new HashMap<>();
-            String uriWithoutMatrixParams = URIUtil.extractMatrixParams(rawUri, matrixParams);
+            String uriWithoutMatrixParams = URIUtil.extractMatrixParams(rawUri, matrixParams, inboundReqMsg);
 
             String[] rawPathAndQuery = extractRawPathAndQuery(uriWithoutMatrixParams);
 
@@ -154,7 +154,7 @@ public class HttpDispatcher {
             String rawUri = (String) inboundReqMsg.getProperty(HttpConstants.TO);
             inboundReqMsg.setProperty(HttpConstants.RAW_URI, rawUri);
             Map<String, Map<String, String>> matrixParams = new HashMap<>();
-            String uriWithoutMatrixParams = URIUtil.extractMatrixParams(rawUri, matrixParams);
+            String uriWithoutMatrixParams = URIUtil.extractMatrixParams(rawUri, matrixParams, inboundReqMsg);
 
             inboundReqMsg.setProperty(HttpConstants.TO, uriWithoutMatrixParams);
             inboundReqMsg.setProperty(HttpConstants.MATRIX_PARAMS, matrixParams);

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
@@ -45,6 +45,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -195,6 +196,16 @@ public class HttpDispatcher {
         inboundReqMsg.setProperty(HttpConstants.QUERY_STR, rawQuery);
         //store query params comes with request as it is
         inboundReqMsg.setProperty(HttpConstants.RAW_QUERY_STR, rawQuery);
+    }
+
+    public static URI getValidatedURI(String uriStr) {
+        URI requestUri;
+        try {
+            requestUri = URI.create(uriStr);
+        } catch (IllegalArgumentException e) {
+            throw new BallerinaConnectorException(e.getMessage());
+        }
+        return requestUri;
     }
 
     /**

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpDispatcher.java
@@ -192,6 +192,7 @@ public class HttpDispatcher {
         String subPath = URIUtil.getSubPath(rawPath, basePath);
         inboundReqMsg.setProperty(HttpConstants.BASE_PATH, basePath);
         inboundReqMsg.setProperty(HttpConstants.SUB_PATH, subPath);
+        inboundReqMsg.setProperty(HttpConstants.QUERY_STR, rawQuery);
         //store query params comes with request as it is
         inboundReqMsg.setProperty(HttpConstants.RAW_QUERY_STR, rawQuery);
     }

--- a/native/src/main/java/io/ballerina/stdlib/http/uri/URIUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/uri/URIUtil.java
@@ -111,7 +111,8 @@ public class URIUtil {
     }
 
 
-    public static String extractMatrixParams(String path, Map<String, Map<String, String>> matrixParams) {
+    public static String extractMatrixParams(String path, Map<String, Map<String, String>> matrixParams,
+                                             HttpCarbonMessage inboundReqMsg) {
         if (path.startsWith("/")) {
             path = path.substring(1);
         }


### PR DESCRIPTION
## Purpose
This is related to https://github.com/ballerina-platform/ballerina-standard-library/issues/4565
Faced some downstream repo test failures with the changes. Therefore adding the apis back.
Builds are working with this - https://github.com/dilanSachi/module-ballerina-http/actions/runs/5267035877/jobs/9521766326
## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
