### PR TITLE
Allow open records as query param

### DIFF
--- a/ballerina-tests/http-advanced-tests/Ballerina.toml
+++ b/ballerina-tests/http-advanced-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_advanced_tests"
-version = "2.9.0"
+version = "2.9.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.9.0"
+version = "2.9.1"
 
 [platform.java11]
 graalvmCompatible = true
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.9.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.9.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-advanced-tests/Dependencies.toml
+++ b/ballerina-tests/http-advanced-tests/Dependencies.toml
@@ -57,7 +57,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.8.0"
+version = "1.8.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -72,7 +72,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -105,7 +105,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_advanced_tests"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},
@@ -125,7 +125,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-client-tests/Ballerina.toml
+++ b/ballerina-tests/http-client-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_client_tests"
-version = "2.9.0"
+version = "2.9.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.9.0"
+version = "2.9.1"
 
 [platform.java11]
 graalvmCompatible = true
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.9.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.9.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-client-tests/Dependencies.toml
+++ b/ballerina-tests/http-client-tests/Dependencies.toml
@@ -57,7 +57,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.8.0"
+version = "1.8.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_client_tests"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-dispatching-tests/Ballerina.toml
+++ b/ballerina-tests/http-dispatching-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_dispatching_tests"
-version = "2.9.0"
+version = "2.9.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.9.0"
+version = "2.9.1"
 
 [platform.java11]
 graalvmCompatible = true
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.9.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.9.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-dispatching-tests/Dependencies.toml
+++ b/ballerina-tests/http-dispatching-tests/Dependencies.toml
@@ -57,7 +57,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.8.0"
+version = "1.8.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_dispatching_tests"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
@@ -124,7 +124,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-interceptor-tests/Dependencies.toml
+++ b/ballerina-tests/http-interceptor-tests/Dependencies.toml
@@ -54,7 +54,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.8.0"
+version = "1.8.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},

--- a/ballerina-tests/http-misc-tests/Ballerina.toml
+++ b/ballerina-tests/http-misc-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_misc_tests"
-version = "2.9.0"
+version = "2.9.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.9.0"
+version = "2.9.1"
 
 [platform.java11]
 graalvmCompatible = true
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.9.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.9.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-misc-tests/Dependencies.toml
+++ b/ballerina-tests/http-misc-tests/Dependencies.toml
@@ -54,7 +54,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.8.0"
+version = "1.8.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_misc_tests"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -118,7 +118,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-resiliency-tests/Ballerina.toml
+++ b/ballerina-tests/http-resiliency-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_resiliency_tests"
-version = "2.9.0"
+version = "2.9.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.9.0"
+version = "2.9.1"
 
 [platform.java11]
 graalvmCompatible = true
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.9.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.9.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-resiliency-tests/Dependencies.toml
+++ b/ballerina-tests/http-resiliency-tests/Dependencies.toml
@@ -54,7 +54,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.8.0"
+version = "1.8.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_resiliency_tests"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -116,7 +116,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-security-tests/Ballerina.toml
+++ b/ballerina-tests/http-security-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.9.0"
+version = "2.9.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.9.0"
+version = "2.9.1"
 
 [platform.java11]
 graalvmCompatible = true
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.9.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.9.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-security-tests/Dependencies.toml
+++ b/ballerina-tests/http-security-tests/Dependencies.toml
@@ -57,7 +57,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.8.0"
+version = "1.8.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "http"},
@@ -120,7 +120,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-service-tests/Ballerina.toml
+++ b/ballerina-tests/http-service-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_service_tests"
-version = "2.9.0"
+version = "2.9.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.9.0"
+version = "2.9.1"
 
 [platform.java11]
 graalvmCompatible = true
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.9.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.9.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-service-tests/Dependencies.toml
+++ b/ballerina-tests/http-service-tests/Dependencies.toml
@@ -54,7 +54,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.8.0"
+version = "1.8.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -69,7 +69,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_service_tests"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http2-tests/Ballerina.toml
+++ b/ballerina-tests/http2-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http2_tests"
-version = "2.9.0"
+version = "2.9.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.9.0"
+version = "2.9.1"
 
 [platform.java11]
 graalvmCompatible = true
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.9.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.9.1-SNAPSHOT.jar"

--- a/ballerina-tests/http2-tests/Dependencies.toml
+++ b/ballerina-tests/http2-tests/Dependencies.toml
@@ -54,7 +54,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.8.0"
+version = "1.8.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -69,7 +69,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http2_tests"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.9.0"
+version = "2.9.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -62,7 +62,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Fix exception when return type of `createInterceptors` function is an array type](https://github.com/ballerina-platform/ballerina-standard-library/issues/4649)
 
+### Added
+
+- [Add open record support for query parameters](https://github.com/ballerina-platform/ballerina-standard-library/issues/4541)
+
 ## [2.9.0] - 2023-06-30
 
 ### Added

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -247,9 +247,8 @@ public class CompilerPluginTest {
         assertTrue(diagnosticResult, 1, "invalid resource parameter type: 'ballerina/http", HTTP_106);
         assertTrue(diagnosticResult, 2, "invalid resource parameter type: 'ballerina/mime", HTTP_106);
         assertTrue(diagnosticResult, 3, "invalid resource parameter type: 'ballerina/mime", HTTP_106);
-        assertError(diagnosticResult, 4, "invalid type of query param 'abc': expected one of the " +
-                "'string', 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them",
-                HTTP_112);
+        assertError(diagnosticResult, 4, "invalid resource parameter type: 'http_test/sample_7:0.1.0:Caller'",
+                HTTP_106);
     }
 
     @Test
@@ -260,28 +259,28 @@ public class CompilerPluginTest {
         Assert.assertEquals(diagnosticResult.errorCount(), 9);
         assertTrue(diagnosticResult, 0, "invalid resource parameter type: 'ballerina/mime", HTTP_106);
         assertError(diagnosticResult, 1, "invalid union type of query param 'a': 'string', 'int', " +
-                "'float', 'boolean', 'decimal', 'map<json>' type or the array types of them can only be union with " +
-                "'()'. Eg: string? or int[]?", HTTP_113);
+                "'float', 'boolean', 'decimal', 'map<anydata>' type or the array types of them can only be union" +
+                " with '()'. Eg: string? or int[]?", HTTP_113);
         assertError(diagnosticResult, 2, "invalid union type of query param 'b': 'string', 'int', " +
-                "'float', 'boolean', 'decimal', 'map<json>' type or the array types of them can only be union with " +
-                "'()'. Eg: string? or int[]?", HTTP_113);
+                "'float', 'boolean', 'decimal', 'map<anydata>' type or the array types of them can only be union" +
+                " with '()'. Eg: string? or int[]?", HTTP_113);
         assertError(diagnosticResult, 3, "invalid union type of query param 'c': 'string', 'int', " +
-                "'float', 'boolean', 'decimal', 'map<json>' type or the array types of them can only be union with " +
-                "'()'. Eg: string? or int[]?", HTTP_113);
+                "'float', 'boolean', 'decimal', 'map<anydata>' type or the array types of them can only be union" +
+                " with '()'. Eg: string? or int[]?", HTTP_113);
         assertError(diagnosticResult, 4, "invalid type of query param 'd': expected one of the " +
-                "'string', 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them",
+                "'string', 'int', 'float', 'boolean', 'decimal', 'map<anydata>' types or the array types of them",
                 HTTP_112);
         assertError(diagnosticResult, 5, "invalid type of query param 'a': expected one of the " +
-                "'string', 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them",
+                "'string', 'int', 'float', 'boolean', 'decimal', 'map<anydata>' types or the array types of them",
                 HTTP_112);
         assertError(diagnosticResult, 6, "invalid type of query param 'aa': expected one of the " +
-                "'string', 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them",
+                "'string', 'int', 'float', 'boolean', 'decimal', 'map<anydata>' types or the array types of them",
                 HTTP_112);
         assertError(diagnosticResult, 7, "invalid type of query param 'd': expected one of the " +
-                "'string', 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them",
+                "'string', 'int', 'float', 'boolean', 'decimal', 'map<anydata>' types or the array types of them",
                 HTTP_112);
         assertError(diagnosticResult, 8, "invalid type of query param 'e': expected one of the " +
-                "'string', 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them",
+                "'string', 'int', 'float', 'boolean', 'decimal', 'map<anydata>' types or the array types of them",
                 HTTP_112);
     }
 
@@ -857,32 +856,32 @@ public class CompilerPluginTest {
         assertError(diagnosticResult, 23, "invalid resource path parameter 'path': expected one of the 'string'," +
                 "'int','float','decimal','boolean' types or a rest parameter with one of the above types", HTTP_145);
         assertError(diagnosticResult, 24, "invalid union type of query param 'query': 'string', 'int', 'float', " +
-                "'boolean', 'decimal', 'map<json>' type or the array types of them can only be union with '()'." +
+                "'boolean', 'decimal', 'map<anydata>' type or the array types of them can only be union with '()'." +
                 " Eg: string? or int[]?", HTTP_113);
         assertError(diagnosticResult, 25, "invalid type of query param 'query': expected one of the 'string'," +
-                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
+                " 'int', 'float', 'boolean', 'decimal', 'map<anydata>' types or the array types of them", HTTP_112);
         assertError(diagnosticResult, 26, "invalid union type of query param 'query': 'string', 'int', 'float'," +
-                " 'boolean', 'decimal', 'map<json>' type or the array types of them can only be union with '()'." +
+                " 'boolean', 'decimal', 'map<anydata>' type or the array types of them can only be union with '()'." +
                 " Eg: string? or int[]?", HTTP_113);
         assertError(diagnosticResult, 27, "invalid type of query param 'query': expected one of the 'string'," +
-                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
+                " 'int', 'float', 'boolean', 'decimal', 'map<anydata>' types or the array types of them", HTTP_112);
         assertError(diagnosticResult, 28, "invalid type of query param 'query': expected one of the 'string'," +
-                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
+                " 'int', 'float', 'boolean', 'decimal', 'map<anydata>' types or the array types of them", HTTP_112);
         assertError(diagnosticResult, 29, "invalid union type of query param 'query': 'string', 'int', 'float'," +
-                " 'boolean', 'decimal', 'map<json>' type or the array types of them can only be union with '()'." +
+                " 'boolean', 'decimal', 'map<anydata>' type or the array types of them can only be union with '()'." +
                 " Eg: string? or int[]?", HTTP_113);
         assertError(diagnosticResult, 30, "invalid type of query param 'query': expected one of the 'string'," +
-                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
+                " 'int', 'float', 'boolean', 'decimal', 'map<anydata>' types or the array types of them", HTTP_112);
         assertError(diagnosticResult, 31, "invalid type of query param 'query': expected one of the 'string'," +
-                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
+                " 'int', 'float', 'boolean', 'decimal', 'map<anydata>' types or the array types of them", HTTP_112);
         assertError(diagnosticResult, 32, "invalid type of query param 'query': expected one of the 'string'," +
-                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
+                " 'int', 'float', 'boolean', 'decimal', 'map<anydata>' types or the array types of them", HTTP_112);
         assertError(diagnosticResult, 33, "invalid type of query param 'query': expected one of the 'string'," +
-                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
-        assertError(diagnosticResult, 34, "invalid type of query param 'query': expected one of the 'string'," +
-                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
-        assertError(diagnosticResult, 35, "invalid type of query param 'query': expected one of the 'string'," +
-                " 'int', 'float', 'boolean', 'decimal', 'map<json>' types or the array types of them", HTTP_112);
+                " 'int', 'float', 'boolean', 'decimal', 'map<anydata>' types or the array types of them", HTTP_112);
+        assertError(diagnosticResult, 34, "invalid resource parameter type: " +
+                "'http_test/sample_38:0.1.0:QueryRecordCombinedInvalid?'", HTTP_106);
+        assertError(diagnosticResult, 35, "invalid resource parameter type: " +
+                "'(http_test/sample_38:0.1.0:QueryRecord|map<any>)[]?'", HTTP_106);
     }
 
     @Test

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_34/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_34/service.bal
@@ -17,6 +17,8 @@
 import ballerina/http;
 import ballerina/mime;
 
+class Query {}
+
 type Caller record {|
     int id;
 |};
@@ -103,15 +105,15 @@ service http:Service on new http:Listener(9090) {
         return "done";
     }
 
-    resource function get callerErr7(@http:Query string? b, @http:Query map<xml> a) returns string {
+    resource function get callerErr7(@http:Query string? b, @http:Query map<Query> a) returns string {
         return "done";
     }
 
-    resource function get callerErr8(@http:Query map<xml>[] b, @http:Query int[] c) returns string {
+    resource function get callerErr8(@http:Query map<Query>[] b, @http:Query int[] c) returns string {
         return "done";
     }
 
-    resource function get callerErr9(@http:Query map<xml>? c, @http:Query map<json> d) returns string {
+    resource function get callerErr9(@http:Query map<Query>? c, @http:Query map<json> d) returns string {
         return "done";
     }
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_38/query_param.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_38/query_param.bal
@@ -69,7 +69,7 @@ service /query/positive on listenerEP {
 
 }
 
-type QueryRecordCombinedInvalid QueryRecord|map<anydata>;
+type QueryRecordCombinedInvalid QueryRecord|map<object {}>;
 
 service /query/negative on listenerEP {
 
@@ -95,5 +95,5 @@ service /query/negative on listenerEP {
 
     resource function get case15(QueryRecordCombinedInvalid? query) {}
 
-    resource function get case16((QueryRecord|map<anydata>)[]? query) {}
+    resource function get case16((QueryRecord|map<any>)[]? query) {}
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_7/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_7/service.bal
@@ -19,7 +19,7 @@ import ballerina/mime;
 
 type Caller record {|
     int id;
-    xml val;
+    any val;
 |};
 
 service http:Service on new http:Listener(9090) {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
@@ -60,7 +60,7 @@ public class Constants {
     public static final String NILABLE_FLOAT_ARRAY = "float[]?";
     public static final String NILABLE_DECIMAL_ARRAY = "decimal[]?";
     public static final String NILABLE_BOOLEAN_ARRAY = "boolean[]?";
-    public static final String NILABLE_MAP_OF_ANYDATA_ARRAY = "map<json>[]?";
+    public static final String NILABLE_MAP_OF_ANYDATA_ARRAY = "map<anydata>[]?";
 
     public static final String RESOURCE_RETURN_TYPE = "ResourceReturnType";
     public static final String INTERCEPTOR_RESOURCE_RETURN_TYPE = "InterceptorResourceReturnType";

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/Constants.java
@@ -41,8 +41,7 @@ public class Constants {
     public static final String DECIMAL_ARRAY = "decimal[]";
     public static final String BOOLEAN = "boolean";
     public static final String BOOLEAN_ARRAY = "boolean[]";
-    public static final String MAP_OF_JSON = "map<json>";
-    public static final String ARRAY_OF_MAP_OF_JSON = "map<json>[]";
+    public static final String ARRAY_OF_MAP_OF_ANYDATA = "map<anydata>[]";
     public static final String NIL = "nil";
     public static final String BYTE_ARRAY = "byte[]";
     public static final String XML = "xml";
@@ -55,13 +54,13 @@ public class Constants {
     public static final String NILABLE_FLOAT = "float?";
     public static final String NILABLE_DECIMAL = "decimal?";
     public static final String NILABLE_BOOLEAN = "boolean?";
-    public static final String NILABLE_MAP_OF_JSON = "map<json>?";
+    public static final String NILABLE_MAP_OF_ANYDATA = "map<anydata>?";
     public static final String NILABLE_STRING_ARRAY = "string[]?";
     public static final String NILABLE_INT_ARRAY = "int[]?";
     public static final String NILABLE_FLOAT_ARRAY = "float[]?";
     public static final String NILABLE_DECIMAL_ARRAY = "decimal[]?";
     public static final String NILABLE_BOOLEAN_ARRAY = "boolean[]?";
-    public static final String NILABLE_MAP_OF_JSON_ARRAY = "map<json>[]?";
+    public static final String NILABLE_MAP_OF_ANYDATA_ARRAY = "map<json>[]?";
 
     public static final String RESOURCE_RETURN_TYPE = "ResourceReturnType";
     public static final String INTERCEPTOR_RESOURCE_RETURN_TYPE = "InterceptorResourceReturnType";

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpCompilerPluginUtil.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpCompilerPluginUtil.java
@@ -48,7 +48,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.ballerina.stdlib.http.compiler.Constants.ANYDATA;
-import static io.ballerina.stdlib.http.compiler.Constants.ARRAY_OF_MAP_OF_JSON;
+import static io.ballerina.stdlib.http.compiler.Constants.ARRAY_OF_MAP_OF_ANYDATA;
 import static io.ballerina.stdlib.http.compiler.Constants.BALLERINA;
 import static io.ballerina.stdlib.http.compiler.Constants.BOOLEAN;
 import static io.ballerina.stdlib.http.compiler.Constants.BOOLEAN_ARRAY;
@@ -67,7 +67,6 @@ import static io.ballerina.stdlib.http.compiler.Constants.INTERCEPTOR_RESOURCE_R
 import static io.ballerina.stdlib.http.compiler.Constants.INT_ARRAY;
 import static io.ballerina.stdlib.http.compiler.Constants.JSON;
 import static io.ballerina.stdlib.http.compiler.Constants.MAP_OF_ANYDATA;
-import static io.ballerina.stdlib.http.compiler.Constants.MAP_OF_JSON;
 import static io.ballerina.stdlib.http.compiler.Constants.NIL;
 import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_BOOLEAN;
 import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_BOOLEAN_ARRAY;
@@ -77,8 +76,8 @@ import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_FLOAT;
 import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_FLOAT_ARRAY;
 import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_INT;
 import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_INT_ARRAY;
-import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_MAP_OF_JSON;
-import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_MAP_OF_JSON_ARRAY;
+import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_MAP_OF_ANYDATA;
+import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_MAP_OF_ANYDATA_ARRAY;
 import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_STRING;
 import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_STRING_ARRAY;
 import static io.ballerina.stdlib.http.compiler.Constants.OBJECT;
@@ -275,8 +274,8 @@ public class HttpCompilerPluginUtil {
         typeSymbols.put(INT_ARRAY, types.builder().ARRAY_TYPE.withType(types.INT).build());
         typeSymbols.put(FLOAT_ARRAY, types.builder().ARRAY_TYPE.withType(types.FLOAT).build());
         typeSymbols.put(DECIMAL_ARRAY, types.builder().ARRAY_TYPE.withType(types.DECIMAL).build());
-        typeSymbols.put(ARRAY_OF_MAP_OF_JSON, types.builder().ARRAY_TYPE.withType(
-                types.builder().MAP_TYPE.withTypeParam(types.JSON).build()).build());
+        typeSymbols.put(ARRAY_OF_MAP_OF_ANYDATA, types.builder().ARRAY_TYPE.withType(
+                types.builder().MAP_TYPE.withTypeParam(types.ANYDATA).build()).build());
         typeSymbols.put(STRUCTURED_ARRAY, types.builder().ARRAY_TYPE
                 .withType(
                         types.builder().UNION_TYPE
@@ -299,7 +298,6 @@ public class HttpCompilerPluginUtil {
         typeSymbols.put(XML, types.XML);
         typeSymbols.put(NIL, types.NIL);
         typeSymbols.put(OBJECT, types.builder().OBJECT_TYPE.build());
-        typeSymbols.put(MAP_OF_JSON, types.builder().MAP_TYPE.withTypeParam(types.JSON).build());
         typeSymbols.put(MAP_OF_ANYDATA, types.builder().MAP_TYPE.withTypeParam(types.ANYDATA).build());
         typeSymbols.put(TABLE_OF_ANYDATA_MAP, types.builder().TABLE_TYPE.withRowType(
                 typeSymbols.get(MAP_OF_ANYDATA)).build());
@@ -312,8 +310,8 @@ public class HttpCompilerPluginUtil {
         typeSymbols.put(NILABLE_INT, types.builder().UNION_TYPE.withMemberTypes(types.INT, types.NIL).build());
         typeSymbols.put(NILABLE_FLOAT, types.builder().UNION_TYPE.withMemberTypes(types.FLOAT, types.NIL).build());
         typeSymbols.put(NILABLE_DECIMAL, types.builder().UNION_TYPE.withMemberTypes(types.DECIMAL, types.NIL).build());
-        typeSymbols.put(NILABLE_MAP_OF_JSON, types.builder().UNION_TYPE.withMemberTypes(
-                typeSymbols.get(MAP_OF_JSON), types.NIL).build());
+        typeSymbols.put(NILABLE_MAP_OF_ANYDATA, types.builder().UNION_TYPE.withMemberTypes(
+                typeSymbols.get(MAP_OF_ANYDATA), types.NIL).build());
     }
 
     private static void populateNilableBasicArrayTypes(Map<String, TypeSymbol> typeSymbols, Types types) {
@@ -327,7 +325,7 @@ public class HttpCompilerPluginUtil {
                 typeSymbols.get(FLOAT_ARRAY), types.NIL).build());
         typeSymbols.put(NILABLE_DECIMAL_ARRAY, types.builder().UNION_TYPE.withMemberTypes(
                 typeSymbols.get(DECIMAL_ARRAY), types.NIL).build());
-        typeSymbols.put(NILABLE_MAP_OF_JSON_ARRAY, types.builder().UNION_TYPE.withMemberTypes(
-                typeSymbols.get(ARRAY_OF_MAP_OF_JSON), types.NIL).build());
+        typeSymbols.put(NILABLE_MAP_OF_ANYDATA_ARRAY, types.builder().UNION_TYPE.withMemberTypes(
+                typeSymbols.get(ARRAY_OF_MAP_OF_ANYDATA), types.NIL).build());
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnosticCodes.java
@@ -51,10 +51,10 @@ public enum HttpDiagnosticCodes {
             " only be union with '()'. Eg: string|() or string[]|()", ERROR),
     HTTP_111("HTTP_111", "invalid type of caller param '%s': expected 'http:Caller'", ERROR),
     HTTP_112("HTTP_112", "invalid type of query param '%s': expected one of the 'string', 'int', 'float', " +
-            "'boolean', 'decimal', 'map<json>' types or the array types of them", ERROR),
+            "'boolean', 'decimal', 'map<anydata>' types or the array types of them", ERROR),
     HTTP_113("HTTP_113", "invalid union type of query param '%s': 'string', 'int', 'float', 'boolean', " +
-            "'decimal', 'map<json>' type or the array types of them can only be union with '()'. Eg: string? or int[]?",
-            ERROR),
+            "'decimal', 'map<anydata>' type or the array types of them can only be union with '()'. Eg: string?" +
+            " or int[]?", ERROR),
     HTTP_114("HTTP_114", "incompatible respond method argument type : expected '%s' according " +
             "to the 'http:CallerInfo' annotation", ERROR),
     HTTP_115("HTTP_115", "invalid multiple 'http:Caller' parameter: '%s'", ERROR),

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpResourceValidator.java
@@ -71,7 +71,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.ballerina.stdlib.http.compiler.Constants.ANYDATA;
-import static io.ballerina.stdlib.http.compiler.Constants.ARRAY_OF_MAP_OF_JSON;
+import static io.ballerina.stdlib.http.compiler.Constants.ARRAY_OF_MAP_OF_ANYDATA;
 import static io.ballerina.stdlib.http.compiler.Constants.BOOLEAN;
 import static io.ballerina.stdlib.http.compiler.Constants.BOOLEAN_ARRAY;
 import static io.ballerina.stdlib.http.compiler.Constants.CALLER_ANNOTATION_NAME;
@@ -91,7 +91,7 @@ import static io.ballerina.stdlib.http.compiler.Constants.HTTP;
 import static io.ballerina.stdlib.http.compiler.Constants.INT;
 import static io.ballerina.stdlib.http.compiler.Constants.INT_ARRAY;
 import static io.ballerina.stdlib.http.compiler.Constants.LINKED_TO;
-import static io.ballerina.stdlib.http.compiler.Constants.MAP_OF_JSON;
+import static io.ballerina.stdlib.http.compiler.Constants.MAP_OF_ANYDATA;
 import static io.ballerina.stdlib.http.compiler.Constants.METHOD;
 import static io.ballerina.stdlib.http.compiler.Constants.NAME;
 import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_BOOLEAN;
@@ -102,8 +102,8 @@ import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_FLOAT;
 import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_FLOAT_ARRAY;
 import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_INT;
 import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_INT_ARRAY;
-import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_MAP_OF_JSON;
-import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_MAP_OF_JSON_ARRAY;
+import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_MAP_OF_ANYDATA;
+import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_MAP_OF_ANYDATA_ARRAY;
 import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_STRING;
 import static io.ballerina.stdlib.http.compiler.Constants.NILABLE_STRING_ARRAY;
 import static io.ballerina.stdlib.http.compiler.Constants.OBJECT;
@@ -558,19 +558,19 @@ public class HttpResourceValidator {
         reportInvalidHeaderParameterType(ctx, paramLocation, paramName, param);
     }
 
-    private static boolean isMapOfJsonType(TypeSymbol typeSymbol, Map<String, TypeSymbol> typeSymbols) {
-        return subtypeOf(typeSymbols, typeSymbol, MAP_OF_JSON) ||
-                subtypeOf(typeSymbols, typeSymbol, NILABLE_MAP_OF_JSON);
+    private static boolean isMapOfAnydataType(TypeSymbol typeSymbol, Map<String, TypeSymbol> typeSymbols) {
+        return subtypeOf(typeSymbols, typeSymbol, MAP_OF_ANYDATA) ||
+                subtypeOf(typeSymbols, typeSymbol, NILABLE_MAP_OF_ANYDATA);
     }
 
-    private static boolean isArrayOfMapOfJsonType(TypeSymbol typeSymbol, Map<String, TypeSymbol> typeSymbols) {
-        return subtypeOf(typeSymbols, typeSymbol, ARRAY_OF_MAP_OF_JSON) ||
-                subtypeOf(typeSymbols, typeSymbol, NILABLE_MAP_OF_JSON_ARRAY);
+    private static boolean isArrayOfMapOfAnydataType(TypeSymbol typeSymbol, Map<String, TypeSymbol> typeSymbols) {
+        return subtypeOf(typeSymbols, typeSymbol, ARRAY_OF_MAP_OF_ANYDATA) ||
+                subtypeOf(typeSymbols, typeSymbol, NILABLE_MAP_OF_ANYDATA_ARRAY);
     }
 
     private static boolean isValidBasicQueryParameterType(TypeSymbol typeSymbol, Map<String, TypeSymbol> typeSymbols) {
         return isValidBasicParamType(typeSymbol, typeSymbols) || isValidNilableBasicParamType(typeSymbol, typeSymbols)
-                || isMapOfJsonType(typeSymbol, typeSymbols) || isArrayOfMapOfJsonType(typeSymbol, typeSymbols);
+                || isMapOfAnydataType(typeSymbol, typeSymbols) || isArrayOfMapOfAnydataType(typeSymbol, typeSymbols);
 
     }
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -456,7 +456,7 @@ with any annotation or additional detail unless any default payload param is def
 and not ordered. The type of query param are as follows
 
 ```ballerina
-type BasicType boolean|int|float|decimal|string|map<json>|enum;
+type BasicType boolean|int|float|decimal|string|map<anydata>|enum;
 public type QueryParamType ()|BasicType|BasicType[];
 ```
 


### PR DESCRIPTION
## Purpose

> $Subject

> Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/4541

## Examples

```bal
import ballerina/http;

type User record {
    int id;
    string name;
};

type UserNew record {
    int id;
    string name;
    Address address;
};

type Address record {
    int no;
    string street;
};

service /sample on new http:Listener(9090) {
    
    resource function get path1(User user) {}

    resource function post path2(@http:Query User user) {}

    resource function put path3(@http:Query record {int id; string name;} user) {}

    resource function get path4(record{|User...;|} user) {}

    resource function post path5(@http:Query UserNew user) {}
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [ ] Checked native-image compatibility
