### PR TITLE
[2201.8.x] Fix `NumberFormatException` when specifying cache configurations as decimal values

### DIFF
--- a/ballerina-tests/http-advanced-tests/Ballerina.toml
+++ b/ballerina-tests/http-advanced-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_advanced_tests"
-version = "2.10.14"
+version = "2.10.15"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.14"
+version = "2.10.15"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.14.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.15-SNAPSHOT.jar"

--- a/ballerina-tests/http-advanced-tests/Dependencies.toml
+++ b/ballerina-tests/http-advanced-tests/Dependencies.toml
@@ -72,7 +72,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -105,7 +105,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_advanced_tests"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},
@@ -125,7 +125,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-advanced-tests/tests/http2_caching_test.bal
+++ b/ballerina-tests/http-advanced-tests/tests/http2_caching_test.bal
@@ -99,7 +99,7 @@ service /cachingBackend on http2CachingListener2 { //new http:Listener(9240) {
     isolated resource function 'default .(http:Caller caller, http:Request req) returns error? {
         http:Response res = new;
         http:ResponseCacheControl resCC = new;
-        resCC.maxAge = 60;
+        resCC.maxAge = 60.54;
         resCC.isPrivate = false;
 
         res.cacheControl = resCC;
@@ -158,13 +158,13 @@ function testHttp2BasicCachingBehaviour() returns error? {
 @test:Config {}
 function testHttp2RequestCacheControlBuildCacheControlDirectives() {
     http:RequestCacheControl reqCC = new;
-    reqCC.maxAge = 60;
+    reqCC.maxAge = 60.34;
     reqCC.noCache = true;
     reqCC.noStore = true;
     reqCC.noTransform = true;
     reqCC.onlyIfCached = true;
-    reqCC.maxStale = 120;
-    reqCC.minFresh = 6;
+    reqCC.maxStale = 120.04;
+    reqCC.minFresh = 6.0;
     test:assertEquals(reqCC.buildCacheControlDirectives(),
         "no-cache, no-store, no-transform, only-if-cached, max-age=60, max-stale=120, min-fresh=6");
 }
@@ -172,14 +172,14 @@ function testHttp2RequestCacheControlBuildCacheControlDirectives() {
 @test:Config {}
 function testHttp2ResponseCacheControlBuildCacheControlDirectives() {
     http:ResponseCacheControl resCC = new;
-    resCC.maxAge = 60;
+    resCC.maxAge = 60.54;
     resCC.isPrivate = false;
     resCC.mustRevalidate = true;
     resCC.noCache = true;
     resCC.noStore = true;
     resCC.noTransform = true;
     resCC.proxyRevalidate = true;
-    resCC.sMaxAge = 60;
+    resCC.sMaxAge = 60.32;
     test:assertEquals(resCC.buildCacheControlDirectives(),
         "must-revalidate, no-cache, no-store, no-transform, public, proxy-revalidate, max-age=60, s-maxage=60");
 }

--- a/ballerina-tests/http-advanced-tests/tests/http_cache_config_annotation_test.bal
+++ b/ballerina-tests/http-advanced-tests/tests/http_cache_config_annotation_test.bal
@@ -117,7 +117,7 @@ service / on new http:Listener(cacheAnnotationTestPort2, httpVersion = http:HTTP
         }
     }
 
-    resource function default maxAgeBE(http:Request req) returns @http:Cache {maxAge: 5, mustRevalidate: false} xml {
+    resource function default maxAgeBE(http:Request req) returns @http:Cache {maxAge: 5.32, mustRevalidate: false} xml {
         int count = 0;
         lock {
             maxAgeHitCountNew += 1;

--- a/ballerina-tests/http-client-tests/Ballerina.toml
+++ b/ballerina-tests/http-client-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_client_tests"
-version = "2.10.14"
+version = "2.10.15"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.14"
+version = "2.10.15"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.14.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.15-SNAPSHOT.jar"

--- a/ballerina-tests/http-client-tests/Dependencies.toml
+++ b/ballerina-tests/http-client-tests/Dependencies.toml
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_client_tests"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-dispatching-tests/Ballerina.toml
+++ b/ballerina-tests/http-dispatching-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_dispatching_tests"
-version = "2.10.14"
+version = "2.10.15"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.14"
+version = "2.10.15"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.14.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.15-SNAPSHOT.jar"

--- a/ballerina-tests/http-dispatching-tests/Dependencies.toml
+++ b/ballerina-tests/http-dispatching-tests/Dependencies.toml
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_dispatching_tests"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
@@ -124,7 +124,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-interceptor-tests/Ballerina.toml
+++ b/ballerina-tests/http-interceptor-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_interceptor_tests"
-version = "2.10.14"
+version = "2.10.15"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.14"
+version = "2.10.15"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.14.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.15-SNAPSHOT.jar"

--- a/ballerina-tests/http-interceptor-tests/Dependencies.toml
+++ b/ballerina-tests/http-interceptor-tests/Dependencies.toml
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_interceptor_tests"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -115,7 +115,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-misc-tests/Ballerina.toml
+++ b/ballerina-tests/http-misc-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_misc_tests"
-version = "2.10.14"
+version = "2.10.15"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.14"
+version = "2.10.15"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.14.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.15-SNAPSHOT.jar"

--- a/ballerina-tests/http-misc-tests/Dependencies.toml
+++ b/ballerina-tests/http-misc-tests/Dependencies.toml
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_misc_tests"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -118,7 +118,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-resiliency-tests/Ballerina.toml
+++ b/ballerina-tests/http-resiliency-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_resiliency_tests"
-version = "2.10.14"
+version = "2.10.15"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.14"
+version = "2.10.15"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.14.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.15-SNAPSHOT.jar"

--- a/ballerina-tests/http-resiliency-tests/Dependencies.toml
+++ b/ballerina-tests/http-resiliency-tests/Dependencies.toml
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_resiliency_tests"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -116,7 +116,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-security-tests/Ballerina.toml
+++ b/ballerina-tests/http-security-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.10.14"
+version = "2.10.15"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.14"
+version = "2.10.15"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.14.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.15-SNAPSHOT.jar"

--- a/ballerina-tests/http-security-tests/Dependencies.toml
+++ b/ballerina-tests/http-security-tests/Dependencies.toml
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "http"},
@@ -120,7 +120,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-service-tests/Ballerina.toml
+++ b/ballerina-tests/http-service-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_service_tests"
-version = "2.10.14"
+version = "2.10.15"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.14"
+version = "2.10.15"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.14.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.15-SNAPSHOT.jar"

--- a/ballerina-tests/http-service-tests/Dependencies.toml
+++ b/ballerina-tests/http-service-tests/Dependencies.toml
@@ -69,7 +69,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_service_tests"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-test-common/Ballerina.toml
+++ b/ballerina-tests/http-test-common/Ballerina.toml
@@ -1,4 +1,4 @@
 [package]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.14"
+version = "2.10.15"

--- a/ballerina-tests/http-test-common/Dependencies.toml
+++ b/ballerina-tests/http-test-common/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.8.0"
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "mime"},

--- a/ballerina-tests/http2-tests/Ballerina.toml
+++ b/ballerina-tests/http2-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http2_tests"
-version = "2.10.14"
+version = "2.10.15"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.14"
+version = "2.10.15"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.14.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.15-SNAPSHOT.jar"

--- a/ballerina-tests/http2-tests/Dependencies.toml
+++ b/ballerina-tests/http2-tests/Dependencies.toml
@@ -69,7 +69,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http2_tests"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.14"
+version = "2.10.15"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.10.14"
+version = "2.10.15"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -16,8 +16,8 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.10.14"
-path = "../native/build/libs/http-native-2.10.14.jar"
+version = "2.10.15"
+path = "../native/build/libs/http-native-2.10.15-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.10.14.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.10.15-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -25,7 +25,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.7.0"
+version = "3.7.1"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -76,7 +76,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -283,7 +283,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.2.0"
+version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/caching_request_cache_control.bal
+++ b/ballerina/caching_request_cache_control.bal
@@ -61,7 +61,7 @@ public class RequestCacheControl {
         }
 
         if self.maxAge >= 0d {
-            directives[i] = MAX_AGE + "=" + self.maxAge.toString();
+            directives[i] = MAX_AGE + "=" + decimal:floor(self.maxAge).toString();
             i += 1;
         }
 
@@ -69,12 +69,12 @@ public class RequestCacheControl {
             directives[i] = MAX_STALE;
             i += 1;
         } else if self.maxStale >= 0d {
-            directives[i] = MAX_STALE + "=" + self.maxStale.toString();
+            directives[i] = MAX_STALE + "=" + decimal:floor(self.maxStale).toString();
             i += 1;
         }
 
         if self.minFresh >= 0d {
-            directives[i] = MIN_FRESH + "=" + self.minFresh.toString();
+            directives[i] = MIN_FRESH + "=" + decimal:floor(self.minFresh).toString();
             i += 1;
         }
 

--- a/ballerina/caching_request_cache_control.bal
+++ b/ballerina/caching_request_cache_control.bal
@@ -61,7 +61,7 @@ public class RequestCacheControl {
         }
 
         if self.maxAge >= 0d {
-            directives[i] = MAX_AGE + "=" + decimal:floor(self.maxAge).toString();
+            directives[i] = string `${MAX_AGE}=${decimal:floor(self.maxAge)}`;
             i += 1;
         }
 
@@ -69,12 +69,12 @@ public class RequestCacheControl {
             directives[i] = MAX_STALE;
             i += 1;
         } else if self.maxStale >= 0d {
-            directives[i] = MAX_STALE + "=" + decimal:floor(self.maxStale).toString();
+            directives[i] = string `${MAX_STALE}=${decimal:floor(self.maxStale)}`;
             i += 1;
         }
 
         if self.minFresh >= 0d {
-            directives[i] = MIN_FRESH + "=" + decimal:floor(self.minFresh).toString();
+            directives[i] = string `${MIN_FRESH}=${decimal:floor(self.minFresh)}`;
             i += 1;
         }
 

--- a/ballerina/caching_response_cache_control.bal
+++ b/ballerina/caching_response_cache_control.bal
@@ -94,12 +94,12 @@ public class ResponseCacheControl {
         }
 
         if self.maxAge >= 0d {
-            directives[i] = MAX_AGE + "=" + decimal:floor(self.maxAge).toString();
+            directives[i] = string `${MAX_AGE}=${decimal:floor(self.maxAge)}`;
             i += 1;
         }
 
         if self.sMaxAge >= 0d {
-            directives[i] = S_MAX_AGE + "=" + decimal:floor(self.sMaxAge).toString();
+            directives[i] = string `${S_MAX_AGE}=${decimal:floor(self.sMaxAge)}`;
             i += 1;
         }
 

--- a/ballerina/caching_response_cache_control.bal
+++ b/ballerina/caching_response_cache_control.bal
@@ -48,8 +48,8 @@ public class ResponseCacheControl {
         self.noTransform = cacheConfig.noTransform;
         self.isPrivate = cacheConfig.isPrivate;
         self.proxyRevalidate = cacheConfig.proxyRevalidate;
-        self.maxAge = cacheConfig.maxAge;
-        self.sMaxAge = cacheConfig.sMaxAge;
+        self.maxAge = decimal:floor(cacheConfig.maxAge);
+        self.sMaxAge = decimal:floor(cacheConfig.sMaxAge);
         self.noCacheFields = cacheConfig.noCacheFields;
         self.privateFields = cacheConfig.privateFields;
     }
@@ -94,12 +94,12 @@ public class ResponseCacheControl {
         }
 
         if self.maxAge >= 0d {
-            directives[i] = MAX_AGE + "=" + self.maxAge.toString();
+            directives[i] = MAX_AGE + "=" + decimal:floor(self.maxAge).toString();
             i += 1;
         }
 
         if self.sMaxAge >= 0d {
-            directives[i] = S_MAX_AGE + "=" + self.sMaxAge.toString();
+            directives[i] = S_MAX_AGE + "=" + decimal:floor(self.sMaxAge).toString();
             i += 1;
         }
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ This file contains all the notable changes done to the Ballerina HTTP package th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [Fix number format exception with decimal values for cache configuration](https://github.com/ballerina-platform/ballerina-library/issues/6765)
+
 ## [2.10.14] - 2024-06-17
 
 ### Fixed

--- a/native/src/main/java/io/ballerina/stdlib/http/api/client/caching/ResponseCacheControlObj.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/client/caching/ResponseCacheControlObj.java
@@ -203,6 +203,13 @@ public class ResponseCacheControlObj {
     }
 
     private long getIntValue(BObject responseCacheControl, BString fieldName) {
-        return Long.parseLong(responseCacheControl.get(fieldName).toString());
+        try {
+            String value = responseCacheControl.get(fieldName).toString();
+            // The value is decimal, and need to compute the floor value
+            return Long.parseLong(value.split("\\.")[0]);
+        } catch (NumberFormatException e) {
+            // Ignore the exception and set 0 as the value
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/6765

## Examples

N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
- [ ] Checked native-image compatibility
- [ ] ~Checked the impact on OpenAPI generation~
