### PR TITLE
[2201.7.x] Fix exception when return type of `createInterceptors` function is an array type

### DIFF
--- a/ballerina-tests/http-interceptor-tests/Ballerina.toml
+++ b/ballerina-tests/http-interceptor-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_interceptor_tests"
-version = "2.9.0"
+version = "2.9.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.9.0"
+version = "2.9.1"
 
 [platform.java11]
 graalvmCompatible = true
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.9.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.9.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-interceptor-tests/Dependencies.toml
+++ b/ballerina-tests/http-interceptor-tests/Dependencies.toml
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_interceptor_tests"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -115,7 +115,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-interceptor-tests/tests/interceptors_basic_tests.bal
+++ b/ballerina-tests/http-interceptor-tests/tests/interceptors_basic_tests.bal
@@ -196,7 +196,7 @@ listener http:Listener responseInterceptorReturnsErrorTestServerEP = new(respons
 
 service http:InterceptableService / on responseInterceptorReturnsErrorTestServerEP {
 
-    public function createInterceptors() returns [LastResponseInterceptor, ResponseInterceptorReturnsError, DefaultResponseInterceptor] {
+    public function createInterceptors() returns http:Interceptor[] {
         return [new LastResponseInterceptor(), new ResponseInterceptorReturnsError(), new DefaultResponseInterceptor()];
     }
 
@@ -561,7 +561,7 @@ service http:InterceptableService /requestInterceptorJwtInformation on new http:
         }
     }) {
 
-    public function createInterceptors() returns RequestInterceptorJwtInformation {
+    public function createInterceptors() returns http:Interceptor {
         return new RequestInterceptorJwtInformation();
     }
 

--- a/ballerina-tests/http-test-common/Ballerina.toml
+++ b/ballerina-tests/http-test-common/Ballerina.toml
@@ -1,4 +1,4 @@
 [package]
 org = "ballerina"
 name = "http_test_common"
-version = "2.9.0"
+version = "2.9.1"

--- a/ballerina-tests/http-test-common/Dependencies.toml
+++ b/ballerina-tests/http-test-common/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.7.0"
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "mime"},

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.9.0"
+version = "2.9.1"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -16,8 +16,8 @@ graalvmCompatible = true
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.9.0"
-path = "../native/build/libs/http-native-2.9.0.jar"
+version = "2.9.1"
+path = "../native/build/libs/http-native-2.9.1-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.9.0.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.9.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -76,7 +76,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ This file contains all the notable changes done to the Ballerina HTTP package th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- [Fix exception when return type of `createInterceptors` function is an array type](https://github.com/ballerina-platform/ballerina-standard-library/issues/4649)
+
 ## [2.9.0] - 2023-06-30
 
 ### Added

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpService.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpService.java
@@ -499,6 +499,9 @@ public class HttpService implements Service {
         Object[] interceptors = interceptorsArrayFromService.getValues();
         List<Object> interceptorServices = new ArrayList<>();
         for (Object interceptor: interceptors) {
+            if (Objects.isNull(interceptor)) {
+                break;
+            }
             interceptorServices.add(interceptor);
         }
 
@@ -529,6 +532,9 @@ public class HttpService implements Service {
                 interceptorsArray.append(interceptor);
             }
             for (Object interceptor : fromService.getValues()) {
+                if (Objects.isNull(interceptor)) {
+                    break;
+                }
                 interceptorsArray.append(interceptor);
             }
             service.setBalInterceptorServicesArray(interceptorsArray);


### PR DESCRIPTION
## Purpose
$subject
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/4649
## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
