### PR TITLE
Disable `testServiceCompletesStreamWithErrorEvent` test

### DIFF
--- a/ballerina-tests/http-advanced-tests/tests/server_sent_event_tests.bal
+++ b/ballerina-tests/http-advanced-tests/tests/server_sent_event_tests.bal
@@ -163,7 +163,8 @@ function testClientRequestMethodsWithStreamType() returns error? {
     check assertEventStream(actualSseEvents, expectedSseEvents);
 }
 
-@test:Config {}
+// disabled due to https://github.com/ballerina-platform/ballerina-library/issues/7427
+@test:Config {enable: false}
 function testServiceCompletesStreamWithErrorEvent() returns error? {
     stream<http:SseEvent, error?> actualSseEvents = check http2SseClient->/sse/completeWithError;
     stream<http:SseEvent, error?> expectedSseEvents = new (new SseEventGenerator(3, true));


### PR DESCRIPTION
## Purpose

Related to this issue: https://github.com/ballerina-platform/ballerina-library/issues/7427

## Examples

N/A

## Checklist
- [ ] ~Linked to an issue~
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
- [ ] ~Checked the impact on OpenAPI generation~
