### PR TITLE
Add compiler plugin completions in http service

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.9.1"
+version = "2.10.0"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.7.0"
+distribution = "2201.8.0"
 export = ["http", "http.httpscerr"]
 
 [platform.java11]
@@ -16,8 +16,8 @@ graalvmCompatible = true
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.9.1"
-path = "../native/build/libs/http-native-2.9.1-SNAPSHOT.jar"
+version = "2.10.0"
+path = "../native/build/libs/http-native-2.10.0-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.9.1-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.10.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.7.0"
+distribution-version = "2201.8.0-20230716-001200-4e224cd5"
 
 [[package]]
 org = "ballerina"
@@ -76,7 +76,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.7.0"
+distribution = "2201.8.0"
 export = ["http", "http.httpscerr"]
 
 [platform.java11]

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/AbstractLSCompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/AbstractLSCompilerPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/AbstractLSCompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/AbstractLSCompilerPluginTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.http.compiler;
+
+import io.ballerina.projects.ProjectEnvironmentBuilder;
+import io.ballerina.projects.environment.Environment;
+import io.ballerina.projects.environment.EnvironmentBuilder;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Abstract compiler plugin test for LS.
+ */
+public class AbstractLSCompilerPluginTest {
+    protected static final Path RESOURCE_PATH = Paths.get("src", "test", "resources");
+    protected static final Path DISTRIBUTION_PATH = Paths.get("../", "target", "ballerina-runtime");
+
+    protected static ProjectEnvironmentBuilder getEnvironmentBuilder() {
+        Environment environment = EnvironmentBuilder.getBuilder().setBallerinaHome(DISTRIBUTION_PATH).build();
+        return ProjectEnvironmentBuilder.getBuilder(environment);
+    }
+}

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/codeaction/AbstractCodeActionTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/codeaction/AbstractCodeActionTest.java
@@ -26,23 +26,20 @@ import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.Package;
 import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.Project;
-import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.directory.ProjectLoader;
-import io.ballerina.projects.environment.Environment;
-import io.ballerina.projects.environment.EnvironmentBuilder;
 import io.ballerina.projects.plugins.codeaction.CodeActionArgument;
 import io.ballerina.projects.plugins.codeaction.CodeActionContextImpl;
 import io.ballerina.projects.plugins.codeaction.CodeActionExecutionContext;
 import io.ballerina.projects.plugins.codeaction.CodeActionExecutionContextImpl;
 import io.ballerina.projects.plugins.codeaction.CodeActionInfo;
 import io.ballerina.projects.plugins.codeaction.DocumentEdit;
+import io.ballerina.stdlib.http.compiler.AbstractLSCompilerPluginTest;
 import io.ballerina.tools.text.LinePosition;
 import org.testng.Assert;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -50,18 +47,10 @@ import java.util.stream.Collectors;
 /**
  * Abstract implementation of codeaction tests.
  */
-public abstract class AbstractCodeActionTest {
-
-    protected static final Path RESOURCE_PATH = Paths.get("src", "test", "resources");
-    protected static final Path DISTRIBUTION_PATH = Paths.get("../", "target", "ballerina-runtime");
+public abstract class AbstractCodeActionTest extends AbstractLSCompilerPluginTest {
 
     private static final Gson GSON = new Gson();
-
-    private static ProjectEnvironmentBuilder getEnvironmentBuilder() {
-        Environment environment = EnvironmentBuilder.getBuilder().setBallerinaHome(DISTRIBUTION_PATH).build();
-        return ProjectEnvironmentBuilder.getBuilder(environment);
-    }
-
+    
     /**
      * Performs the actual test. This will verify both the code action title/args and the edits made once executed.
      *

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/completion/AbstractCompletionTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/completion/AbstractCompletionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/completion/AbstractCompletionTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/completion/AbstractCompletionTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.http.compiler.completion;
+
+import com.google.gson.Gson;
+import io.ballerina.compiler.syntax.tree.ModulePartNode;
+import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.projects.CompletionManager;
+import io.ballerina.projects.CompletionResult;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.Module;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageCompilation;
+import io.ballerina.projects.Project;
+import io.ballerina.projects.directory.ProjectLoader;
+import io.ballerina.projects.plugins.completion.CompletionContext;
+import io.ballerina.projects.plugins.completion.CompletionContextImpl;
+import io.ballerina.projects.plugins.completion.CompletionException;
+import io.ballerina.projects.plugins.completion.CompletionItem;
+import io.ballerina.stdlib.http.compiler.AbstractLSCompilerPluginTest;
+import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.TextRange;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Abstract implementation of completion tests.
+ */
+public abstract class AbstractCompletionTest extends AbstractLSCompilerPluginTest {
+
+    private static final Gson GSON = new Gson();
+
+
+    @Test(dataProvider = "completion-data-provider")
+    protected void test(String filePath, int line, int offset, String configFile)
+            throws IOException {
+
+        Path sourceFilePath = Path.of(filePath);
+        Path configfilePath = Path.of(configFile);
+        TestConfig expectedList =
+                GSON.fromJson(Files.newBufferedReader(configfilePath), TestConfig.class);
+        List<CompletionItem> expectedItems = expectedList.getItems();
+        LinePosition cursorPos = LinePosition.from(line, offset);
+
+        Project project = ProjectLoader.loadProject(sourceFilePath, getEnvironmentBuilder());
+        CompletionResult completionResult = getCompletions(sourceFilePath, cursorPos, project);
+        List<CompletionItem> actualItems = completionResult.getCompletionItems();
+        List<CompletionException> errors = completionResult.getErrors();
+        Assert.assertTrue(errors.isEmpty());
+        Assert.assertTrue(compareCompletionItems(actualItems, expectedItems));
+    }
+
+    private static boolean compareCompletionItems(List<CompletionItem> actualItems,
+                                                  List<CompletionItem> expectedItems) {
+        List<String> actualList = actualItems.stream()
+                .map(AbstractCompletionTest::getCompletionItemPropertyString)
+                .collect(Collectors.toList());
+        List<String> expectedList = expectedItems.stream()
+                .map(AbstractCompletionTest::getCompletionItemPropertyString)
+                .collect(Collectors.toList());
+        return actualList.containsAll(expectedList) && actualItems.size() == expectedItems.size();
+    }
+
+    private static String getCompletionItemPropertyString(CompletionItem completionItem) {
+        // Here we replace the Windows specific \r\n to \n for evaluation only
+        String additionalTextEdits = "";
+        if (completionItem.getAdditionalTextEdits() != null && !completionItem.getAdditionalTextEdits().isEmpty()) {
+            additionalTextEdits = "," + GSON.toJson(completionItem.getAdditionalTextEdits());
+        }
+        return ("{" +
+                completionItem.getInsertText() + "," +
+                completionItem.getLabel() + "," +
+                completionItem.getPriority() +
+                additionalTextEdits +
+                "}").replace("\r\n", "\n").replace("\\r\\n", "\\n");
+    }
+
+    private CompletionResult getCompletions(Path filePath, LinePosition cursorPos, Project project) {
+
+        Package currentPackage = project.currentPackage();
+        PackageCompilation compilation = currentPackage.getCompilation();
+        CompletionManager completionManager = compilation.getCompletionManager();
+
+        DocumentId documentId = project.documentId(filePath);
+        Document document = currentPackage.getDefaultModule().document(documentId);
+        Module module = project.currentPackage().module(documentId.moduleId());
+
+        int cursorPositionInTree = document.textDocument().textPositionFrom(cursorPos);
+        TextRange range = TextRange.from(cursorPositionInTree, 0);
+        NonTerminalNode nodeAtCursor = ((ModulePartNode) document.syntaxTree().rootNode()).findNode(range);
+
+        CompletionContext completionContext = CompletionContextImpl.from(filePath.toUri().toString(),
+                filePath, cursorPos, cursorPositionInTree, nodeAtCursor, document,
+                module.getCompilation().getSemanticModel());
+
+        return completionManager.completions(completionContext);
+    }
+
+    @DataProvider(name = "completion-data-provider")
+    public abstract Object[][] dataProvider();
+
+    /**
+     * Represents the completion test config.
+     */
+    public static class TestConfig {
+        private List<CompletionItem> items;
+
+        public void setItems(List<CompletionItem> items) {
+            this.items = items;
+        }
+
+        public List<CompletionItem> getItems() {
+            return items;
+        }
+    }
+
+}

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/completion/ServiceDeclarationNodeContextTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/completion/ServiceDeclarationNodeContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/completion/ServiceDeclarationNodeContextTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/completion/ServiceDeclarationNodeContextTest.java
@@ -47,8 +47,7 @@ public class ServiceDeclarationNodeContextTest extends AbstractCompletionTest {
         return new Object[][]{
                 {"sample_completion_package_1/main.bal", 22, 5, "expected_completions1.json"},
                 {"sample_completion_package_2/main.bal", 22, 5, "expected_completions1.json"},
-                {"sample_completion_package_2/main.bal", 35, 5, "expected_completions1.json"},
-                
+                {"sample_completion_package_2/main.bal", 35, 5, "expected_completions1.json"}
         };
     }
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/completion/ServiceDeclarationNodeContextTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/completion/ServiceDeclarationNodeContextTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.http.compiler.completion;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Tests the completions in ServiceDeclarationNode context.
+ */
+public class ServiceDeclarationNodeContextTest extends AbstractCompletionTest {
+
+    
+    @Override
+    @Test(dataProvider = "completion-data-provider")
+    protected void test(String filePath, int line, int offset, String configFile)
+            throws IOException {
+        Path filePathFromSourceRoot = RESOURCE_PATH.resolve("ballerina_sources")
+                .resolve(filePath);
+        Path configPath = RESOURCE_PATH.resolve("completion")
+                .resolve(getConfigDir())
+                .resolve(configFile);
+        super.test(filePathFromSourceRoot.toString(), line, offset, configPath.toString());
+    }
+
+    @DataProvider(name = "completion-data-provider")
+    @Override
+    public Object[][] dataProvider() {
+        return new Object[][]{
+                {"sample_completion_package_1/main.bal", 22, 5, "expected_completions1.json"},
+                {"sample_completion_package_2/main.bal", 22, 5, "expected_completions1.json"},
+                {"sample_completion_package_2/main.bal", 35, 5, "expected_completions1.json"},
+                
+        };
+    }
+
+    protected String getConfigDir() {
+        return "service_declaration";
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_completion_package_1/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_completion_package_1/Ballerina.toml
@@ -1,0 +1,5 @@
+[package]
+org = "http_test"
+name = "sample_completion_package_1"
+version = "0.1.0"
+

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_completion_package_1/main.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_completion_package_1/main.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_completion_package_1/main.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_completion_package_1/main.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This is added to test some auto generated code segments.
+// Please ignore the indentation.
+
+import ballerina/http;
+
+service /greeting on new http:Listener(9090) {
+    r
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_completion_package_2/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_completion_package_2/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "http_test"
+name = "sample_completion_package_2"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_completion_package_2/main.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_completion_package_2/main.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_completion_package_2/main.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_completion_package_2/main.bal
@@ -1,0 +1,37 @@
+// Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This is added to test some auto generated code segments.
+// Please ignore the indentation.
+
+import ballerina/http;
+
+service /greeting on new http:Listener(9090) {
+    r
+    
+    resource function post() returns string {
+        return "Hello Ballerina";
+    }
+}
+
+service /greeting on new http:Listener(8080) {
+    
+    resource function post() returns string {
+        return "Hello Ballerina";
+    }
+    
+    r
+}

--- a/compiler-plugin-tests/src/test/resources/completion/service_declaration/expected_completions1.json
+++ b/compiler-plugin-tests/src/test/resources/completion/service_declaration/expected_completions1.json
@@ -1,0 +1,34 @@
+{
+  "items": [
+    {
+      "label": "resource function get path()",
+      "insertText": "resource function get ${1:path}(${2}) ${3}{\n\t${4}\n}",
+      "priority": "HIGH"
+    },
+    {
+      "label": "resource function post path()",
+      "insertText": "resource function post ${1:path}(${2}) ${3}{\n\t${4}\n}",
+      "priority": "HIGH"
+    },
+    {
+      "label": "resource function put path()",
+      "insertText": "resource function put ${1:path}(${2}) ${3}{\n\t${4}\n}",
+      "priority": "HIGH"
+    },
+    {
+      "label": "resource function delete path()",
+      "insertText": "resource function delete ${1:path}(${2}) ${3}{\n\t${4}\n}",
+      "priority": "HIGH"
+    },
+    {
+      "label": "resource function head path()",
+      "insertText": "resource function head ${1:path}(${2}) ${3}{\n\t${4}\n}",
+      "priority": "HIGH"
+    },
+    {
+      "label": "resource function options path()",
+      "insertText": "resource function options ${1:path}(${2}) ${3}{\n\t${4}\n}",
+      "priority": "HIGH"
+    }
+  ]
+}

--- a/compiler-plugin-tests/src/test/resources/testng.xml
+++ b/compiler-plugin-tests/src/test/resources/testng.xml
@@ -22,6 +22,7 @@
     <test name="UnitTests">
         <packages>
             <package name="io.ballerina.stdlib.http.compiler.codeaction.*"/>
+            <package name="io.ballerina.stdlib.http.compiler.completion.*"/>
         </packages>
         <classes>
             <class name="io.ballerina.stdlib.http.compiler.CompilerPluginTest"/>

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpCompilerPlugin.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpCompilerPlugin.java
@@ -18,9 +18,11 @@
 
 package io.ballerina.stdlib.http.compiler;
 
+import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.projects.plugins.CompilerPlugin;
 import io.ballerina.projects.plugins.CompilerPluginContext;
 import io.ballerina.projects.plugins.codeaction.CodeAction;
+import io.ballerina.projects.plugins.completion.CompletionProvider;
 import io.ballerina.stdlib.http.compiler.codeaction.AddHeaderParameterCodeAction;
 import io.ballerina.stdlib.http.compiler.codeaction.AddInterceptorRemoteMethodCodeAction;
 import io.ballerina.stdlib.http.compiler.codeaction.AddInterceptorResourceMethodCodeAction;
@@ -31,6 +33,7 @@ import io.ballerina.stdlib.http.compiler.codeaction.ChangeHeaderParamTypeToStrin
 import io.ballerina.stdlib.http.compiler.codeaction.ChangeHeaderParamTypeToStringCodeAction;
 import io.ballerina.stdlib.http.compiler.codeaction.ChangeReturnTypeWithCallerCodeAction;
 import io.ballerina.stdlib.http.compiler.codemodifier.HttpServiceModifier;
+import io.ballerina.stdlib.http.compiler.completion.HttpServiceBodyContextProvider;
 
 import java.util.List;
 
@@ -44,6 +47,7 @@ public class HttpCompilerPlugin extends CompilerPlugin {
         context.addCodeModifier(new HttpServiceModifier());
         context.addCodeAnalyzer(new HttpServiceAnalyzer());
         getCodeActions().forEach(context::addCodeAction);
+        getCompletionProviders().forEach(context::addCompletionProvider);
     }
 
     private List<CodeAction> getCodeActions() {
@@ -58,5 +62,9 @@ public class HttpCompilerPlugin extends CompilerPlugin {
                 new AddInterceptorResourceMethodCodeAction(),
                 new AddInterceptorRemoteMethodCodeAction()
         );
+    }
+
+    private List<CompletionProvider<? extends Node>> getCompletionProviders() {
+        return List.of(new HttpServiceBodyContextProvider());
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/completion/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/completion/Constants.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.http.compiler.completion;
+
+
+import java.util.List;
+
+/**
+ * Constants related to compiler plugin completion implementation.
+ */
+public class Constants {
+    public static final String GET = "get";
+    public static final String POST = "post";
+
+    public static final String PUT = "put";
+    public static final String DELETE = "delete";
+
+    public static final String HEAD = "head";
+
+    public static final String OPTIONS = "options";
+
+    public static final List<String> METHODS = List.of(GET, POST, PUT, DELETE, HEAD, OPTIONS);
+
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/completion/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/completion/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/completion/HttpServiceBodyContextProvider.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/completion/HttpServiceBodyContextProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.http.compiler.completion;
+
+import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
+import io.ballerina.projects.plugins.completion.CompletionContext;
+import io.ballerina.projects.plugins.completion.CompletionException;
+import io.ballerina.projects.plugins.completion.CompletionItem;
+import io.ballerina.projects.plugins.completion.CompletionProvider;
+import io.ballerina.projects.plugins.completion.CompletionUtil;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Completion provider for Http services.
+ */
+public class HttpServiceBodyContextProvider implements CompletionProvider<ServiceDeclarationNode> {
+
+    private static final String NAME = "HttpServiceBodyProvider";
+
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public List<CompletionItem> getCompletions(CompletionContext completionContext,
+                                               ServiceDeclarationNode serviceDeclarationNode)
+            throws CompletionException {
+
+        //Add resource function snippets for get,post,delete,put,head,and options http methods.
+        return Constants.METHODS.stream().map(method -> {
+            String insertText = "resource function " + method + " "
+                    + CompletionUtil.getPlaceHolderText(1, "path")
+                    + "(" + CompletionUtil.getPlaceHolderText(2) + ") " + CompletionUtil.getPlaceHolderText(3)
+                    + "{" + CompletionUtil.LINE_BREAK + CompletionUtil.PADDING + CompletionUtil.getPlaceHolderText(4)
+                    + CompletionUtil.LINE_BREAK + "}";
+            String label = "resource function " + method + " path()";
+            return new CompletionItem(label, insertText, CompletionItem.Priority.HIGH);
+        }).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Class<ServiceDeclarationNode>> getSupportedNodes() {
+        return List.of(ServiceDeclarationNode.class);
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/completion/HttpServiceBodyContextProvider.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/completion/HttpServiceBodyContextProvider.java
@@ -47,11 +47,11 @@ public class HttpServiceBodyContextProvider implements CompletionProvider<Servic
 
         //Add resource function snippets for get,post,delete,put,head,and options http methods.
         return Constants.METHODS.stream().map(method -> {
-            String insertText = "resource function " + method + " "
-                    + CompletionUtil.getPlaceHolderText(1, "path")
-                    + "(" + CompletionUtil.getPlaceHolderText(2) + ") " + CompletionUtil.getPlaceHolderText(3)
-                    + "{" + CompletionUtil.LINE_BREAK + CompletionUtil.PADDING + CompletionUtil.getPlaceHolderText(4)
-                    + CompletionUtil.LINE_BREAK + "}";
+            String insertText = String.format("resource function %s %s(%s) %s{%s}", method
+                    , CompletionUtil.getPlaceHolderText(1, "path")
+                    , CompletionUtil.getPlaceHolderText(2), CompletionUtil.getPlaceHolderText(3)
+                    , CompletionUtil.LINE_BREAK + CompletionUtil.PADDING + CompletionUtil.getPlaceHolderText(4)
+                            + CompletionUtil.LINE_BREAK);
             String label = "resource function " + method + " path()";
             return new CompletionItem(label, insertText, CompletionItem.Priority.HIGH);
         }).collect(Collectors.toList());

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.10.0-SNAPSHOT
-ballerinaLangVersion= 2201.8.0-20230716-001200-4e224cd5
+ballerinaLangVersion=2201.8.0-20230716-001200-4e224cd5
 ballerinaTomlParserVersion=1.2.2
 commonsLang3Version=3.8.1
 nettyVersion=4.1.94.Final

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=2.9.1-SNAPSHOT
-ballerinaLangVersion=2201.7.0
+version=2.10.0-SNAPSHOT
+ballerinaLangVersion= 2201.8.0-20230716-001200-4e224cd5
 ballerinaTomlParserVersion=1.2.2
 commonsLang3Version=3.8.1
 nettyVersion=4.1.94.Final


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/40634

## Examples
![http_compiler_plugin](https://github.com/ballerina-platform/module-ballerina-http/assets/35211477/2768fac7-da10-4b78-bc5d-c48379c8c3c6)

This PR implements a CompletionProvider in http compiler plugin which adds six new completion items for get, post, delete, put, head, and options http methods. 

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
