### PR TITLE
[2201.7.x] Fix overwriting the Host header

### DIFF
--- a/ballerina-tests/http-client-tests/tests/http_client_host_header_test.bal
+++ b/ballerina-tests/http-client-tests/tests/http_client_host_header_test.bal
@@ -1,0 +1,131 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.org).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/test;
+
+final http:Client http2ClientHost1 = check new("localhost:" + http2ClientHostHeaderTestPort.toString());
+final http:Client http2ClientHost2 = check new("localhost:" + httpClientHostHeaderTestPort.toString());
+final http:Client httpClientHost1 = check new("localhost:" + httpClientHostHeaderTestPort.toString(), httpVersion = http:HTTP_1_1);
+final http:Client httpClientHost2 = check new("localhost:" + http2ClientHostHeaderTestPort.toString(), httpVersion = http:HTTP_1_1);
+
+service / on new http:Listener(http2ClientHostHeaderTestPort) {
+
+    resource function 'default host(http:Request req) returns string|error {
+        return req.getHeader("Host");
+    }
+}
+
+service / on new http:Listener(httpClientHostHeaderTestPort, httpVersion = http:HTTP_1_1) {
+
+    resource function 'default host(http:Request req) returns string|error {
+        return req.getHeader("Host");
+    }
+}
+
+@test:Config {}
+function testHttpClientHostHeader1() returns error? {
+    string host = check httpClientHost1->/host;
+    test:assertEquals(host, "localhost:" + httpClientHostHeaderTestPort.toString());
+
+    host = check httpClientHost1->get("/host");
+    test:assertEquals(host, "localhost:" + httpClientHostHeaderTestPort.toString());
+
+    host = check httpClientHost2->/host;
+    test:assertEquals(host, "localhost:" + http2ClientHostHeaderTestPort.toString());
+
+    host = check httpClientHost2->get("/host");
+    test:assertEquals(host, "localhost:" + http2ClientHostHeaderTestPort.toString());
+}
+
+@test:Config {}
+function testHttpClientHostHeader2() returns error? {
+    string host = check httpClientHost1->/host.get({"Host": "mock.com"});
+    test:assertEquals(host, "mock.com");
+
+    host = check httpClientHost1->get("/host", {"Host": "mock.com"});
+    test:assertEquals(host, "mock.com");
+
+    host = check httpClientHost2->/host.get({"Host": "mock.com"});
+    test:assertEquals(host, "mock.com");
+
+    host = check httpClientHost2->get("/host", {"Host": "mock.com"});
+    test:assertEquals(host, "mock.com");
+}
+
+@test:Config {}
+function testHttpClientHostHeader3() returns error? {
+    http:Request req = new;
+    req.setHeader("Host", "mock.com");
+    string host = check httpClientHost1->/host.post(req);
+    test:assertEquals(host, "mock.com");
+
+    host = check httpClientHost1->post("/host", req, {"Host": "mock2.com"});
+    test:assertEquals(host, "mock2.com");
+
+    host = check httpClientHost2->/host.post(req);
+    test:assertEquals(host, "mock2.com");
+
+    host = check httpClientHost2->post("/host", req, {"Host": "mock3.com"});
+    test:assertEquals(host, "mock3.com");
+}
+
+@test:Config {}
+function testHttp2ClientHostHeader1() returns error? {
+    string host = check http2ClientHost1->/host;
+    test:assertEquals(host, "localhost:" + http2ClientHostHeaderTestPort.toString());
+
+    host = check http2ClientHost1->get("/host");
+    test:assertEquals(host, "localhost:" + http2ClientHostHeaderTestPort.toString());
+
+    host = check http2ClientHost2->/host;
+    test:assertEquals(host, "localhost:" + httpClientHostHeaderTestPort.toString());
+
+    host = check http2ClientHost2->get("/host");
+    test:assertEquals(host, "localhost:" + httpClientHostHeaderTestPort.toString());
+}
+
+@test:Config {}
+function testHttp2ClientHostHeader2() returns error? {
+    string host = check http2ClientHost1->/host.get({"Host": "mock.com"});
+    test:assertEquals(host, "mock.com");
+
+    host = check http2ClientHost1->get("/host", {"Host": "mock.com"});
+    test:assertEquals(host, "mock.com");
+
+    host = check http2ClientHost2->/host.get({"Host": "mock.com"});
+    test:assertEquals(host, "mock.com");
+
+    host = check http2ClientHost2->get("/host", {"Host": "mock.com"});
+    test:assertEquals(host, "mock.com");
+}
+
+@test:Config {}
+function testHttp2ClientHostHeader3() returns error? {
+    http:Request req = new;
+    req.setHeader("Host", "mock.com");
+    string host = check http2ClientHost1->/host.post(req);
+    test:assertEquals(host, "mock.com");
+
+    host = check http2ClientHost1->post("/host", req, {"Host": "mock2.com"});
+    test:assertEquals(host, "mock2.com");
+
+    host = check http2ClientHost2->/host.post(req);
+    test:assertEquals(host, "mock2.com");
+
+    host = check http2ClientHost2->post("/host", req, {"Host": "mock3.com"});
+    test:assertEquals(host, "mock3.com");
+}

--- a/ballerina-tests/http-client-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-client-tests/tests/test_service_ports.bal
@@ -32,3 +32,6 @@ const int clientSchemeTestHttpsListenerTestPort = 9624;
 
 const int clientResourceMethodsTestPort = 9631;
 const int clientFormUrlEncodedTestPort = 9604;
+
+const int http2ClientHostHeaderTestPort = 9605;
+const int httpClientHostHeaderTestPort = 9605;

--- a/ballerina-tests/http-client-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-client-tests/tests/test_service_ports.bal
@@ -34,4 +34,4 @@ const int clientResourceMethodsTestPort = 9631;
 const int clientFormUrlEncodedTestPort = 9604;
 
 const int http2ClientHostHeaderTestPort = 9605;
-const int httpClientHostHeaderTestPort = 9605;
+const int httpClientHostHeaderTestPort = 9606;

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.9.5"
+version = "2.9.6"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -16,8 +16,8 @@ graalvmCompatible = true
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.9.5"
-path = "../native/build/libs/http-native-2.9.5.jar"
+version = "2.9.6"
+path = "../native/build/libs/http-native-2.9.6-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.9.5.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.9.6-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -50,7 +50,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -62,7 +62,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -76,7 +76,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.9.5"
+version = "2.9.6"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -240,7 +240,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ This file contains all the notable changes done to the Ballerina HTTP package th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- [Make the `Host` header overridable](https://github.com/ballerina-platform/ballerina-library/issues/6133)
+
 ## [2.9.5] - 2023-10-13
 
 ### Fixed

--- a/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/AbstractHTTPAction.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/AbstractHTTPAction.java
@@ -213,6 +213,9 @@ public abstract class AbstractHTTPAction {
     }
 
     private static void setHostHeader(String host, int port, HttpHeaders headers) {
+        if (headers.contains(HttpHeaderNames.HOST)) {
+            return;
+        }
         if (port == 80 || port == 443) {
             headers.set(HttpHeaderNames.HOST, host);
         } else {

--- a/test-utils/src/main/java/io/ballerina/stdlib/http/testutils/client/HttpClient.java
+++ b/test-utils/src/main/java/io/ballerina/stdlib/http/testutils/client/HttpClient.java
@@ -36,6 +36,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import org.slf4j.Logger;
@@ -100,7 +101,7 @@ public class HttpClient {
         this.responseHandler.setLatch(latch);
         this.responseHandler.setWaitForConnectionClosureLatch(this.waitForConnectionClosureLatch);
 
-        httpRequest.headers().set(HttpHeaderNames.HOST, host + ":" + port);
+        addHostHeader(httpRequest);
         this.connectedChannel.writeAndFlush(httpRequest);
         try {
             latch.await();
@@ -117,7 +118,7 @@ public class HttpClient {
         this.responseHandler.setLatch(latch);
         this.responseHandler.setWaitForConnectionClosureLatch(this.waitForConnectionClosureLatch);
 
-        httpRequest.headers().set(HttpHeaderNames.HOST, host + ":" + port);
+        addHostHeader(httpRequest);
         httpRequest.headers().set(HttpHeaderNames.EXPECT, HttpHeaderValues.CONTINUE);
         this.connectedChannel.writeAndFlush(httpRequest);
 
@@ -149,7 +150,7 @@ public class HttpClient {
         this.responseHandler.setLatch(latch);
         this.responseHandler.setWaitForConnectionClosureLatch(this.waitForConnectionClosureLatch);
 
-        httpRequest.headers().set(HttpHeaderNames.HOST, host + ":" + port);
+        addHostHeader(httpRequest);
         this.connectedChannel.writeAndFlush(httpRequest.copy());
 
         this.connectedChannel.writeAndFlush(httpRequest);
@@ -159,6 +160,12 @@ public class HttpClient {
             log.warn("Interrupted before receiving the response");
         }
         return this.responseHandler.getHttpFullResponses();
+    }
+
+    private void addHostHeader(HttpRequest httpRequest) {
+        if (!httpRequest.headers().contains(HttpHeaderNames.HOST)) {
+            httpRequest.headers().set(HttpHeaderNames.HOST, host + ":" + port);
+        }
     }
 
     /**
@@ -236,7 +243,7 @@ public class HttpClient {
      */
     private FullHttpRequest getFullHttpRequest(String path, String requestId) {
         FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, path);
-        request.headers().set(HttpHeaderNames.HOST, host + ":" + port);
+        addHostHeader(request);
         request.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
         request.headers().set("message-id", requestId);
         return request;


### PR DESCRIPTION
## Purpose

> Related to: https://github.com/ballerina-platform/ballerina-library/issues/6133

**Note:** With this improvement users can override the `Host` header, but **this does not change the connection internals**. We will still connect to the endpoint defined in the client `URL` but the `Host` header send in the request can be overridable. This is in line with the cURL client.

## Examples

N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
- [x] Checked native-image compatibility
- [ ] ~Checked the impact on OpenAPI generation~
