### PR TITLE
Generate and host SwaggerUI for the generated OpenAPI specification for an HTTP service as a built-in resource 

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -50,7 +50,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.7.1"
+version = "2.7.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpIntrospectionResource.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpIntrospectionResource.java
@@ -20,8 +20,6 @@ package io.ballerina.stdlib.http.api;
 
 import io.netty.handler.codec.http.HttpHeaderValues;
 
-import static io.ballerina.stdlib.http.api.HttpConstants.SINGLE_SLASH;
-
 /**
  * {@code HttpIntrospectionResource} is the resource which respond the service Open API JSON specification.
  *

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpIntrospectionResource.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpIntrospectionResource.java
@@ -50,7 +50,7 @@ public class HttpIntrospectionResource extends HttpOASResource {
         return HttpHeaderValues.APPLICATION_JSON.toString();
     }
 
-    public static String getIntrospectionResourceId() {
+    public static String getResourceId() {
         return RESOURCE_METHOD + RESOURCE_NAME;
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpIntrospectionResource.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpIntrospectionResource.java
@@ -18,7 +18,7 @@
 
 package io.ballerina.stdlib.http.api;
 
-import java.util.List;
+import io.netty.handler.codec.http.HttpHeaderValues;
 
 import static io.ballerina.stdlib.http.api.HttpConstants.SINGLE_SLASH;
 
@@ -27,41 +27,29 @@ import static io.ballerina.stdlib.http.api.HttpConstants.SINGLE_SLASH;
  *
  * @since SL beta 3
  */
-public class HttpIntrospectionResource extends HttpResource {
+public class HttpIntrospectionResource extends HttpOASResource {
 
     private static final String RESOURCE_NAME = "openapi-doc-dygixywsw";
-    private static final String RESOURCE_METHOD = "$get$";
-    private static final String REL_PARAM = "rel=\"service-desc\"";
     private final byte[] payload;
 
-    protected HttpIntrospectionResource(HttpService httpService, byte[] payload) {
-        String path = (httpService.getBasePath() + SINGLE_SLASH + RESOURCE_NAME).replaceAll("/+", SINGLE_SLASH);
-        httpService.setIntrospectionResourcePathHeaderValue("<" + path + ">;" + REL_PARAM);
-        this.payload = payload.clone();
+    public HttpIntrospectionResource(HttpService httpService, byte[] payload) {
+        super(httpService, RESOURCE_NAME);
+        this.payload = payload;
     }
 
-    public String getName() {
-        return RESOURCE_METHOD + RESOURCE_NAME;
-    }
-
-    public String getPath() {
-        return SINGLE_SLASH + RESOURCE_NAME;
-    }
-
+    @Override
     public byte[] getPayload() {
         return this.payload.clone();
     }
 
-    public List<String> getMethods() {
-        return List.of(HttpConstants.HTTP_METHOD_GET);
+    @Override
+    protected String getResourceName() {
+        return RESOURCE_NAME;
     }
 
-    public List<String> getConsumes() {
-        return null;
-    }
-
-    public List<String> getProduces() {
-        return null;
+    @Override
+    public String getContentType() {
+        return HttpHeaderValues.APPLICATION_JSON.toString();
     }
 
     public static String getIntrospectionResourceId() {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpOASResource.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpOASResource.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.stdlib.http.api;
+
+import java.util.List;
+
+import static io.ballerina.stdlib.http.api.HttpConstants.SINGLE_SLASH;
+
+/**
+ * {@code HttpOASResource} is the super class for the service introspection resources.
+ *
+ * @since v2.11.2
+ */
+public abstract class HttpOASResource extends HttpResource {
+    protected static final String RESOURCE_METHOD = "$get$";
+    protected static final String REL_PARAM = "rel=\"service-desc\"";
+
+    public HttpOASResource(HttpService httpService, String resourcePath) {
+        String path = (httpService.getBasePath() + SINGLE_SLASH + resourcePath).replaceAll("/+", SINGLE_SLASH);
+        httpService.setIntrospectionResourcePathHeaderValue("<" + path + ">;" + REL_PARAM);
+    }
+
+    public String getName() {
+        return String.format("%s%s", RESOURCE_METHOD, getResourceName());
+    }
+
+    public String getPath() {
+        return String.format("%s%s", SINGLE_SLASH, getResourceName());
+    }
+
+    public List<String> getMethods() {
+        return List.of(HttpConstants.HTTP_METHOD_GET);
+    }
+
+    public List<String> getConsumes() {
+        return null;
+    }
+
+    public List<String> getProduces() {
+        return null;
+    }
+
+    protected abstract String getResourceName();
+
+    public abstract byte[] getPayload();
+
+    public abstract String getContentType();
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpOASResource.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpOASResource.java
@@ -33,7 +33,7 @@ public abstract class HttpOASResource extends HttpResource {
 
     public HttpOASResource(HttpService httpService, String resourcePath) {
         String path = (httpService.getBasePath() + SINGLE_SLASH + resourcePath).replaceAll("/+", SINGLE_SLASH);
-        httpService.setIntrospectionResourcePathHeaderValue("<" + path + ">;" + REL_PARAM);
+        httpService.addOasResourceLink("<" + path + ">;" + REL_PARAM);
     }
 
     public String getName() {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpService.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpService.java
@@ -412,7 +412,7 @@ public class HttpService implements Service {
         if (this.oasResourceLinks.isEmpty()) {
             return null;
         }
-        return this.oasResourceLinks.stream().collect(Collectors.joining(", "));
+        return String.join(", ", this.oasResourceLinks);
     }
 
     protected void addOasResourceLink(String oasResourcePath) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpService.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpService.java
@@ -273,6 +273,8 @@ public class HttpService implements Service {
         if (introspectionPayload.length > 0) {
             updateResourceTree(httpService, httpResources, new HttpIntrospectionResource(httpService,
                                                                                          introspectionPayload));
+            updateResourceTree(
+                    httpService, httpResources, new HttpSwaggerUiResource(httpService, introspectionPayload));
         } else {
             log.debug("OpenAPI definition is not available");
         }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpService.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpService.java
@@ -90,7 +90,7 @@ public class HttpService implements Service {
     private String hostName;
     private String chunkingConfig;
     private String mediaTypeSubtypePrefix;
-    private String introspectionResourcePath;
+    private List<String> oasResourceLinks = new ArrayList<>();
     private boolean treatNilableAsOptional = true;
     private List<HTTPInterceptorServicesRegistry> interceptorServicesRegistries;
     private BArray balInterceptorServicesArray;
@@ -408,12 +408,15 @@ public class HttpService implements Service {
     }
 
     @Override
-    public String getIntrospectionResourcePathHeaderValue() {
-        return this.introspectionResourcePath;
+    public String getOasResourceLink() {
+        if (this.oasResourceLinks.isEmpty()) {
+            return null;
+        }
+        return this.oasResourceLinks.stream().collect(Collectors.joining(", "));
     }
 
-    protected void setIntrospectionResourcePathHeaderValue(String introspectionResourcePath) {
-        this.introspectionResourcePath = introspectionResourcePath;
+    protected void addOasResourceLink(String oasResourcePath) {
+        this.oasResourceLinks.add(oasResourcePath);
     }
 
     public void setInterceptorServicesRegistries(List<HTTPInterceptorServicesRegistry> interceptorServicesRegistries) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpSwaggerUiResource.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpSwaggerUiResource.java
@@ -78,7 +78,7 @@ public class HttpSwaggerUiResource extends HttpOASResource {
         return HttpHeaderValues.TEXT_HTML.toString();
     }
 
-    public static String getSwaggerUiResourceId() {
+    public static String getResourceId() {
         return RESOURCE_METHOD + RESOURCE_NAME;
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpSwaggerUiResource.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpSwaggerUiResource.java
@@ -18,18 +18,15 @@
 
 package io.ballerina.stdlib.http.api;
 
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.util.CharsetUtil;
-
-import java.util.List;
-
-import static io.ballerina.stdlib.http.api.HttpConstants.SINGLE_SLASH;
 
 /**
  * {@code HttpIntrospectionResource} is the resource which respond the service Open API JSON specification.
  *
  * @since v2.11.2
  */
-public class HttpSwaggerUiResource extends HttpResource {
+public class HttpSwaggerUiResource extends HttpOASResource {
 
     private static final String STATIC_HTML_PAGE = """
                     <!DOCTYPE html>
@@ -47,7 +44,7 @@ public class HttpSwaggerUiResource extends HttpResource {
                     <script>
                       window.onload = () => {
                         window.ui = SwaggerUIBundle({
-                          spec: OPEN_API_SPEC,
+                          spec: OPENAPI_SPEC,
                           dom_id: '#swagger-ui',
                         });
                       };
@@ -56,44 +53,32 @@ public class HttpSwaggerUiResource extends HttpResource {
                     </html>
             """;
     private static final String RESOURCE_NAME = "swagger-ui-dygixywsw";
-    private static final String RESOURCE_METHOD = "$get$";
-    private static final String REL_PARAM = "rel=\"service-desc\"";
-
+    private static final String OAS_PLACEHOLDER = "OPENAPI_SPEC";
     private final byte[] payload;
 
     public HttpSwaggerUiResource(HttpService httpService, byte[] payload) {
-//        String path = (httpService.getBasePath() + SINGLE_SLASH + RESOURCE_NAME).replaceAll("/+", SINGLE_SLASH);
-//        httpService.setIntrospectionResourcePathHeaderValue("<" + path + ">;" + REL_PARAM);
+        super(httpService, RESOURCE_NAME);
         String oasSpec = new String(payload.clone(), CharsetUtil.UTF_8);
-        String content = STATIC_HTML_PAGE.replace("OPEN_API_SPEC", oasSpec);
+        String content = STATIC_HTML_PAGE.replace(OAS_PLACEHOLDER, oasSpec);
         this.payload = content.getBytes(CharsetUtil.UTF_8);
     }
 
-    public String getName() {
-        return RESOURCE_METHOD + RESOURCE_NAME;
-    }
-
-    public String getPath() {
-        return SINGLE_SLASH + RESOURCE_NAME;
-    }
-
+    @Override
     public byte[] getPayload() {
         return this.payload.clone();
     }
 
-    public List<String> getMethods() {
-        return List.of(HttpConstants.HTTP_METHOD_GET);
+    @Override
+    protected String getResourceName() {
+        return RESOURCE_NAME;
     }
 
-    public List<String> getConsumes() {
-        return null;
+    @Override
+    public String getContentType() {
+        return HttpHeaderValues.TEXT_HTML.toString();
     }
 
-    public List<String> getProduces() {
-        return null;
-    }
-
-    public static String getIntrospectionResourceId() {
+    public static String getSwaggerUiResourceId() {
         return RESOURCE_METHOD + RESOURCE_NAME;
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpSwaggerUiResource.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpSwaggerUiResource.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.api;
+
+import io.netty.util.CharsetUtil;
+
+import java.util.List;
+
+import static io.ballerina.stdlib.http.api.HttpConstants.SINGLE_SLASH;
+
+/**
+ * {@code HttpIntrospectionResource} is the resource which respond the service Open API JSON specification.
+ *
+ * @since v2.11.2
+ */
+public class HttpSwaggerUiResource extends HttpResource {
+
+    private static final String STATIC_HTML_PAGE = """
+                    <!DOCTYPE html>
+                    <html lang="en">
+                    <head>
+                      <meta charset="utf-8" />
+                      <meta name="viewport" content="width=device-width, initial-scale=1" />
+                      <meta name="description" content="SwaggerUI" />
+                      <title>SwaggerUI</title>
+                      <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css" />
+                    </head>
+                    <body>
+                    <div id="swagger-ui"></div>
+                    <script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js" crossorigin></script>
+                    <script>
+                      window.onload = () => {
+                        window.ui = SwaggerUIBundle({
+                          spec: OPEN_API_SPEC,
+                          dom_id: '#swagger-ui',
+                        });
+                      };
+                    </script>
+                    </body>
+                    </html>
+            """;
+    private static final String RESOURCE_NAME = "swagger-ui-dygixywsw";
+    private static final String RESOURCE_METHOD = "$get$";
+    private static final String REL_PARAM = "rel=\"service-desc\"";
+
+    private final byte[] payload;
+
+    public HttpSwaggerUiResource(HttpService httpService, byte[] payload) {
+//        String path = (httpService.getBasePath() + SINGLE_SLASH + RESOURCE_NAME).replaceAll("/+", SINGLE_SLASH);
+//        httpService.setIntrospectionResourcePathHeaderValue("<" + path + ">;" + REL_PARAM);
+        String oasSpec = new String(payload.clone(), CharsetUtil.UTF_8);
+        String content = STATIC_HTML_PAGE.replace("OPEN_API_SPEC", oasSpec);
+        this.payload = content.getBytes(CharsetUtil.UTF_8);
+    }
+
+    public String getName() {
+        return RESOURCE_METHOD + RESOURCE_NAME;
+    }
+
+    public String getPath() {
+        return SINGLE_SLASH + RESOURCE_NAME;
+    }
+
+    public byte[] getPayload() {
+        return this.payload.clone();
+    }
+
+    public List<String> getMethods() {
+        return List.of(HttpConstants.HTTP_METHOD_GET);
+    }
+
+    public List<String> getConsumes() {
+        return null;
+    }
+
+    public List<String> getProduces() {
+        return null;
+    }
+
+    public static String getIntrospectionResourceId() {
+        return RESOURCE_METHOD + RESOURCE_NAME;
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpSwaggerUiResource.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpSwaggerUiResource.java
@@ -22,7 +22,7 @@ import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.util.CharsetUtil;
 
 /**
- * {@code HttpIntrospectionResource} is the resource which respond the service Open API JSON specification.
+ * {@code HttpSwaggerUiResource} is the resource which respond the Swagger-UI for the generated Open API specification.
  *
  * @since v2.11.2
  */

--- a/native/src/main/java/io/ballerina/stdlib/http/api/InterceptorService.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/InterceptorService.java
@@ -74,7 +74,7 @@ public class InterceptorService implements Service {
     }
 
     @Override
-    public String getIntrospectionResourcePathHeaderValue() {
+    public String getOasResourceLink() {
         return null;
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDataElement.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDataElement.java
@@ -80,6 +80,11 @@ public class ResourceDataElement implements DataElement<Resource, HttpCarbonMess
                                 "Open API spec retrieval resource: '" + r.getName() + "'";
                         throw HttpUtil.createHttpError(message, GENERIC_LISTENER_ERROR);
                     }
+                    if (r.getName().equals(HttpSwaggerUiResource.getSwaggerUiResourceId())) {
+                        String message = "Resources cannot have the accessor and name as same as the auto generated " +
+                                "Swagger-UI retrieval resource: '" + r.getName() + "'";
+                        throw HttpUtil.createHttpError(message, GENERIC_LISTENER_ERROR);
+                    }
                     throw HttpUtil.createHttpError("Two resources have the same addressable URI, "
                                                            + r.getName() + " and " + newResource.getName(),
                                                    GENERIC_LISTENER_ERROR);

--- a/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDataElement.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDataElement.java
@@ -75,12 +75,12 @@ public class ResourceDataElement implements DataElement<Resource, HttpCarbonMess
         this.resource.forEach(r -> {
             for (String newMethod : newMethods) {
                 if (DispatcherUtil.isMatchingMethodExist(r, newMethod)) {
-                    if (r.getName().equals(HttpIntrospectionResource.getIntrospectionResourceId())) {
+                    if (r.getName().equals(HttpIntrospectionResource.getResourceId())) {
                         String message = "Resources cannot have the accessor and name as same as the auto generated " +
                                 "Open API spec retrieval resource: '" + r.getName() + "'";
                         throw HttpUtil.createHttpError(message, GENERIC_LISTENER_ERROR);
                     }
-                    if (r.getName().equals(HttpSwaggerUiResource.getSwaggerUiResourceId())) {
+                    if (r.getName().equals(HttpSwaggerUiResource.getResourceId())) {
                         String message = "Resources cannot have the accessor and name as same as the auto generated " +
                                 "Swagger-UI retrieval resource: '" + r.getName() + "'";
                         throw HttpUtil.createHttpError(message, GENERIC_LISTENER_ERROR);

--- a/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDispatcher.java
@@ -25,7 +25,6 @@ import io.ballerina.stdlib.http.uri.URITemplateException;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaderValues;
 
 import static io.ballerina.stdlib.http.api.HttpErrorType.INTERNAL_RESOURCE_DISPATCHING_SERVER_ERROR;
 import static io.ballerina.stdlib.http.api.HttpErrorType.INTERNAL_RESOURCE_NOT_FOUND_ERROR;
@@ -95,7 +94,7 @@ public class ResourceDispatcher {
             throw HttpUtil.createHttpStatusCodeError(INTERNAL_RESOURCE_NOT_FOUND_ERROR, message);
         }
         CorsHeaderGenerator.process(cMsg, response, false);
-        String introspectionResourcePathHeaderValue = service.getIntrospectionResourcePathHeaderValue();
+        String introspectionResourcePathHeaderValue = service.getOasResourceLink();
         if (introspectionResourcePathHeaderValue != null) {
             response.setHeader(HttpConstants.LINK_HEADER, introspectionResourcePathHeaderValue);
         }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDispatcher.java
@@ -43,12 +43,12 @@ public class ResourceDispatcher {
         HttpResourceArguments resourceArgumentValues = new HttpResourceArguments();
         try {
             Resource resource = service.getUriTemplate().matches(subPath, resourceArgumentValues, inboundRequest);
-            if (resource instanceof HttpIntrospectionResource) {
-                handleIntrospectionRequest(inboundRequest, (HttpIntrospectionResource) resource);
+            if (resource instanceof HttpIntrospectionResource introspectionResource) {
+                handleOasResourceRequest(inboundRequest, introspectionResource);
                 return null;
             }
             if (resource instanceof HttpSwaggerUiResource swaggerUiResource) {
-                handleSwaggerUiRequest(inboundRequest, swaggerUiResource);
+                handleOasResourceRequest(inboundRequest, swaggerUiResource);
                 return null;
             }
             if (resource != null) {
@@ -105,21 +105,11 @@ public class ResourceDispatcher {
         cMsg.waitAndReleaseAllEntities();
     }
 
-    private static void handleIntrospectionRequest(HttpCarbonMessage cMsg, HttpIntrospectionResource resource) {
+    private static void handleOasResourceRequest(HttpCarbonMessage cMsg, HttpOASResource resource) {
         HttpCarbonMessage response = HttpUtil.createHttpCarbonMessage(false);
         response.waitAndReleaseAllEntities();
         response.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(resource.getPayload())));
-        response.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), HttpHeaderValues.APPLICATION_JSON.toString());
-        response.setHttpStatusCode(200);
-        PipeliningHandler.sendPipelinedResponse(cMsg, response);
-        cMsg.waitAndReleaseAllEntities();
-    }
-
-    private static void handleSwaggerUiRequest(HttpCarbonMessage cMsg, HttpSwaggerUiResource resource) {
-        HttpCarbonMessage response = HttpUtil.createHttpCarbonMessage(false);
-        response.waitAndReleaseAllEntities();
-        response.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(resource.getPayload())));
-        response.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), HttpHeaderValues.TEXT_HTML.toString());
+        response.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), resource.getContentType());
         response.setHttpStatusCode(200);
         PipeliningHandler.sendPipelinedResponse(cMsg, response);
         cMsg.waitAndReleaseAllEntities();

--- a/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDispatcher.java
@@ -47,6 +47,10 @@ public class ResourceDispatcher {
                 handleIntrospectionRequest(inboundRequest, (HttpIntrospectionResource) resource);
                 return null;
             }
+            if (resource instanceof HttpSwaggerUiResource swaggerUiResource) {
+                handleSwaggerUiRequest(inboundRequest, swaggerUiResource);
+                return null;
+            }
             if (resource != null) {
                 inboundRequest.setProperty(HttpConstants.RESOURCE_ARGS, resourceArgumentValues);
                 inboundRequest.setProperty(HttpConstants.RESOURCES_CORS, resource.getCorsHeaders());
@@ -106,6 +110,16 @@ public class ResourceDispatcher {
         response.waitAndReleaseAllEntities();
         response.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(resource.getPayload())));
         response.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), HttpHeaderValues.APPLICATION_JSON.toString());
+        response.setHttpStatusCode(200);
+        PipeliningHandler.sendPipelinedResponse(cMsg, response);
+        cMsg.waitAndReleaseAllEntities();
+    }
+
+    private static void handleSwaggerUiRequest(HttpCarbonMessage cMsg, HttpSwaggerUiResource resource) {
+        HttpCarbonMessage response = HttpUtil.createHttpCarbonMessage(false);
+        response.waitAndReleaseAllEntities();
+        response.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(resource.getPayload())));
+        response.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), HttpHeaderValues.TEXT_HTML.toString());
         response.setHttpStatusCode(200);
         PipeliningHandler.sendPipelinedResponse(cMsg, response);
         cMsg.waitAndReleaseAllEntities();

--- a/native/src/main/java/io/ballerina/stdlib/http/api/Service.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/Service.java
@@ -73,9 +73,9 @@ public interface Service {
     List<String> getAllAllowedMethods();
 
     /**
-     * Returns introspection resource path header configured in the service.
+     * Returns OAS resource path header configured in the service.
      *
      * @return the introspection resource path header string
      */
-    String getIntrospectionResourcePathHeaderValue();
+    String getOasResourceLink();
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/api/HttpServiceTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/api/HttpServiceTest.java
@@ -74,7 +74,7 @@ public class HttpServiceTest {
 
     @Test
     public void testGetIntrospectionResourceIdOfIntrospectionResource() {
-        Assert.assertEquals(HttpIntrospectionResource.getIntrospectionResourceId(), "$get$openapi-doc-dygixywsw");
+        Assert.assertEquals(HttpIntrospectionResource.getResourceId(), "$get$openapi-doc-dygixywsw");
     }
 
     @Test
@@ -87,7 +87,7 @@ public class HttpServiceTest {
 
     @Test
     public void testGetSwaggerUiResourceIdOfIntrospectionResource() {
-        Assert.assertEquals(HttpSwaggerUiResource.getSwaggerUiResourceId(), "$get$swagger-ui-dygixywsw");
+        Assert.assertEquals(HttpSwaggerUiResource.getResourceId(), "$get$swagger-ui-dygixywsw");
     }
 
     @Test

--- a/native/src/test/java/io/ballerina/stdlib/http/api/HttpServiceTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/api/HttpServiceTest.java
@@ -86,6 +86,19 @@ public class HttpServiceTest {
     }
 
     @Test
+    public void testGetSwaggerUiResourceIdOfIntrospectionResource() {
+        Assert.assertEquals(HttpSwaggerUiResource.getSwaggerUiResourceId(), "$get$swagger-ui-dygixywsw");
+    }
+
+    @Test
+    public void testGetNameOfSwaggerUiResource() {
+        BObject service = TestUtils.getNewServiceObject("hello");
+        HttpService httpService = new HttpService(service);
+        HttpSwaggerUiResource swaggerUiResource = new HttpSwaggerUiResource(httpService, "abc".getBytes());
+        Assert.assertEquals(swaggerUiResource.getName(), "$get$swagger-ui-dygixywsw");
+    }
+
+    @Test
     public void testGetAbsoluteResourcePath() {
         HttpService httpService = new HttpService(TestUtils.getNewServiceObject("hello"));
         httpService.setBasePath("/basePath/");


### PR DESCRIPTION
## Purpose
> $subject

Fixes: [#6622](https://github.com/ballerina-platform/ballerina-library/issues/6622)

## Examples
- Run the Ballerina Snowpeak sample using `bal run`.
- Access [`http://localhost:9090/snowpeak/swagger-ui-dygixywsw`](http://localhost:9090/snowpeak/swagger-ui-dygixywsw) URL on your browser.

![swagger-ui-sample-ext](https://github.com/ballerina-platform/module-ballerina-http/assets/77491511/2a3c49e0-0291-4a05-b7a3-d528d0bebc1c)

## Checklist
- [X] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
- [ ] Checked the impact on OpenAPI generation
