### PR TITLE
[2201.5.x] Update `Host` header only when the user intentionally provide a value

### DIFF
--- a/ballerina-tests/http-advanced-tests/Ballerina.toml
+++ b/ballerina-tests/http-advanced-tests/Ballerina.toml
@@ -1,14 +1,14 @@
 [package]
 org = "ballerina"
 name = "http_advanced_tests"
-version = "2.7.4"
+version = "2.7.5"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.7.4"
+version = "2.7.5"
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.7.4.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.7.5-SNAPSHOT.jar"

--- a/ballerina-tests/http-advanced-tests/Dependencies.toml
+++ b/ballerina-tests/http-advanced-tests/Dependencies.toml
@@ -73,7 +73,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -105,7 +105,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_advanced_tests"
-version = "2.7.4"
+version = "2.7.5"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},
@@ -125,7 +125,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-client-tests/Ballerina.toml
+++ b/ballerina-tests/http-client-tests/Ballerina.toml
@@ -1,14 +1,14 @@
 [package]
 org = "ballerina"
 name = "http_client_tests"
-version = "2.7.4"
+version = "2.7.5"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.7.4"
+version = "2.7.5"
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.7.4.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.7.5-SNAPSHOT.jar"

--- a/ballerina-tests/http-client-tests/Dependencies.toml
+++ b/ballerina-tests/http-client-tests/Dependencies.toml
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_client_tests"
-version = "2.7.4"
+version = "2.7.5"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-client-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-client-tests/tests/test_service_ports.bal
@@ -35,3 +35,5 @@ const int clientFormUrlEncodedTestPort = 9604;
 
 const int http2ClientHostHeaderTestPort = 9605;
 const int httpClientHostHeaderTestPort = 9606;
+const int passthroughHostTestPort1 = 9607;
+const int passthroughHostTestPort2 = 9608;

--- a/ballerina-tests/http-dispatching-tests/Ballerina.toml
+++ b/ballerina-tests/http-dispatching-tests/Ballerina.toml
@@ -1,14 +1,14 @@
 [package]
 org = "ballerina"
 name = "http_dispatching_tests"
-version = "2.7.4"
+version = "2.7.5"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.7.4"
+version = "2.7.5"
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.7.4.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.7.5-SNAPSHOT.jar"

--- a/ballerina-tests/http-dispatching-tests/Dependencies.toml
+++ b/ballerina-tests/http-dispatching-tests/Dependencies.toml
@@ -67,7 +67,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_dispatching_tests"
-version = "2.7.4"
+version = "2.7.5"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -120,7 +120,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-interceptor-tests/Ballerina.toml
+++ b/ballerina-tests/http-interceptor-tests/Ballerina.toml
@@ -1,14 +1,14 @@
 [package]
 org = "ballerina"
 name = "http_interceptor_tests"
-version = "2.7.4"
+version = "2.7.5"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.7.4"
+version = "2.7.5"
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.7.4.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.7.5-SNAPSHOT.jar"

--- a/ballerina-tests/http-interceptor-tests/Dependencies.toml
+++ b/ballerina-tests/http-interceptor-tests/Dependencies.toml
@@ -67,7 +67,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_interceptor_tests"
-version = "2.7.4"
+version = "2.7.5"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -115,7 +115,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-misc-tests/Ballerina.toml
+++ b/ballerina-tests/http-misc-tests/Ballerina.toml
@@ -1,14 +1,14 @@
 [package]
 org = "ballerina"
 name = "http_misc_tests"
-version = "2.7.4"
+version = "2.7.5"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.7.4"
+version = "2.7.5"
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.7.4.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.7.5-SNAPSHOT.jar"

--- a/ballerina-tests/http-misc-tests/Dependencies.toml
+++ b/ballerina-tests/http-misc-tests/Dependencies.toml
@@ -67,7 +67,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_misc_tests"
-version = "2.7.4"
+version = "2.7.5"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -118,7 +118,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-resiliency-tests/Ballerina.toml
+++ b/ballerina-tests/http-resiliency-tests/Ballerina.toml
@@ -1,14 +1,14 @@
 [package]
 org = "ballerina"
 name = "http_resiliency_tests"
-version = "2.7.4"
+version = "2.7.5"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.7.4"
+version = "2.7.5"
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.7.4.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.7.5-SNAPSHOT.jar"

--- a/ballerina-tests/http-resiliency-tests/Dependencies.toml
+++ b/ballerina-tests/http-resiliency-tests/Dependencies.toml
@@ -67,7 +67,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_resiliency_tests"
-version = "2.7.4"
+version = "2.7.5"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -116,7 +116,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-security-tests/Ballerina.toml
+++ b/ballerina-tests/http-security-tests/Ballerina.toml
@@ -1,14 +1,14 @@
 [package]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.7.4"
+version = "2.7.5"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.7.4"
+version = "2.7.5"
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.7.4.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.7.5-SNAPSHOT.jar"

--- a/ballerina-tests/http-security-tests/Dependencies.toml
+++ b/ballerina-tests/http-security-tests/Dependencies.toml
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.7.4"
+version = "2.7.5"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-service-tests/Ballerina.toml
+++ b/ballerina-tests/http-service-tests/Ballerina.toml
@@ -1,14 +1,14 @@
 [package]
 org = "ballerina"
 name = "http_service_tests"
-version = "2.7.4"
+version = "2.7.5"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.7.4"
+version = "2.7.5"
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.7.4.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.7.5-SNAPSHOT.jar"

--- a/ballerina-tests/http-service-tests/Dependencies.toml
+++ b/ballerina-tests/http-service-tests/Dependencies.toml
@@ -70,7 +70,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_service_tests"
-version = "2.7.4"
+version = "2.7.5"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-test-common/Ballerina.toml
+++ b/ballerina-tests/http-test-common/Ballerina.toml
@@ -1,4 +1,4 @@
 [package]
 org = "ballerina"
 name = "http_test_common"
-version = "2.7.4"
+version = "2.7.5"

--- a/ballerina-tests/http-test-common/Dependencies.toml
+++ b/ballerina-tests/http-test-common/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.5.0"
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.7.4"
+version = "2.7.5"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "mime"},

--- a/ballerina-tests/http2-tests/Ballerina.toml
+++ b/ballerina-tests/http2-tests/Ballerina.toml
@@ -1,14 +1,14 @@
 [package]
 org = "ballerina"
 name = "http2_tests"
-version = "2.7.4"
+version = "2.7.5"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.7.4"
+version = "2.7.5"
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.7.4.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.7.5-SNAPSHOT.jar"

--- a/ballerina-tests/http2-tests/Dependencies.toml
+++ b/ballerina-tests/http2-tests/Dependencies.toml
@@ -70,7 +70,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http2_tests"
-version = "2.7.4"
+version = "2.7.5"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.7.4"
+version = "2.7.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.7.4"
+version = "2.7.5"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -12,8 +12,8 @@ distribution = "2201.5.0"
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.7.4"
-path = "../native/build/libs/http-native-2.7.4.jar"
+version = "2.7.5"
+path = "../native/build/libs/http-native-2.7.5-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.7.4.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.7.5-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -51,7 +51,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.3.0"
+version = "2.3.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -63,13 +63,11 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "os"},
-	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
 ]
 modules = [
@@ -79,7 +77,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.7.4"
+version = "2.7.5"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -110,7 +108,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -240,7 +238,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -254,7 +252,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -304,7 +302,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.4.0"
+version = "1.4.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.string"}
@@ -316,7 +314,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -325,7 +323,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -336,7 +334,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ This file contains all the notable changes done to the Ballerina HTTP package th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- [Update Host header only when a value is intentionally provided](https://github.com/ballerina-platform/ballerina-library/issues/6149)
+
 ## [2.7.4] - 2024-03-05
 
 ### Added

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -236,6 +236,7 @@ public class HttpConstants {
     public static final int NO_CONTENT_LENGTH_FOUND = -1;
     public static final short ONE_BYTE = 1;
     public static final String HTTP_HEADERS = "http_headers";
+    public static final String SET_HOST_HEADER = "set_host_header";
     public static final String HTTP_TRAILER_HEADERS = "http_trailer_headers";
     public static final String LEADING_HEADER = "leading";
     public static final BString HEADER_REQUEST_FIELD = StringUtils.fromString("request");

--- a/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/AbstractHTTPAction.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/AbstractHTTPAction.java
@@ -66,9 +66,11 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 import static io.ballerina.runtime.api.constants.RuntimeConstants.BALLERINA_VERSION;
 import static io.ballerina.stdlib.http.api.HttpConstants.ANN_CONFIG_ATTR_COMPRESSION;
+import static io.ballerina.stdlib.http.api.HttpConstants.SET_HOST_HEADER;
 import static io.ballerina.stdlib.http.api.HttpUtil.extractEntity;
 import static io.ballerina.stdlib.http.api.HttpUtil.getCompressionState;
 import static io.ballerina.stdlib.http.transport.contract.Constants.ENCODING_DEFLATE;
@@ -93,7 +95,7 @@ public abstract class AbstractHTTPAction {
         HttpCarbonMessage requestMsg = HttpUtil.getCarbonMsg(request, HttpUtil.createHttpCarbonMessage(true));
         HttpUtil.checkEntityAvailability(request);
         HttpUtil.enrichOutboundMessage(requestMsg, request);
-        prepareOutboundRequest(serviceUri, path, requestMsg, isNoEntityBodyRequest(request));
+        prepareOutboundRequest(serviceUri, path, requestMsg, isNoEntityBodyRequest(request), isHostHeaderSet(request));
         handleAcceptEncodingHeader(requestMsg, getCompressionConfigFromEndpointConfig(config));
         return requestMsg;
     }
@@ -115,7 +117,7 @@ public abstract class AbstractHTTPAction {
     }
 
     static void prepareOutboundRequest(String serviceUri, String path, HttpCarbonMessage outboundRequest,
-                                       Boolean nonEntityBodyReq) {
+                                       Boolean nonEntityBodyReq, Boolean isHostHeaderSet) {
         TransactionResourceManager trxResourceManager = TransactionResourceManager.getInstance();
         if (trxResourceManager.isInTransaction()) {
             TransactionLocalContext transactionLocalContext = trxResourceManager.getCurrentTransactionContext();
@@ -132,7 +134,7 @@ public abstract class AbstractHTTPAction {
             String host = url.getHost();
 
             setOutboundReqProperties(outboundRequest, url, port, host, nonEntityBodyReq);
-            setOutboundReqHeaders(outboundRequest, port, host);
+            setOutboundReqHeaders(outboundRequest, port, host, isHostHeaderSet);
 
         } catch (MalformedURLException e) {
             throw HttpUtil.createHttpError("malformed URL specified. " + e.getMessage(),
@@ -158,9 +160,10 @@ public abstract class AbstractHTTPAction {
         return uri.trim().replaceAll(WHITESPACE, "%20");
     }
 
-    private static void setOutboundReqHeaders(HttpCarbonMessage outboundRequest, int port, String host) {
+    private static void setOutboundReqHeaders(HttpCarbonMessage outboundRequest, int port, String host,
+                                              Boolean isHostHeaderSet) {
         HttpHeaders headers = outboundRequest.getHeaders();
-        setHostHeader(host, port, headers);
+        setHostHeader(host, port, headers, isHostHeaderSet);
         setOutboundUserAgent(headers);
         removeConnectionHeader(headers);
     }
@@ -212,8 +215,8 @@ public abstract class AbstractHTTPAction {
         return 0;
     }
 
-    private static void setHostHeader(String host, int port, HttpHeaders headers) {
-        if (headers.contains(HttpHeaderNames.HOST)) {
+    private static void setHostHeader(String host, int port, HttpHeaders headers, Boolean isHostHeaderSet) {
+        if (isHostHeaderSet && headers.contains(HttpHeaderNames.HOST)) {
             return;
         }
         if (port == 80 || port == 443) {
@@ -321,6 +324,10 @@ public abstract class AbstractHTTPAction {
 
     static boolean isNoEntityBodyRequest(BObject request) {
         return (Boolean) request.get(HttpConstants.REQUEST_NO_ENTITY_BODY_FIELD);
+    }
+
+    static boolean isHostHeaderSet(BObject request) {
+        return Objects.nonNull(request.getNativeData(SET_HOST_HEADER));
     }
 
     private static boolean dirty(BObject request) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/Execute.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/Execute.java
@@ -55,7 +55,8 @@ public class Execute extends AbstractHTTPAction {
 
         HttpUtil.checkEntityAvailability(requestObj);
         HttpUtil.enrichOutboundMessage(outboundRequestMsg, requestObj);
-        prepareOutboundRequest(serviceUri, path, outboundRequestMsg, isNoEntityBodyRequest(requestObj));
+        prepareOutboundRequest(serviceUri, path, outboundRequestMsg, isNoEntityBodyRequest(requestObj),
+                isHostHeaderSet(requestObj));
 
         String verb = "";
         if (!httpVerb.isEmpty()) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/Forward.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/Forward.java
@@ -59,11 +59,11 @@ public class Forward extends AbstractHTTPAction {
         if (HttpUtil.isEntityDataSourceAvailable(requestObj)) {
             HttpUtil.enrichOutboundMessage(outboundRequestMsg, requestObj);
             prepareOutboundRequest(serviceUri, path, outboundRequestMsg,
-                                   !checkRequestBodySizeHeadersAvailability(outboundRequestMsg));
+                    !checkRequestBodySizeHeadersAvailability(outboundRequestMsg), isHostHeaderSet(requestObj));
             outboundRequestMsg.setHttpMethod(requestObj.get(HttpConstants.HTTP_REQUEST_METHOD).toString());
         } else {
             prepareOutboundRequest(serviceUri, path, outboundRequestMsg,
-                                   !checkRequestBodySizeHeadersAvailability(outboundRequestMsg));
+                    !checkRequestBodySizeHeadersAvailability(outboundRequestMsg), isHostHeaderSet(requestObj));
             String httpVerb = outboundRequestMsg.getHttpMethod();
             outboundRequestMsg.setHttpMethod(httpVerb.trim().toUpperCase(Locale.getDefault()));
         }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternHeaders.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternHeaders.java
@@ -39,6 +39,7 @@ import java.util.TreeSet;
 import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_HEADERS;
 import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_TRAILER_HEADERS;
 import static io.ballerina.stdlib.http.api.HttpConstants.LEADING_HEADER;
+import static io.ballerina.stdlib.http.api.HttpConstants.SET_HOST_HEADER;
 import static io.ballerina.stdlib.http.api.HttpErrorType.HEADER_NOT_FOUND_ERROR;
 import static io.ballerina.stdlib.mime.util.MimeConstants.INVALID_HEADER_OPERATION_ERROR;
 
@@ -120,6 +121,7 @@ public class ExternHeaders {
         }
         try {
             getOrCreateHeadersBasedOnPosition(messageObj, position).set(headerName.getValue(), headerValue.getValue());
+            messageObj.addNativeData(SET_HOST_HEADER, true);
         } catch (IllegalArgumentException ex) {
             throw MimeUtil.createError(INVALID_HEADER_OPERATION_ERROR, ex.getMessage());
         }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternHeaders.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternHeaders.java
@@ -121,7 +121,9 @@ public class ExternHeaders {
         }
         try {
             getOrCreateHeadersBasedOnPosition(messageObj, position).set(headerName.getValue(), headerValue.getValue());
-            messageObj.addNativeData(SET_HOST_HEADER, true);
+            if (headerName.getValue().equalsIgnoreCase(HttpHeaderNames.HOST.toString())) {
+                messageObj.addNativeData(SET_HOST_HEADER, true);
+            }
         } catch (IllegalArgumentException ex) {
             throw MimeUtil.createError(INVALID_HEADER_OPERATION_ERROR, ex.getMessage());
         }


### PR DESCRIPTION
## Purpose

Related to: https://github.com/ballerina-platform/ballerina-library/issues/6149

With this improvement we only overwrite the `Host` header when the user intentionally provide a value for that. Otherwise the `Host` header will be inferred from the client URL

## Examples

```bal
final http:Client clientEP = check new("localhost:9091");

service /api on new http:Listener(9090) {

     resource function get test1(http:Request req) returns http:Response|error {
          // Here the `Host` header will be overwritten by the clientEP URL
          return clientEP->execute("get", "api/test", req);
     }

     resource function get test2(http:Request req) returns http:Response|error {
          // Header is intentionally overwritten by the user
          req.setHeader("Host", check req.getHeader("Host"));
          // The `Host` header will not be overwritten by the clientEP
          return clientEP->execute("get", "api/test", req);
     }
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
- [x] Checked native-image compatibility
- [ ] ~Checked the impact on OpenAPI generation~
