### PR TITLE
[2201.7.x] Handle bal future complete panic by logging the error

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/http/api/DataContext.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/DataContext.java
@@ -91,6 +91,7 @@ public class DataContext {
             balFuture.complete(result);
         } catch (BError err) {
             System.err.printf(FUTURE_COMPLETE_ERR_MSG, methodCall, err.getMessage());
+            HttpUtil.printStacktraceIfError(result);
         }
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpCallableUnitCallback.java
@@ -130,7 +130,7 @@ public class HttpCallableUnitCallback implements Callback {
             @Override
             public void notifySuccess(Object result) {
                 stopObserverContext();
-                printStacktraceIfError(result);
+                HttpUtil.printStacktraceIfError(result);
             }
 
             @Override
@@ -188,17 +188,11 @@ public class HttpCallableUnitCallback implements Callback {
             HttpUtil.methodInvocationCheck(requestMessage, HttpConstants.INVALID_STATUS_CODE, ILLEGAL_FUNCTION_INVOKED);
         } catch (BError e) {
             if (result != null) { // handles nil return and end of resource exec
-                printStacktraceIfError(result);
+                HttpUtil.printStacktraceIfError(result);
                 err.println(HttpConstants.HTTP_RUNTIME_WARNING_PREFIX + e.getMessage());
             }
             return true;
         }
         return false;
-    }
-
-    private void printStacktraceIfError(Object result) {
-        if (result instanceof BError) {
-            ((BError) result).printStackTrace();
-        }
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -613,6 +613,8 @@ public class HttpConstants {
 
     public static final BString REQUEST_CTX_MEMBERS = StringUtils.fromString("members");
 
+    public static final String FUTURE_COMPLETE_ERR_MSG = "%s failed with bal future completion error: %s%n";
+
     private HttpConstants() {
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpRequestInterceptorUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpRequestInterceptorUnitCallback.java
@@ -101,12 +101,6 @@ public class HttpRequestInterceptorUnitCallback extends HttpCallableUnitCallback
         return false;
     }
 
-    private void printStacktraceIfError(Object result) {
-        if (result instanceof BError) {
-            ((BError) result).printStackTrace();
-        }
-    }
-
     private void sendRequestToNextService() {
         ballerinaHTTPConnectorListener.onMessage(requestMessage);
     }
@@ -186,7 +180,7 @@ public class HttpRequestInterceptorUnitCallback extends HttpCallableUnitCallback
         Callback returnCallback = new Callback() {
             @Override
             public void notifySuccess(Object result) {
-                printStacktraceIfError(result);
+                HttpUtil.printStacktraceIfError(result);
             }
 
             @Override

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpResponseInterceptorUnitCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpResponseInterceptorUnitCallback.java
@@ -88,12 +88,6 @@ public class HttpResponseInterceptorUnitCallback extends HttpCallableUnitCallbac
         returnErrorResponse(error);
     }
 
-    private void printStacktraceIfError(Object result) {
-        if (result instanceof BError) {
-            ((BError) result).printStackTrace();
-        }
-    }
-
     private void sendResponseToNextService() {
         Respond.nativeRespondWithDataCtx(environment, caller, response, dataContext);
     }
@@ -171,7 +165,7 @@ public class HttpResponseInterceptorUnitCallback extends HttpCallableUnitCallbac
             public void notifySuccess(Object result) {
                 stopObserverContext();
                 dataContext.notifyOutboundResponseStatus(null);
-                printStacktraceIfError(result);
+                HttpUtil.printStacktraceIfError(result);
             }
 
             @Override

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -1971,6 +1971,12 @@ public class HttpUtil {
         return false;
     }
 
+    public static void printStacktraceIfError(Object result) {
+        if (result instanceof BError) {
+            ((BError) result).printStackTrace();
+        }
+    }
+
     private HttpUtil() {
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/HasPromise.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/HasPromise.java
@@ -18,12 +18,15 @@ package io.ballerina.stdlib.http.api.client.actions;
 
 import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.Future;
+import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.stdlib.http.api.HttpConstants;
 import io.ballerina.stdlib.http.api.HttpUtil;
 import io.ballerina.stdlib.http.transport.contract.HttpClientConnector;
 import io.ballerina.stdlib.http.transport.contract.HttpClientConnectorListener;
 import io.ballerina.stdlib.http.transport.message.ResponseHandle;
+
+import static io.ballerina.stdlib.http.api.HttpConstants.FUTURE_COMPLETE_ERR_MSG;
 
 /**
  * {@code HasPromise} action can be used to check whether a push promise is available.
@@ -51,7 +54,11 @@ public class HasPromise extends AbstractHTTPAction {
 
         @Override
         public void onPushPromiseAvailability(boolean isPromiseAvailable) {
-            balFuture.complete(isPromiseAvailable);
+            try {
+                balFuture.complete(isPromiseAvailable);
+            } catch (BError err) {
+                System.err.printf(FUTURE_COMPLETE_ERR_MSG, "check promise availability", err.getMessage());
+            }
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/HttpClientAction.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/HttpClientAction.java
@@ -52,6 +52,7 @@ import static io.ballerina.stdlib.http.api.HttpConstants.CLIENT_ENDPOINT_SERVICE
 import static io.ballerina.stdlib.http.api.HttpConstants.CURRENT_TRANSACTION_CONTEXT_PROPERTY;
 import static io.ballerina.stdlib.http.api.HttpConstants.EMPTY;
 import static io.ballerina.stdlib.http.api.HttpConstants.EQUAL_SIGN;
+import static io.ballerina.stdlib.http.api.HttpConstants.FUTURE_COMPLETE_ERR_MSG;
 import static io.ballerina.stdlib.http.api.HttpConstants.MAIN_STRAND;
 import static io.ballerina.stdlib.http.api.HttpConstants.ORIGIN_HOST;
 import static io.ballerina.stdlib.http.api.HttpConstants.POOLED_BYTE_BUFFER_FACTORY;
@@ -226,7 +227,12 @@ public class HttpClientAction extends AbstractHTTPAction {
         env.getRuntime().invokeMethodAsync(client, methodName, null, null, new Callback() {
             @Override
             public void notifySuccess(Object result) {
-                balFuture.complete(result);
+                try {
+                    balFuture.complete(result);
+                } catch (BError err) {
+                    System.err.printf(FUTURE_COMPLETE_ERR_MSG, "invoke client method with success result",
+                            err.getMessage());
+                }
             }
 
             @Override
@@ -234,7 +240,12 @@ public class HttpClientAction extends AbstractHTTPAction {
                 BError invocationError =
                         HttpUtil.createHttpError("client method invocation failed: " + bError.getErrorMessage(),
                                                  HttpErrorType.CLIENT_ERROR, bError);
-                balFuture.complete(invocationError);
+                try {
+                    balFuture.complete(invocationError);
+                } catch (BError err) {
+                    System.err.printf(FUTURE_COMPLETE_ERR_MSG, "invoke client method with failure result",
+                            err.getMessage());
+                }
             }
         }, propertyMap, PredefinedTypes.TYPE_NULL, paramFeed);
         return null;

--- a/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/HttpClientAction.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/client/actions/HttpClientAction.java
@@ -232,6 +232,7 @@ public class HttpClientAction extends AbstractHTTPAction {
                 } catch (BError err) {
                     System.err.printf(FUTURE_COMPLETE_ERR_MSG, "invoke client method with success result",
                             err.getMessage());
+                    HttpUtil.printStacktraceIfError(result);
                 }
             }
 
@@ -245,6 +246,7 @@ public class HttpClientAction extends AbstractHTTPAction {
                 } catch (BError err) {
                     System.err.printf(FUTURE_COMPLETE_ERR_MSG, "invoke client method with failure result",
                             err.getMessage());
+                    HttpUtil.printStacktraceIfError(invocationError);
                 }
             }
         }, propertyMap, PredefinedTypes.TYPE_NULL, paramFeed);

--- a/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternHttpDataSourceBuilder.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternHttpDataSourceBuilder.java
@@ -40,6 +40,7 @@ import java.io.InputStream;
 import java.util.Locale;
 import java.util.Objects;
 
+import static io.ballerina.stdlib.http.api.HttpConstants.FUTURE_COMPLETE_ERR_MSG;
 import static io.ballerina.stdlib.mime.util.EntityBodyHandler.constructBlobDataSource;
 import static io.ballerina.stdlib.mime.util.EntityBodyHandler.constructJsonDataSource;
 import static io.ballerina.stdlib.mime.util.EntityBodyHandler.constructStringDataSource;
@@ -229,7 +230,13 @@ public class ExternHttpDataSourceBuilder extends MimeDataSourceBuilder {
     }
 
     private static void setReturnValuesAndNotify(Future balFuture, Object result) {
-        balFuture.complete(result);
+        try {
+            balFuture.complete(result);
+        } catch (BError error) {
+            String resultType = result instanceof BError ? "error" : "success";
+            System.err.printf(FUTURE_COMPLETE_ERR_MSG, "return data source builder " + resultType + " result",
+                    error.getMessage());
+        }
     }
 
     private static void updateDataSourceAndNotify(Future balFuture, BObject entityObj,

--- a/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternHttpDataSourceBuilder.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternHttpDataSourceBuilder.java
@@ -236,6 +236,7 @@ public class ExternHttpDataSourceBuilder extends MimeDataSourceBuilder {
             String resultType = result instanceof BError ? "error" : "success";
             System.err.printf(FUTURE_COMPLETE_ERR_MSG, "return data source builder " + resultType + " result",
                     error.getMessage());
+            HttpUtil.printStacktraceIfError(result);
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/connection/Respond.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/connection/Respond.java
@@ -92,7 +92,7 @@ public class Respond extends ConnectionAction {
                                   "as the response has been already used.", inboundRequestMsg.getSequenceId());
             }
             BError httpError = HttpUtil.createHttpError(errorMessage, HttpErrorType.GENERIC_LISTENER_ERROR);
-            dataContext.getFuture().complete(httpError);
+            dataContext.completeFuture(httpError, "notify outbound dirty response");
             return null;
         }
         outboundResponseObj.addNativeData(HttpConstants.DIRTY_RESPONSE, true);
@@ -107,7 +107,7 @@ public class Respond extends ConnectionAction {
             HttpUtil.checkFunctionValidity(inboundRequestMsg, outboundResponseMsg);
         } catch (BError e) {
             log.debug(e.getPrintableStackTrace(), e);
-            dataContext.getFuture().complete(e);
+            dataContext.completeFuture(e, "notify function availability failure");
             return null;
         }
 
@@ -151,14 +151,14 @@ public class Respond extends ConnectionAction {
             }
         } catch (BError e) {
             log.debug(e.getPrintableStackTrace(), e);
-            dataContext.getFuture().complete(
-                    HttpUtil.createHttpError(e.getMessage(), HttpErrorType.GENERIC_LISTENER_ERROR));
+            dataContext.completeFuture(HttpUtil.createHttpError(e.getMessage(), HttpErrorType.GENERIC_LISTENER_ERROR),
+                    "notify outbound response sent error");
         } catch (Throwable e) {
             //Exception is already notified by http transport.
             String errorMessage = "Couldn't complete outbound response: " + e.getMessage();
             log.debug(errorMessage, e);
-            dataContext.getFuture().complete(
-                    HttpUtil.createHttpError(errorMessage, HttpErrorType.GENERIC_LISTENER_ERROR));
+            dataContext.completeFuture(HttpUtil.createHttpError(errorMessage, HttpErrorType.GENERIC_LISTENER_ERROR),
+                    "notify outbound response completion error");
         }
         return null;
     }


### PR DESCRIPTION
## Purpose

> $Subject

The Bal Future complete will throw an error when we try to complete the same future twice(this is an unexpected behaviour). In the current implementation, we do not handle that error, and in some scenarios, this is ending up in a panic, which cause the service to crash. This PR is to catch that exception and add a log which can resolve the panic behaviour and will provide more context on where this error occur(this can be used to trace the unexpected completion).

## Examples

N/A

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
- [ ] Checked the impact on OpenAPI generation
