### PR TITLE
[2201.8.x] Fix `Content-Type` header duplication via `addHeader` method

### DIFF
--- a/ballerina-tests/http-advanced-tests/Ballerina.toml
+++ b/ballerina-tests/http-advanced-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_advanced_tests"
-version = "2.10.16"
+version = "2.10.17"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.16"
+version = "2.10.17"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.16.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.17-SNAPSHOT.jar"

--- a/ballerina-tests/http-advanced-tests/Dependencies.toml
+++ b/ballerina-tests/http-advanced-tests/Dependencies.toml
@@ -72,7 +72,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -105,7 +105,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_advanced_tests"
-version = "2.10.16"
+version = "2.10.17"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},
@@ -125,7 +125,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-client-tests/Ballerina.toml
+++ b/ballerina-tests/http-client-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_client_tests"
-version = "2.10.16"
+version = "2.10.17"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.16"
+version = "2.10.17"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.16.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.17-SNAPSHOT.jar"

--- a/ballerina-tests/http-client-tests/Dependencies.toml
+++ b/ballerina-tests/http-client-tests/Dependencies.toml
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_client_tests"
-version = "2.10.16"
+version = "2.10.17"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-dispatching-tests/Ballerina.toml
+++ b/ballerina-tests/http-dispatching-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_dispatching_tests"
-version = "2.10.16"
+version = "2.10.17"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.16"
+version = "2.10.17"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.16.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.17-SNAPSHOT.jar"

--- a/ballerina-tests/http-dispatching-tests/Dependencies.toml
+++ b/ballerina-tests/http-dispatching-tests/Dependencies.toml
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_dispatching_tests"
-version = "2.10.16"
+version = "2.10.17"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
@@ -124,7 +124,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-interceptor-tests/Ballerina.toml
+++ b/ballerina-tests/http-interceptor-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_interceptor_tests"
-version = "2.10.16"
+version = "2.10.17"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.16"
+version = "2.10.17"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.16.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.17-SNAPSHOT.jar"

--- a/ballerina-tests/http-interceptor-tests/Dependencies.toml
+++ b/ballerina-tests/http-interceptor-tests/Dependencies.toml
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_interceptor_tests"
-version = "2.10.16"
+version = "2.10.17"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -115,7 +115,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-misc-tests/Ballerina.toml
+++ b/ballerina-tests/http-misc-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_misc_tests"
-version = "2.10.16"
+version = "2.10.17"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.16"
+version = "2.10.17"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.16.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.17-SNAPSHOT.jar"

--- a/ballerina-tests/http-misc-tests/Dependencies.toml
+++ b/ballerina-tests/http-misc-tests/Dependencies.toml
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_misc_tests"
-version = "2.10.16"
+version = "2.10.17"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -118,7 +118,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-misc-tests/tests/http_header_test.bal
+++ b/ballerina-tests/http-misc-tests/tests/http_header_test.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/mime;
 import ballerina/test;
 import ballerina/http;
 import ballerina/http_test_common as common;
@@ -274,5 +275,26 @@ function testPassthruWithBody() returns error? {
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }
+}
+
+@test:Config {}
+function testAddHeaderWithContentType() returns error? {
+    http:Request req = new;
+    check req.setContentType(mime:APPLICATION_JSON);
+    test:assertEquals(check req.getHeaders(http:CONTENT_TYPE), [mime:APPLICATION_JSON]);
+    req.addHeader(http:CONTENT_TYPE, mime:APPLICATION_XML);
+    test:assertEquals(check req.getHeaders(http:CONTENT_TYPE), [mime:APPLICATION_XML]);
+
+    http:Response res = new;
+    check res.setContentType(mime:APPLICATION_JSON);
+    test:assertEquals(check res.getHeaders(http:CONTENT_TYPE), [mime:APPLICATION_JSON]);
+    res.addHeader(http:CONTENT_TYPE, mime:APPLICATION_XML);
+    test:assertEquals(check res.getHeaders(http:CONTENT_TYPE), [mime:APPLICATION_XML]);
+
+    http:PushPromise pushPromise = new;
+    pushPromise.addHeader(http:CONTENT_TYPE, mime:APPLICATION_JSON);
+    test:assertEquals(pushPromise.getHeaders(http:CONTENT_TYPE), [mime:APPLICATION_JSON]);
+    pushPromise.addHeader(http:CONTENT_TYPE, mime:APPLICATION_XML);
+    test:assertEquals(pushPromise.getHeaders(http:CONTENT_TYPE), [mime:APPLICATION_XML]);
 }
 

--- a/ballerina-tests/http-resiliency-tests/Ballerina.toml
+++ b/ballerina-tests/http-resiliency-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_resiliency_tests"
-version = "2.10.16"
+version = "2.10.17"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.16"
+version = "2.10.17"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.16.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.17-SNAPSHOT.jar"

--- a/ballerina-tests/http-resiliency-tests/Dependencies.toml
+++ b/ballerina-tests/http-resiliency-tests/Dependencies.toml
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_resiliency_tests"
-version = "2.10.16"
+version = "2.10.17"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -116,7 +116,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-security-tests/Ballerina.toml
+++ b/ballerina-tests/http-security-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.10.16"
+version = "2.10.17"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.16"
+version = "2.10.17"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.16.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.17-SNAPSHOT.jar"

--- a/ballerina-tests/http-security-tests/Dependencies.toml
+++ b/ballerina-tests/http-security-tests/Dependencies.toml
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.10.16"
+version = "2.10.17"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "http"},
@@ -120,7 +120,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-service-tests/Ballerina.toml
+++ b/ballerina-tests/http-service-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_service_tests"
-version = "2.10.16"
+version = "2.10.17"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.16"
+version = "2.10.17"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.16.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.17-SNAPSHOT.jar"

--- a/ballerina-tests/http-service-tests/Dependencies.toml
+++ b/ballerina-tests/http-service-tests/Dependencies.toml
@@ -69,7 +69,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_service_tests"
-version = "2.10.16"
+version = "2.10.17"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-test-common/Ballerina.toml
+++ b/ballerina-tests/http-test-common/Ballerina.toml
@@ -1,4 +1,4 @@
 [package]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.16"
+version = "2.10.17"

--- a/ballerina-tests/http-test-common/Dependencies.toml
+++ b/ballerina-tests/http-test-common/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.8.0"
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.16"
+version = "2.10.17"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "mime"},

--- a/ballerina-tests/http2-tests/Ballerina.toml
+++ b/ballerina-tests/http2-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http2_tests"
-version = "2.10.16"
+version = "2.10.17"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.16"
+version = "2.10.17"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.16.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.17-SNAPSHOT.jar"

--- a/ballerina-tests/http2-tests/Dependencies.toml
+++ b/ballerina-tests/http2-tests/Dependencies.toml
@@ -69,7 +69,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http2_tests"
-version = "2.10.16"
+version = "2.10.17"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.16"
+version = "2.10.17"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.10.16"
+version = "2.10.17"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -16,8 +16,8 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.10.16"
-path = "../native/build/libs/http-native-2.10.16.jar"
+version = "2.10.17"
+path = "../native/build/libs/http-native-2.10.17-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.10.16.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.10.17-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -25,7 +25,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.7.0"
+version = "3.7.1"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -76,7 +76,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.16"
+version = "2.10.17"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -283,7 +283,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/http2_push_promise.bal
+++ b/ballerina/http2_push_promise.bal
@@ -59,11 +59,15 @@ public class PushPromise {
         return externPromiseGetHeaders(self, headerName);
     }
 
-    # Adds the specified key/value pair as an HTTP header to the `http:PushPromise`.
+    # Adds the specified key/value pair as an HTTP header to the `http:PushPromise`. In the case of the `Content-Type`
+    # header, the existing value is replaced with the specified value.
     #
     # + headerName - The header name
     # + headerValue - The header value
     public isolated function addHeader(string headerName, string headerValue) {
+        if headerName.equalsIgnoreCaseAscii(CONTENT_TYPE) {
+            return externPromiseSetHeader(self, headerName, headerValue);
+        }
         return externPromiseAddHeader(self, headerName, headerValue);
     }
 

--- a/ballerina/http_request.bal
+++ b/ballerina/http_request.bal
@@ -164,12 +164,17 @@ public class Request {
         externRequestSetHeader(self, headerName, headerValue);
     }
 
-    # Adds the specified header to the request. Existing header values are not replaced. Panic if an illegal header is passed.
+    # Adds the specified header to the request. Existing header values are not replaced, except for the `Content-Type`
+    # header. In the case of the `Content-Type` header, the existing value is replaced with the specified value.
+    # Panic if an illegal header is passed.
     #
     # + headerName - The header name
     # + headerValue - The header value
     public isolated function addHeader(string headerName, string headerValue) {
-        externRequestAddHeader(self, headerName, headerValue);
+        if headerName.equalsIgnoreCaseAscii(CONTENT_TYPE) {
+            return externRequestSetHeader(self, headerName, headerValue);
+        }
+        return externRequestAddHeader(self, headerName, headerValue);
     }
 
     # Removes the specified header from the request.

--- a/ballerina/http_response.bal
+++ b/ballerina/http_response.bal
@@ -109,13 +109,18 @@ public class Response {
         return externResponseGetHeader(self, headerName, position);
     }
 
-    # Adds the specified header to the response. Existing header values are not replaced. Panic if an illegal header is passed.
+    # Adds the specified header to the response. Existing header values are not replaced, except for the `Content-Type`
+    # header. In the case of the `Content-Type` header, the existing value is replaced with the specified value.
+    #. Panic if an illegal header is passed.
     #
     # + headerName - The header name
     # + headerValue - The header value
     # + position - Represents the position of the header as an optional parameter. If the position is `http:TRAILING`,
     #              the entity-body of the `Response` must be accessed initially.
     public isolated function addHeader(string headerName, string headerValue, HeaderPosition position = LEADING) {
+        if headerName.equalsIgnoreCaseAscii(CONTENT_TYPE) {
+            return externResponseSetHeader(self, headerName, headerValue, position);
+        }
         return externResponseAddHeader(self, headerName, headerValue, position);
     }
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ This file contains all the notable changes done to the Ballerina HTTP package th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [Fix duplicating `Content-Type` header via the `addHeader` method](https://github.com/ballerina-platform/ballerina-library/issues/7268)
+
 ## [2.10.16] - 2024-09-25
 
 ### Fixed


### PR DESCRIPTION
## Purpose

> Part of: https://github.com/ballerina-platform/ballerina-library/issues/7268

## Examples

N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
- [ ] Checked native-image compatibility
- [ ] ~Checked the impact on OpenAPI generation~
