### PR TITLE
[2201.9.x] Generate and host SwaggerUI for the generated OpenAPI specification as a built-in resource

### DIFF
--- a/ballerina-tests/http-misc-tests/tests/http_introspection_resource_test.bal
+++ b/ballerina-tests/http-misc-tests/tests/http_introspection_resource_test.bal
@@ -80,12 +80,14 @@ function testIntrospectionResourceLink() returns error? {
     http:Response response = check httpIntroResTestClient->options("/hello");
     test:assertEquals(response.statusCode, 204, msg = "Found unexpected statusCode");
     test:assertEquals(check response.getHeader(common:ALLOW), "GET, OPTIONS", msg = "Found unexpected Header");
-    common:assertHeaderValue(check response.getHeader(common:LINK), "</hello/openapi-doc-dygixywsw>;rel=\"service-desc\"");
+    common:assertHeaderValue(check response.getHeader(common:LINK), 
+        "</hello/openapi-doc-dygixywsw>;rel=\"service-desc\", </hello/swagger-ui-dygixywsw>;rel=\"swagger-ui\"");
 
     response = check httpIntroResTestClient->options("/hello/greeting");
     test:assertEquals(response.statusCode, 204, msg = "Found unexpected statusCode");
     test:assertEquals(check response.getHeader(common:ALLOW), "GET, OPTIONS", msg = "Found unexpected Header");
-    common:assertHeaderValue(check response.getHeader(common:LINK), "</hello/openapi-doc-dygixywsw>;rel=\"service-desc\"");
+    common:assertHeaderValue(check response.getHeader(common:LINK), 
+        "</hello/openapi-doc-dygixywsw>;rel=\"service-desc\", </hello/swagger-ui-dygixywsw>;rel=\"swagger-ui\"");
 }
 
 @test:Config {}

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- [Generate and host SwaggerUI for the generated OpenAPI specification as a built-in resource](https://github.com/ballerina-platform/ballerina-library/issues/6622)
+
 ### Fixed
 
 - [Remove the resource level annotation restrictions](https://github.com/ballerina-platform/ballerina-library/issues/5831)

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpIntrospectionResource.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpIntrospectionResource.java
@@ -18,53 +18,40 @@
 
 package io.ballerina.stdlib.http.api;
 
-import java.util.List;
-
-import static io.ballerina.stdlib.http.api.HttpConstants.SINGLE_SLASH;
+import io.netty.handler.codec.http.HttpHeaderValues;
 
 /**
  * {@code HttpIntrospectionResource} is the resource which respond the service Open API JSON specification.
  *
  * @since SL beta 3
  */
-public class HttpIntrospectionResource extends HttpResource {
+public class HttpIntrospectionResource extends HttpOASResource {
 
     private static final String RESOURCE_NAME = "openapi-doc-dygixywsw";
-    private static final String RESOURCE_METHOD = "$get$";
     private static final String REL_PARAM = "rel=\"service-desc\"";
     private final byte[] payload;
 
-    protected HttpIntrospectionResource(HttpService httpService, byte[] payload) {
-        String path = (httpService.getBasePath() + SINGLE_SLASH + RESOURCE_NAME).replaceAll("/+", SINGLE_SLASH);
-        httpService.setIntrospectionResourcePathHeaderValue("<" + path + ">;" + REL_PARAM);
-        this.payload = payload.clone();
+    public HttpIntrospectionResource(HttpService httpService, byte[] payload) {
+        super(httpService, REL_PARAM, RESOURCE_NAME);
+        this.payload = payload;
     }
 
-    public String getName() {
-        return RESOURCE_METHOD + RESOURCE_NAME;
-    }
-
-    public String getPath() {
-        return SINGLE_SLASH + RESOURCE_NAME;
-    }
-
+    @Override
     public byte[] getPayload() {
         return this.payload.clone();
     }
 
-    public List<String> getMethods() {
-        return List.of(HttpConstants.HTTP_METHOD_GET);
+    @Override
+    protected String getResourceName() {
+        return RESOURCE_NAME;
     }
 
-    public List<String> getConsumes() {
-        return null;
+    @Override
+    public String getContentType() {
+        return HttpHeaderValues.APPLICATION_JSON.toString();
     }
 
-    public List<String> getProduces() {
-        return null;
-    }
-
-    public static String getIntrospectionResourceId() {
-        return RESOURCE_METHOD + RESOURCE_NAME;
+    public static String getResourceId() {
+        return String.format("%s%s", RESOURCE_METHOD, RESOURCE_NAME);
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpOASResource.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpOASResource.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.api;
+
+import java.util.Collections;
+import java.util.List;
+
+import static io.ballerina.stdlib.http.api.HttpConstants.SINGLE_SLASH;
+
+/**
+ * {@code HttpOASResource} is the super class for the service introspection resources.
+ *
+ * @since v2.11.2
+ */
+public abstract class HttpOASResource extends HttpResource {
+    protected static final String RESOURCE_METHOD = "$get$";
+
+    protected HttpOASResource(HttpService httpService, String rel, String resourcePath) {
+        String path = (httpService.getBasePath() + SINGLE_SLASH + resourcePath).replaceAll("/+", SINGLE_SLASH);
+        httpService.addOasResourceLink("<" + path + ">;" + rel);
+    }
+
+    @Override
+    public String getName() {
+        return String.format("%s%s", RESOURCE_METHOD, getResourceName());
+    }
+
+    @Override
+    public String getPath() {
+        return String.format("%s%s", SINGLE_SLASH, getResourceName());
+    }
+
+    @Override
+    public List<String> getMethods() {
+        return List.of(HttpConstants.HTTP_METHOD_GET);
+    }
+
+    @Override
+    public List<String> getConsumes() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<String> getProduces() {
+        return Collections.emptyList();
+    }
+
+    protected abstract String getResourceName();
+
+    public abstract byte[] getPayload();
+
+    public abstract String getContentType();
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpService.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpService.java
@@ -90,7 +90,7 @@ public class HttpService implements Service {
     private String hostName;
     private String chunkingConfig;
     private String mediaTypeSubtypePrefix;
-    private String introspectionResourcePath;
+    private List<String> oasResourceLinks = new ArrayList<>();
     private boolean treatNilableAsOptional = true;
     private List<HTTPInterceptorServicesRegistry> interceptorServicesRegistries;
     private BArray balInterceptorServicesArray;
@@ -273,6 +273,8 @@ public class HttpService implements Service {
         if (introspectionPayload.length > 0) {
             updateResourceTree(httpService, httpResources, new HttpIntrospectionResource(httpService,
                                                                                          introspectionPayload));
+            updateResourceTree(
+                    httpService, httpResources, new HttpSwaggerUiResource(httpService, introspectionPayload));
         } else {
             log.debug("OpenAPI definition is not available");
         }
@@ -406,12 +408,15 @@ public class HttpService implements Service {
     }
 
     @Override
-    public String getIntrospectionResourcePathHeaderValue() {
-        return this.introspectionResourcePath;
+    public String getOasResourceLink() {
+        if (this.oasResourceLinks.isEmpty()) {
+            return null;
+        }
+        return String.join(", ", this.oasResourceLinks);
     }
 
-    protected void setIntrospectionResourcePathHeaderValue(String introspectionResourcePath) {
-        this.introspectionResourcePath = introspectionResourcePath;
+    protected void addOasResourceLink(String oasResourcePath) {
+        this.oasResourceLinks.add(oasResourcePath);
     }
 
     public void setInterceptorServicesRegistries(List<HTTPInterceptorServicesRegistry> interceptorServicesRegistries) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpSwaggerUiResource.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpSwaggerUiResource.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.api;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.util.CharsetUtil;
+
+/**
+ * {@code HttpSwaggerUiResource} is the resource which respond the Swagger-UI for the generated Open API specification.
+ *
+ * @since v2.11.2
+ */
+public class HttpSwaggerUiResource extends HttpOASResource {
+
+    private static final String STATIC_HTML_PAGE = """
+                    <!DOCTYPE html>
+                    <html lang="en">
+                    <head>
+                      <meta charset="utf-8" />
+                      <meta name="viewport" content="width=device-width, initial-scale=1" />
+                      <meta name="description" content="SwaggerUI" />
+                      <title>SwaggerUI</title>
+                      <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css" />
+                    </head>
+                    <body>
+                    <div id="swagger-ui"></div>
+                    <script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js" crossorigin></script>
+                    <script>
+                      window.onload = () => {
+                        window.ui = SwaggerUIBundle({
+                          spec: OPENAPI_SPEC,
+                          dom_id: '#swagger-ui',
+                        });
+                      };
+                    </script>
+                    </body>
+                    </html>
+            """;
+    private static final String RESOURCE_NAME = "swagger-ui-dygixywsw";
+    private static final String REL_PARAM = "rel=\"swagger-ui\"";
+    private static final String OAS_PLACEHOLDER = "OPENAPI_SPEC";
+    private final byte[] payload;
+
+    public HttpSwaggerUiResource(HttpService httpService, byte[] payload) {
+        super(httpService, REL_PARAM, RESOURCE_NAME);
+        String oasSpec = new String(payload.clone(), CharsetUtil.UTF_8);
+        String content = STATIC_HTML_PAGE.replace(OAS_PLACEHOLDER, oasSpec);
+        this.payload = content.getBytes(CharsetUtil.UTF_8);
+    }
+
+    @Override
+    public byte[] getPayload() {
+        return this.payload.clone();
+    }
+
+    @Override
+    protected String getResourceName() {
+        return RESOURCE_NAME;
+    }
+
+    @Override
+    public String getContentType() {
+        return HttpHeaderValues.TEXT_HTML.toString();
+    }
+
+    public static String getResourceId() {
+        return String.format("%s%s", RESOURCE_METHOD, RESOURCE_NAME);
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/api/InterceptorService.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/InterceptorService.java
@@ -74,7 +74,7 @@ public class InterceptorService implements Service {
     }
 
     @Override
-    public String getIntrospectionResourcePathHeaderValue() {
+    public String getOasResourceLink() {
         return null;
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDataElement.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDataElement.java
@@ -75,9 +75,14 @@ public class ResourceDataElement implements DataElement<Resource, HttpCarbonMess
         this.resource.forEach(r -> {
             for (String newMethod : newMethods) {
                 if (DispatcherUtil.isMatchingMethodExist(r, newMethod)) {
-                    if (r.getName().equals(HttpIntrospectionResource.getIntrospectionResourceId())) {
+                    if (r.getName().equals(HttpIntrospectionResource.getResourceId())) {
                         String message = "Resources cannot have the accessor and name as same as the auto generated " +
                                 "Open API spec retrieval resource: '" + r.getName() + "'";
+                        throw HttpUtil.createHttpError(message, GENERIC_LISTENER_ERROR);
+                    }
+                    if (r.getName().equals(HttpSwaggerUiResource.getResourceId())) {
+                        String message = "Resources cannot have the accessor and name as same as the auto generated " +
+                                "Swagger-UI retrieval resource: '" + r.getName() + "'";
                         throw HttpUtil.createHttpError(message, GENERIC_LISTENER_ERROR);
                     }
                     throw HttpUtil.createHttpError("Two resources have the same addressable URI, "
@@ -177,7 +182,7 @@ public class ResourceDataElement implements DataElement<Resource, HttpCarbonMess
         String contentMediaType = extractContentMediaType(cMsg.getHeader(HttpHeaderNames.CONTENT_TYPE.toString()));
         List<String> consumesList = resource.getConsumes();
 
-        if (consumesList == null) {
+        if (consumesList == null || consumesList.isEmpty()) {
             return;
         }
         //when Content-Type header is not set, treat it as "application/octet-stream"
@@ -205,7 +210,7 @@ public class ResourceDataElement implements DataElement<Resource, HttpCarbonMess
         List<String> acceptMediaTypes = extractAcceptMediaTypes(cMsg.getHeader(HttpHeaderNames.ACCEPT.toString()));
         List<String> producesList = resource.getProduces();
 
-        if (producesList == null || acceptMediaTypes == null) {
+        if (producesList == null || producesList.isEmpty() || acceptMediaTypes == null) {
             return;
         }
         //If Accept header field is not present, then it is assumed that the client accepts all media types.

--- a/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/ResourceDispatcher.java
@@ -25,7 +25,6 @@ import io.ballerina.stdlib.http.uri.URITemplateException;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaderValues;
 
 import static io.ballerina.stdlib.http.api.HttpErrorType.INTERNAL_RESOURCE_DISPATCHING_SERVER_ERROR;
 import static io.ballerina.stdlib.http.api.HttpErrorType.INTERNAL_RESOURCE_NOT_FOUND_ERROR;
@@ -43,8 +42,12 @@ public class ResourceDispatcher {
         HttpResourceArguments resourceArgumentValues = new HttpResourceArguments();
         try {
             Resource resource = service.getUriTemplate().matches(subPath, resourceArgumentValues, inboundRequest);
-            if (resource instanceof HttpIntrospectionResource) {
-                handleIntrospectionRequest(inboundRequest, (HttpIntrospectionResource) resource);
+            if (resource instanceof HttpIntrospectionResource introspectionResource) {
+                handleOasResourceRequest(inboundRequest, introspectionResource);
+                return null;
+            }
+            if (resource instanceof HttpSwaggerUiResource swaggerUiResource) {
+                handleOasResourceRequest(inboundRequest, swaggerUiResource);
                 return null;
             }
             if (resource != null) {
@@ -91,7 +94,7 @@ public class ResourceDispatcher {
             throw HttpUtil.createHttpStatusCodeError(INTERNAL_RESOURCE_NOT_FOUND_ERROR, message);
         }
         CorsHeaderGenerator.process(cMsg, response, false);
-        String introspectionResourcePathHeaderValue = service.getIntrospectionResourcePathHeaderValue();
+        String introspectionResourcePathHeaderValue = service.getOasResourceLink();
         if (introspectionResourcePathHeaderValue != null) {
             response.setHeader(HttpConstants.LINK_HEADER, introspectionResourcePathHeaderValue);
         }
@@ -101,11 +104,11 @@ public class ResourceDispatcher {
         cMsg.waitAndReleaseAllEntities();
     }
 
-    private static void handleIntrospectionRequest(HttpCarbonMessage cMsg, HttpIntrospectionResource resource) {
+    private static void handleOasResourceRequest(HttpCarbonMessage cMsg, HttpOASResource resource) {
         HttpCarbonMessage response = HttpUtil.createHttpCarbonMessage(false);
         response.waitAndReleaseAllEntities();
         response.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(resource.getPayload())));
-        response.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), HttpHeaderValues.APPLICATION_JSON.toString());
+        response.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), resource.getContentType());
         response.setHttpStatusCode(200);
         PipeliningHandler.sendPipelinedResponse(cMsg, response);
         cMsg.waitAndReleaseAllEntities();

--- a/native/src/main/java/io/ballerina/stdlib/http/api/Service.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/Service.java
@@ -73,9 +73,9 @@ public interface Service {
     List<String> getAllAllowedMethods();
 
     /**
-     * Returns introspection resource path header configured in the service.
+     * Returns OAS resource path header configured in the service.
      *
      * @return the introspection resource path header string
      */
-    String getIntrospectionResourcePathHeaderValue();
+    String getOasResourceLink();
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/api/HttpServiceTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/api/HttpServiceTest.java
@@ -74,7 +74,7 @@ public class HttpServiceTest {
 
     @Test
     public void testGetIntrospectionResourceIdOfIntrospectionResource() {
-        Assert.assertEquals(HttpIntrospectionResource.getIntrospectionResourceId(), "$get$openapi-doc-dygixywsw");
+        Assert.assertEquals(HttpIntrospectionResource.getResourceId(), "$get$openapi-doc-dygixywsw");
     }
 
     @Test
@@ -83,6 +83,19 @@ public class HttpServiceTest {
         HttpService httpService = new HttpService(service);
         HttpIntrospectionResource introspectionResource = new HttpIntrospectionResource(httpService, "abc".getBytes());
         Assert.assertEquals(introspectionResource.getName(), "$get$openapi-doc-dygixywsw");
+    }
+
+    @Test
+    public void testGetSwaggerUiResourceIdOfIntrospectionResource() {
+        Assert.assertEquals(HttpSwaggerUiResource.getResourceId(), "$get$swagger-ui-dygixywsw");
+    }
+
+    @Test
+    public void testGetNameOfSwaggerUiResource() {
+        BObject service = TestUtils.getNewServiceObject("hello");
+        HttpService httpService = new HttpService(service);
+        HttpSwaggerUiResource swaggerUiResource = new HttpSwaggerUiResource(httpService, "abc".getBytes());
+        Assert.assertEquals(swaggerUiResource.getName(), "$get$swagger-ui-dygixywsw");
     }
 
     @Test


### PR DESCRIPTION
## Purpose
> $subject

Fixes: [#6622](https://github.com/ballerina-platform/ballerina-library/issues/6622)

## Examples
- Run the [Ballerina Snowpeak](https://github.com/ballerina-platform/module-ballerina-http/tree/master/examples/snowpeak) sample using `bal run` by enabling OAS generation.
```ballerina
configurable int port = 9090;

# A fake mountain resort
@openapi:ServiceInfo { embed: true }
@http:ServiceConfig { mediaTypeSubtypePrefix: "vnd.snowpeak.resort", cors: { allowOrigins: ["*"] }}
service /snowpeak on new http:Listener(port) {
  // ...
}
```

- Access [`http://localhost:9090/snowpeak/swagger-ui-dygixywsw`](http://localhost:9090/snowpeak/swagger-ui-dygixywsw) URL on your browser.

![swagger-ui-sample-ext](https://github.com/ballerina-platform/module-ballerina-http/assets/77491511/2a3c49e0-0291-4a05-b7a3-d528d0bebc1c)

- Following is a sample screenshot for a service which contains an invalid OpenAPI definition.

![swagger-ui-error](https://github.com/ballerina-platform/module-ballerina-http/assets/77491511/2f1b452d-449d-41a7-9432-a1a015014af7)

 

## Checklist
- [X] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [ ] Checked native-image compatibility
- [ ] Checked the impact on OpenAPI generation
