### PR TITLE
Fix resilient client failure in passthrough

### DIFF
--- a/ballerina-tests/http-advanced-tests/Ballerina.toml
+++ b/ballerina-tests/http-advanced-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_advanced_tests"
-version = "2.10.0"
+version = "2.10.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.0"
+version = "2.10.1"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-advanced-tests/Dependencies.toml
+++ b/ballerina-tests/http-advanced-tests/Dependencies.toml
@@ -72,7 +72,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -105,7 +105,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_advanced_tests"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},
@@ -125,7 +125,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-client-tests/Ballerina.toml
+++ b/ballerina-tests/http-client-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_client_tests"
-version = "2.10.0"
+version = "2.10.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.0"
+version = "2.10.1"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-client-tests/Dependencies.toml
+++ b/ballerina-tests/http-client-tests/Dependencies.toml
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_client_tests"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-dispatching-tests/Ballerina.toml
+++ b/ballerina-tests/http-dispatching-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_dispatching_tests"
-version = "2.10.0"
+version = "2.10.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.0"
+version = "2.10.1"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-dispatching-tests/Dependencies.toml
+++ b/ballerina-tests/http-dispatching-tests/Dependencies.toml
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_dispatching_tests"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
@@ -124,7 +124,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-interceptor-tests/Ballerina.toml
+++ b/ballerina-tests/http-interceptor-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_interceptor_tests"
-version = "2.10.0"
+version = "2.10.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.0"
+version = "2.10.1"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-interceptor-tests/Dependencies.toml
+++ b/ballerina-tests/http-interceptor-tests/Dependencies.toml
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_interceptor_tests"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -115,7 +115,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-misc-tests/Ballerina.toml
+++ b/ballerina-tests/http-misc-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_misc_tests"
-version = "2.10.0"
+version = "2.10.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.0"
+version = "2.10.1"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-misc-tests/Dependencies.toml
+++ b/ballerina-tests/http-misc-tests/Dependencies.toml
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_misc_tests"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -118,7 +118,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-resiliency-tests/Ballerina.toml
+++ b/ballerina-tests/http-resiliency-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_resiliency_tests"
-version = "2.10.0"
+version = "2.10.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.0"
+version = "2.10.1"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-resiliency-tests/Dependencies.toml
+++ b/ballerina-tests/http-resiliency-tests/Dependencies.toml
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_resiliency_tests"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -116,7 +116,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-resiliency-tests/tests/resiliency_passthrough_test.bal
+++ b/ballerina-tests/http-resiliency-tests/tests/resiliency_passthrough_test.bal
@@ -1,0 +1,202 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/test;
+
+public type Data record {|
+    string name;
+    int age;
+    string[] address;
+|};
+
+final http:Client passthroughRetryClient = check new (string`http://localhost:${passthroughTestPort1}`,
+    retryConfig = {
+        count: 3,
+        interval: 10
+    }
+);
+
+final http:LoadBalanceClient passthroughLoadBalancerClient = check new ({
+    targets: [
+        {url: string`http://localhost:${passthroughTestPort1}`}
+    ],
+    timeout: 5
+}
+);
+
+final http:FailoverClient passthroughFailoverClient = check new ({
+    timeout: 5,
+    failoverCodes: [501, 502, 503],
+    interval: 5,
+    targets: [
+        {url: "http://nonexistentEP"},
+        {url: string`http://localhost:${passthroughTestPort1}`}
+    ]
+});
+
+final http:Client passthroughRedirectClient = check new (string`http://localhost:${passthroughTestPort1}`,
+    followRedirects = {
+        enabled: true,
+        maxCount: 5
+    }
+);
+
+service on new http:Listener(passthroughTestPort2) {
+
+    resource function post passRetryWithReq(http:Request req) returns http:Response|error {
+        return passthroughRetryClient->/echo.post(req);
+    }
+
+    resource function post passRetryWithPayload(@http:Payload Data[]|xml|string payload) returns Data[]|xml|string|error {
+        return passthroughRetryClient->/echo.post(payload);
+    }
+
+    resource function post passLoadBalancerWithReq(http:Request req) returns http:Response|error {
+        return passthroughLoadBalancerClient->/echo.post(req);
+    }
+
+    resource function post passLoadBalancerWithPayload(@http:Payload Data[]|xml|string payload) returns Data[]|xml|string|error {
+        return passthroughLoadBalancerClient->/echo.post(payload);
+    }
+
+    resource function post passFailoverWithReq(http:Request req) returns http:Response|error {
+        return passthroughFailoverClient->/echo.post(req);
+    }
+
+    resource function post passFailoverWithPayload(@http:Payload Data[]|xml|string payload) returns Data[]|xml|string|error {
+        return passthroughFailoverClient->/echo.post(payload);
+    }
+
+    resource function post passRedirectWithReq(http:Request req) returns http:Response|error {
+        return passthroughRedirectClient->/echo.post(req);
+    }
+
+    resource function post passRedirectWithPayload(@http:Payload Data[]|xml|string payload) returns Data[]|xml|string|error {
+        return passthroughRedirectClient->/echo.post(payload);
+    }
+}
+
+service on new http:Listener(passthroughTestPort1) {
+
+    resource function post echo(@http:Payload Data[]|xml|string payload) returns Data[]|xml|string {
+        return payload;
+    }
+}
+
+@test:Config {}
+function testPassthroughRetryClientWithReq() returns error? {
+    http:Client clientEP = check new(string`http://localhost:${passthroughTestPort2}`);
+    string stringResp = check clientEP->/passRetryWithReq.post("Hello World");
+    test:assertEquals(stringResp, "Hello World");
+
+    json jsonResp = check clientEP->/passRetryWithReq.post([{name:"John", age:30, address:["Colombo", "Sri Lanka"]}]);
+    test:assertEquals(jsonResp, [{name:"John", age:30, address:["Colombo", "Sri Lanka"]}]);
+
+    xml xmlResp = check clientEP->/passRetryWithReq.post(xml`<message>Hello World</message>`);
+    test:assertEquals(xmlResp, xml`<message>Hello World</message>`);
+}
+
+@test:Config {}
+function testPassthroughRetryClientWithPayload() returns error? {
+    http:Client clientEP = check new(string`http://localhost:${passthroughTestPort2}`);
+    string stringResp = check clientEP->/passRetryWithPayload.post("Hello World");
+    test:assertEquals(stringResp, "Hello World");
+
+    json jsonResp = check clientEP->/passRetryWithPayload.post([{name:"John", age:30, address:["Colombo", "Sri Lanka"]}]);
+    test:assertEquals(jsonResp, [{name:"John", age:30, address:["Colombo", "Sri Lanka"]}]);
+
+    xml xmlResp = check clientEP->/passRetryWithPayload.post(xml`<message>Hello World</message>`);
+    test:assertEquals(xmlResp, xml`<message>Hello World</message>`);
+}
+
+@test:Config {}
+function testPassthroughLoadBalancerClientWithReq() returns error? {
+    http:Client clientEP = check new(string`http://localhost:${passthroughTestPort2}`);
+    string stringResp = check clientEP->/passLoadBalancerWithReq.post("Hello World");
+    test:assertEquals(stringResp, "Hello World");
+
+    json jsonResp = check clientEP->/passLoadBalancerWithReq.post([{name:"John", age:30, address:["Colombo", "Sri Lanka"]}]);
+    test:assertEquals(jsonResp, [{name:"John", age:30, address:["Colombo", "Sri Lanka"]}]);
+
+    xml xmlResp = check clientEP->/passLoadBalancerWithReq.post(xml`<message>Hello World</message>`);
+    test:assertEquals(xmlResp, xml`<message>Hello World</message>`);
+}
+
+@test:Config {}
+function testPassthroughLoadBalancerClientWithPayload() returns error? {
+    http:Client clientEP = check new(string`http://localhost:${passthroughTestPort2}`);
+    string stringResp = check clientEP->/passLoadBalancerWithPayload.post("Hello World");
+    test:assertEquals(stringResp, "Hello World");
+
+    json jsonResp = check clientEP->/passLoadBalancerWithPayload.post([{name:"John", age:30, address:["Colombo", "Sri Lanka"]}]);
+    test:assertEquals(jsonResp, [{name:"John", age:30, address:["Colombo", "Sri Lanka"]}]);
+
+    xml xmlResp = check clientEP->/passLoadBalancerWithPayload.post(xml`<message>Hello World</message>`);
+    test:assertEquals(xmlResp, xml`<message>Hello World</message>`);
+}
+
+@test:Config {}
+function testPassthroughFailoverClientWithReq() returns error? {
+    http:Client clientEP = check new(string`http://localhost:${passthroughTestPort2}`);
+    string stringResp = check clientEP->/passFailoverWithReq.post("Hello World");
+    test:assertEquals(stringResp, "Hello World");
+
+    json jsonResp = check clientEP->/passFailoverWithReq.post([{name:"John", age:30, address:["Colombo", "Sri Lanka"]}]);
+    test:assertEquals(jsonResp, [{name:"John", age:30, address:["Colombo", "Sri Lanka"]}]);
+
+    xml xmlResp = check clientEP->/passFailoverWithReq.post(xml`<message>Hello World</message>`);
+    test:assertEquals(xmlResp, xml`<message>Hello World</message>`);
+}
+
+@test:Config {}
+function testPassthroughFailoverClientWithPayload() returns error? {
+    http:Client clientEP = check new(string`http://localhost:${passthroughTestPort2}`);
+    string stringResp = check clientEP->/passFailoverWithPayload.post("Hello World");
+    test:assertEquals(stringResp, "Hello World");
+
+    json jsonResp = check clientEP->/passFailoverWithPayload.post([{name:"John", age:30, address:["Colombo", "Sri Lanka"]}]);
+    test:assertEquals(jsonResp, [{name:"John", age:30, address:["Colombo", "Sri Lanka"]}]);
+
+    xml xmlResp = check clientEP->/passFailoverWithPayload.post(xml`<message>Hello World</message>`);
+    test:assertEquals(xmlResp, xml`<message>Hello World</message>`);
+}
+
+@test:Config {}
+function testPassthroughRedirectClientWithReq() returns error? {
+    http:Client clientEP = check new(string`http://localhost:${passthroughTestPort2}`);
+    string stringResp = check clientEP->/passRedirectWithReq.post("Hello World");
+    test:assertEquals(stringResp, "Hello World");
+
+    json jsonResp = check clientEP->/passRedirectWithReq.post([{name:"John", age:30, address:["Colombo", "Sri Lanka"]}]);
+    test:assertEquals(jsonResp, [{name:"John", age:30, address:["Colombo", "Sri Lanka"]}]);
+
+    xml xmlResp = check clientEP->/passRedirectWithReq.post(xml`<message>Hello World</message>`);
+    test:assertEquals(xmlResp, xml`<message>Hello World</message>`);
+}
+
+@test:Config {}
+function testPassthroughRedirectClientWithPayload() returns error? {
+    http:Client clientEP = check new(string`http://localhost:${passthroughTestPort2}`);
+    string stringResp = check clientEP->/passRedirectWithPayload.post("Hello World");
+    test:assertEquals(stringResp, "Hello World");
+
+    json jsonResp = check clientEP->/passRedirectWithPayload.post([{name:"John", age:30, address:["Colombo", "Sri Lanka"]}]);
+    test:assertEquals(jsonResp, [{name:"John", age:30, address:["Colombo", "Sri Lanka"]}]);
+
+    xml xmlResp = check clientEP->/passRedirectWithPayload.post(xml`<message>Hello World</message>`);
+    test:assertEquals(xmlResp, xml`<message>Hello World</message>`);
+}

--- a/ballerina-tests/http-resiliency-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-resiliency-tests/tests/test_service_ports.bal
@@ -25,5 +25,5 @@ const int foClientWithoutStatusCodeTestPort2 = 9572;
 
 const int http2RetryFunctionTestPort = 9706;
 
-int passthroughTestPort1 = 9543;
-int passthroughTestPort2 = 9544;
+const int passthroughTestPort1 = 9543;
+const int passthroughTestPort2 = 9544;

--- a/ballerina-tests/http-resiliency-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-resiliency-tests/tests/test_service_ports.bal
@@ -24,3 +24,6 @@ const int foClientWithoutStatusCodeTestPort1 = 9571;
 const int foClientWithoutStatusCodeTestPort2 = 9572;
 
 const int http2RetryFunctionTestPort = 9706;
+
+int passthroughTestPort1 = 9543;
+int passthroughTestPort2 = 9544;

--- a/ballerina-tests/http-security-tests/Ballerina.toml
+++ b/ballerina-tests/http-security-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.10.0"
+version = "2.10.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.0"
+version = "2.10.1"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-security-tests/Dependencies.toml
+++ b/ballerina-tests/http-security-tests/Dependencies.toml
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "http"},
@@ -120,7 +120,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-service-tests/Ballerina.toml
+++ b/ballerina-tests/http-service-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_service_tests"
-version = "2.10.0"
+version = "2.10.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.0"
+version = "2.10.1"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-service-tests/Dependencies.toml
+++ b/ballerina-tests/http-service-tests/Dependencies.toml
@@ -69,7 +69,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_service_tests"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-test-common/Ballerina.toml
+++ b/ballerina-tests/http-test-common/Ballerina.toml
@@ -1,4 +1,4 @@
 [package]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.0"
+version = "2.10.1"

--- a/ballerina-tests/http-test-common/Dependencies.toml
+++ b/ballerina-tests/http-test-common/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.8.0"
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "mime"},

--- a/ballerina-tests/http2-tests/Ballerina.toml
+++ b/ballerina-tests/http2-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http2_tests"
-version = "2.10.0"
+version = "2.10.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.0"
+version = "2.10.1"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.1-SNAPSHOT.jar"

--- a/ballerina-tests/http2-tests/Dependencies.toml
+++ b/ballerina-tests/http2-tests/Dependencies.toml
@@ -69,7 +69,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http2_tests"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.0"
+version = "2.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.10.0"
+version = "2.10.1"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -16,8 +16,8 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.10.0"
-path = "../native/build/libs/http-native-2.10.0.jar"
+version = "2.10.1"
+path = "../native/build/libs/http-native-2.10.1-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.10.0.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.10.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -76,7 +76,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/ballerina/http_request.bal
+++ b/ballerina/http_request.bal
@@ -587,6 +587,13 @@ public class Request {
         return externCheckReqEntityBodyAvailability(self);
     }
 
+    # Check whether the message data source is already built.
+    #
+    # + return - A boolean indicating the availability of the message data source
+    isolated function hasMsgDataSource() returns boolean {
+        return externHasMsgDataSource(self);
+    }
+
     # Adds cookies to the request.
     #
     # + cookiesToAdd - Represents the cookies to be added
@@ -690,6 +697,12 @@ isolated function externCheckReqEntityBodyAvailability(Request request) returns 
 @java:Method {
     'class: "io.ballerina.stdlib.http.api.nativeimpl.ExternRequest",
     name: "checkEntityBodyAvailability"
+} external;
+
+isolated function externHasMsgDataSource(Request request) returns boolean =
+@java:Method {
+    'class: "io.ballerina.stdlib.http.api.nativeimpl.ExternRequest",
+    name: "hasMsgDataSource"
 } external;
 
 # A record for providing mutual SSL handshake results.

--- a/ballerina/redirect_http_client.bal
+++ b/ballerina/redirect_http_client.bal
@@ -317,7 +317,7 @@ client isolated class RedirectClient {
             // When performing redirect operation for non-safe method, message needs to be built before sending out the
             // to keep the request message to subsequent redirect.
             if !inRequest.hasMsgDataSource() {
-                byte[]|error binaryPayload = check inRequest.getBinaryPayload();
+                byte[]|error binaryPayload = inRequest.getBinaryPayload();
                 if binaryPayload is error {
                     log:printDebug("Error building datasource for request redirect: " + binaryPayload.message());
                 }

--- a/ballerina/redirect_http_client.bal
+++ b/ballerina/redirect_http_client.bal
@@ -316,9 +316,11 @@ client isolated class RedirectClient {
         if !(httpOperation is safeHttpOperation) {
             // When performing redirect operation for non-safe method, message needs to be built before sending out the
             // to keep the request message to subsequent redirect.
-            byte[]|error binaryPayload = check inRequest.getBinaryPayload();
-            if binaryPayload is error {
-                log:printDebug("Error building datasource for request redirect: " + binaryPayload.message());
+            if !inRequest.hasMsgDataSource() {
+                byte[]|error binaryPayload = check inRequest.getBinaryPayload();
+                if binaryPayload is error {
+                    log:printDebug("Error building datasource for request redirect: " + binaryPayload.message());
+                }
             }
             // Build message for for multipart requests
             inRequest = check populateMultipartRequest(inRequest);

--- a/ballerina/resiliency_failover_client.bal
+++ b/ballerina/resiliency_failover_client.bal
@@ -523,9 +523,11 @@ public client isolated class FailoverClient {
         } else {
             // When performing passthrough scenarios using Failover connector, message needs to be built before trying
             // out the failover endpoints to keep the request message to failover the messages.
-            byte[]|error binaryPayload = failoverRequest.getBinaryPayload();
-            if binaryPayload is error {
-                log:printDebug("Error building payload for request failover: " + binaryPayload.message());
+            if !failoverRequest.hasMsgDataSource() {
+                byte[]|error binaryPayload = failoverRequest.getBinaryPayload();
+                if binaryPayload is error {
+                    log:printDebug("Error building payload for request failover: " + binaryPayload.message());
+                }
             }
             requestEntity = check failoverRequest.getEntity();
         }

--- a/ballerina/resiliency_http_retry_client.bal
+++ b/ballerina/resiliency_http_retry_client.bal
@@ -304,9 +304,11 @@ isolated function performRetryAction(string path, Request request, HttpOperation
     Request inRequest = request;
     // When performing passthrough scenarios using retry client, message needs to be built before sending out the
     // to keep the request message to retry.
-    byte[]|error binaryPayload = check inRequest.getBinaryPayload();
-    if binaryPayload is error {
-        log:printDebug("Error building payload for request retry: " + binaryPayload.message());
+    if !inRequest.hasMsgDataSource() {
+        byte[]|error binaryPayload = check inRequest.getBinaryPayload();
+        if binaryPayload is error {
+            log:printDebug("Error building payload for request retry: " + binaryPayload.message());
+        }
     }
 
     while (currentRetryCount < (retryCount + 1)) {

--- a/ballerina/resiliency_http_retry_client.bal
+++ b/ballerina/resiliency_http_retry_client.bal
@@ -305,7 +305,7 @@ isolated function performRetryAction(string path, Request request, HttpOperation
     // When performing passthrough scenarios using retry client, message needs to be built before sending out the
     // to keep the request message to retry.
     if !inRequest.hasMsgDataSource() {
-        byte[]|error binaryPayload = check inRequest.getBinaryPayload();
+        byte[]|error binaryPayload = inRequest.getBinaryPayload();
         if binaryPayload is error {
             log:printDebug("Error building payload for request retry: " + binaryPayload.message());
         }

--- a/ballerina/resiliency_load_balance_client.bal
+++ b/ballerina/resiliency_load_balance_client.bal
@@ -424,9 +424,11 @@ public client isolated class LoadBalanceClient {
                 // When performing passthrough scenarios using Load Balance connector,
                 // message needs to be built before trying out the load balance endpoints to keep the request message
                 // to load balance the messages in case of failure.
-                byte[]|error binaryPayload = loadBalancerInRequest.getBinaryPayload();
-                if binaryPayload is error {
-                    log:printDebug("Error building payload for request load balance: " + binaryPayload.message());
+                if !loadBalancerInRequest.hasMsgDataSource() {
+                    byte[]|error binaryPayload = loadBalancerInRequest.getBinaryPayload();
+                    if binaryPayload is error {
+                        log:printDebug("Error building payload for request load balance: " + binaryPayload.message());
+                    }
                 }
                 requestEntity = check loadBalancerInRequest.getEntity();
             }

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ This file contains all the notable changes done to the Ballerina HTTP package th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [Fix resilient client failure in passthrough scenarios](https://github.com/ballerina-platform/ballerina-standard-library/issues/4824)
+
 ## [2.10.0] - 2023-09-15
 
 ### Fixed

--- a/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternRequest.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternRequest.java
@@ -32,6 +32,8 @@ import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
 import io.ballerina.stdlib.http.uri.URIUtil;
 import io.ballerina.stdlib.mime.util.EntityBodyHandler;
 
+import java.util.Objects;
+
 import static io.ballerina.stdlib.http.api.HttpConstants.QUERY_PARAM_MAP;
 import static io.ballerina.stdlib.http.api.HttpConstants.TRANSPORT_MESSAGE;
 import static io.ballerina.stdlib.http.api.HttpUtil.checkRequestBodySizeHeadersAvailability;
@@ -101,6 +103,11 @@ public class ExternRequest {
     public static boolean checkEntityBodyAvailability(BObject requestObj) {
         BObject entityObj = (BObject) requestObj.get(REQUEST_ENTITY_FIELD);
         return lengthHeaderCheck(requestObj) || EntityBodyHandler.checkEntityBodyAvailability(entityObj);
+    }
+
+    public static boolean hasMsgDataSource(BObject requestObj) {
+        BObject entityObj = (BObject) requestObj.get(REQUEST_ENTITY_FIELD);
+        return Objects.nonNull(EntityBodyHandler.getMessageDataSource(entityObj));
     }
 
     private static boolean lengthHeaderCheck(BObject requestObj) {


### PR DESCRIPTION
## Purpose

> Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/4824

## Examples

```bal
import ballerina/http;
import ballerina/log;

public type Data record {|
    string name;
    int age;
    string[] address;
|};

final http:Client clientEP = check new ("http://localhost:9090", retryConfig = {
    count: 3,
    interval: 10
});

service on new http:Listener(9091) {

    resource function post data(Data[] data) returns http:Response? {
        do {
            return check clientEP->/data.post(data);
        } on fail error err {
            log:printError("Error: ", err);
            return;
        }
    }
}
```

This was failing before when we try to build the binary payload for the request where the data source is already available. This fix will check the availability of the data source before trying to build the payload as `byte[]`.

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
- [x] Checked native-image compatibility
