### PR TITLE
Release the `perRoutePoolLatch` when connection closes abruptly in H2 upgrade scenario

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.10.5"
+version = "2.10.6"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -16,8 +16,8 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.10.5"
-path = "../native/build/libs/http-native-2.10.5.jar"
+version = "2.10.6"
+path = "../native/build/libs/http-native-2.10.6-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.10.5.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.10.6-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -76,7 +76,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.5"
+version = "2.10.6"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - [Fix `IndexOutOfBoundsException` when decoding jwt header](https://github.com/ballerina-platform/ballerina-library/issues/5856)
+- [Fix HTTP/2 upgrade client hanging when server closes the connection abruptly](https://github.com/ballerina-platform/ballerina-library/issues/5955)
 
 ## [2.10.4] - 2023-11-17
 

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/TargetHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/TargetHandler.java
@@ -120,6 +120,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
         if (!idleTimeoutTriggered) {
             targetChannel.senderReqRespStateManager.handleAbruptChannelClosure(this, httpResponseFuture);
         }
+        releasePerRoutePoolLatchOnFailure();
         connectionManager.invalidateTargetChannel(targetChannel);
 
         if (handlerExecutor != null) {


### PR DESCRIPTION
## Purpose
$subject
Fixes https://github.com/ballerina-platform/ballerina-library/issues/5955

Relevant test case is here - https://github.com/ballerina-platform/module-ballerina-http/pull/1833/commits/e1755c95fa8cccd674c6693ccb3410d0e24ca04c

Couldnt add the test case to this PR as the TCPServer tests are not merged yet

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
