### PR TITLE
Replace deprecated classes and methods used in OCSP

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/certificatevalidation/RevocationVerificationManager.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/certificatevalidation/RevocationVerificationManager.java
@@ -31,8 +31,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 
-import javax.security.cert.CertificateEncodingException;
-
 /**
  * Manager class responsible for verifying certificates. This class will use the available verifiers according to
  * a predefined policy (First check with OCSP access end point and then move to CRL distribution point to validate).
@@ -63,7 +61,7 @@ public class RevocationVerificationManager {
      * @throws CertificateVerificationException Occurs when certificate fails to be validated from both OCSP and CRL.
      * @return true If the process of certificate revocation becomes successful.
      */
-    public boolean verifyRevocationStatus(javax.security.cert.X509Certificate[] peerCertificates)
+    public boolean verifyRevocationStatus(java.security.cert.Certificate[] peerCertificates)
             throws CertificateVerificationException {
 
         X509Certificate[] convertedCertificates = convert(peerCertificates);
@@ -102,7 +100,7 @@ public class RevocationVerificationManager {
      * @throws CertificateVerificationException If an error occurs while converting certificates
      * from java to javax
      */
-    private X509Certificate[] convert(javax.security.cert.X509Certificate[] certs)
+    private X509Certificate[] convert(java.security.cert.Certificate[] certs)
             throws CertificateVerificationException {
         X509Certificate[] certChain = new X509Certificate[certs.length];
         Throwable exceptionThrown;
@@ -113,7 +111,7 @@ public class RevocationVerificationManager {
                 CertificateFactory certificateFactory = CertificateFactory.getInstance(Constants.X_509);
                 certChain[i] = ((X509Certificate) certificateFactory.generateCertificate(byteArrayInputStream));
                 continue;
-            } catch (CertificateEncodingException | CertificateException e) {
+            } catch (CertificateException e) {
                 exceptionThrown = e;
             }
             throw new CertificateVerificationException("Cant Convert certificates from javax to java", exceptionThrown);

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/CertificateValidationHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/CertificateValidationHandler.java
@@ -56,7 +56,7 @@ public class CertificateValidationHandler extends ChannelInboundHandlerAdapter {
             SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
 
             if (event.isSuccess() && revocationVerifier
-                    .verifyRevocationStatus(sslEngine.getSession().getPeerCertificateChain())) {
+                    .verifyRevocationStatus(sslEngine.getSession().getPeerCertificates())) {
                 ctx.fireChannelRead(evt);
             } else {
                 ctx.close();

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/OCSPStaplingHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/OCSPStaplingHandler.java
@@ -31,10 +31,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
-
-import javax.net.ssl.SSLSession;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+
+import javax.net.ssl.SSLSession;
 
 import static io.ballerina.stdlib.http.transport.contractimpl.common.certificatevalidation.Constants.CACHE_DEFAULT_ALLOCATED_SIZE;
 import static io.ballerina.stdlib.http.transport.contractimpl.common.certificatevalidation.Constants.CACHE_DEFAULT_DELAY_MINS;

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/certificatevalidation/OCSPStaplingTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/certificatevalidation/OCSPStaplingTest.java
@@ -54,7 +54,7 @@ public class OCSPStaplingTest {
         Utils.setUp("ocspStapling");
     }
 
-    @Test (description = "Tests with ocsp stapling enabled client and a server.", enabled = false)
+    @Test (description = "Tests with ocsp stapling enabled client and a server.")
     public void testOcspStapling() {
         Utils.testResponse();
     }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/certificatevalidation/OCSPValidationTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/certificatevalidation/OCSPValidationTest.java
@@ -33,7 +33,7 @@ public class OCSPValidationTest {
         Utils.setUp("OCSPandCRL");
     }
 
-    @Test (description = "Integration test for OCSP validation", enabled = false)
+    @Test (description = "Integration test for OCSP validation")
     public void testOcspStapling() {
         Utils.testResponse();
     }


### PR DESCRIPTION
## Purpose

> Fixes: [Enable Ocsp Tests with Java 17](https://github.com/ballerina-platform/ballerina-standard-library/issues/4695)

Due to these deprecated classes and methods with Java17, some tests were failing during the Java17 migration. The root cause was some removed classes:
```
java.lang.ClassNotFoundException: com/sun/security/cert/internal/x509/X509V1CertImpl exception
```
Related StackOverflow link: https://stackoverflow.com/questions/74698707/java-lang-classnotfoundexception-com-sun-security-cert-internal-x509-x509v1cert

This PR will re-enable these test cases by replacing the deprecated classes and methods

## Examples

N/A

## Checklist
- [ ] Linked to an issue
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Updated the spec~
- [ ] Checked native-image compatibility
