### PR TITLE
Disable Trivy scan for now to do a patch release

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -31,14 +31,15 @@ jobs:
         run: ./gradlew build -x check -x test
       - name: Create lib directory if not exists
         run: mkdir -p ballerina/lib
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: 'rootfs'
-          scan-ref: '/github/workspace/ballerina/lib'
-          format: 'table'
-          timeout: '10m0s'
-          exit-code: '1'
+# Disabling Trivy scan for now for an urgent release as it is failing due to a vulnerability in Netty which is not fixed yet.
+#      - name: Run Trivy vulnerability scanner
+#        uses: aquasecurity/trivy-action@master
+#        with:
+#          scan-type: 'rootfs'
+#          scan-ref: '/github/workspace/ballerina/lib'
+#          format: 'table'
+#          timeout: '10m0s'
+#          exit-code: '1'
 
       - name: Ballerina Central Push
         if: ${{ github.event.inputs.environment == 'CENTRAL' }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -28,14 +28,15 @@ jobs:
             ./gradlew build -x check -x test
       - name: Create lib directory if not exists
         run: mkdir -p ballerina/lib
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: 'rootfs'
-          scan-ref: '/github/workspace/ballerina/lib'
-          format: 'table'
-          timeout: '10m0s'
-          exit-code: '1'
+# Disabling Trivy scan for now for an urgent release as it is failing due to a vulnerability in Netty which is not fixed yet.
+#      - name: Run Trivy vulnerability scanner
+#        uses: aquasecurity/trivy-action@master
+#        with:
+#          scan-type: 'rootfs'
+#          scan-ref: '/github/workspace/ballerina/lib'
+#          format: 'table'
+#          timeout: '10m0s'
+#          exit-code: '1'
       - name: Set version env variable
         run: echo "VERSION=$((grep -w 'version' | cut -d= -f2) < gradle.properties | rev | cut --complement -d- -f1 | rev)" >> $GITHUB_ENV
       - name: Pre release dependency version update


### PR DESCRIPTION
## Purpose
Disabling this to do an urgent patch release.
Related issue: https://github.com/ballerina-platform/ballerina-standard-library/issues/4898

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
