### PR TITLE
[Master] Add support for configuring server name to be used in the SSL SNI extension

### DIFF
--- a/ballerina-tests/http-security-tests/tests/http2_ssl_test.bal
+++ b/ballerina-tests/http-security-tests/tests/http2_ssl_test.bal
@@ -36,8 +36,7 @@ http:ClientConfiguration http2SslClientConf1 = {
         cert: {
             path: common:TRUSTSTORE_PATH,
             password: "ballerina"
-        },
-        sniHostName: "localhost2"
+        }
     }
 };
 

--- a/ballerina-tests/http-security-tests/tests/http2_ssl_test.bal
+++ b/ballerina-tests/http-security-tests/tests/http2_ssl_test.bal
@@ -36,7 +36,8 @@ http:ClientConfiguration http2SslClientConf1 = {
         cert: {
             path: common:TRUSTSTORE_PATH,
             password: "ballerina"
-        }
+        },
+        sniHostName: "localhost2"
     }
 };
 

--- a/ballerina-tests/http-security-tests/tests/ssl_sni_host_name_test.bal
+++ b/ballerina-tests/http-security-tests/tests/ssl_sni_host_name_test.bal
@@ -1,0 +1,80 @@
+// Copyright (c) 2024 WSO2 Inc. (http://www.wso2.org).
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/test;
+import ballerina/http_test_common as common;
+
+listener http:Listener http2SniListener = new (9207, http2SslServiceConf);
+
+http:ListenerConfiguration http1SniServiceConf = {
+    httpVersion: http:HTTP_1_1,
+    secureSocket: {
+        key: {
+            path: common:KEYSTORE_PATH,
+            password: "ballerina"
+        }
+    }
+};
+
+listener http:Listener http1SniListener = new (9208, http1SniServiceConf);
+
+service /http2SniService on http2SniListener {
+    resource function get .() returns string {
+        return "Sni works with HTTP_2!";
+    }
+}
+
+service /http1SniService on http1SniListener {
+    resource function get .() returns string {
+        return "Sni works with HTTP_1.1!";
+    }
+}
+
+http:ClientConfiguration http2SniClientConf = {
+    secureSocket: {
+        cert: {
+            path: common:TRUSTSTORE_PATH,
+            password: "ballerina"
+        },
+        serverName: "localhost"
+    }
+};
+
+http:ClientConfiguration http1SniClientConf = {
+    httpVersion: http:HTTP_1_1,
+    secureSocket: {
+        cert: {
+            path: common:TRUSTSTORE_PATH,
+            password: "ballerina"
+        },
+        serverName: "localhost"
+    }
+};
+
+@test:Config {enable: true}
+public function testHttp2Sni() returns error? {
+    http:Client clientEP = check new ("https://127.0.0.1:9207", http2SniClientConf);
+    string resp = check clientEP->get("/http2SniService/");
+    common:assertTextPayload(resp, "Sni works with HTTP_2!");
+}
+
+@test:Config {enable: true}
+public function testHttp1Sni() returns error? {
+    http:Client clientEP = check new ("https://127.0.0.1:9208", http1SniClientConf);
+    string resp = check clientEP->get("/http1SniService/");
+    common:assertTextPayload(resp, "Sni works with HTTP_1.1!");
+}

--- a/ballerina-tests/http-security-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-security-tests/tests/test_service_ports.bal
@@ -19,3 +19,6 @@ const int stsPort = 9445;
 
 const int http2GeneralPort = 9100;
 const int http2SslGeneralPort = 9107;
+
+const int http2SniListenerPort = 9207;
+const int http1SniListenerPort = 9208;

--- a/ballerina/http_client_config.bal
+++ b/ballerina/http_client_config.bal
@@ -96,6 +96,7 @@ public type RetryConfig record {|
 # + shareSession - Enable/disable new SSL session creation
 # + handshakeTimeout - SSL handshake time out
 # + sessionTimeout - SSL session time out
+# + sniHostName - Server name indication(SNI) to be used. If this is not present, hostname from the target URL will be used
 public type ClientSecureSocket record {|
     boolean enable = true;
     crypto:TrustStore|string cert?;
@@ -114,6 +115,7 @@ public type ClientSecureSocket record {|
     boolean shareSession = true;
     decimal handshakeTimeout?;
     decimal sessionTimeout?;
+    string sniHostName?;
 |};
 
 # Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.

--- a/ballerina/http_client_config.bal
+++ b/ballerina/http_client_config.bal
@@ -96,7 +96,7 @@ public type RetryConfig record {|
 # + shareSession - Enable/disable new SSL session creation
 # + handshakeTimeout - SSL handshake time out
 # + sessionTimeout - SSL session time out
-# + sniHostName - Server name indication(SNI) to be used. If this is not present, hostname from the target URL will be used
+# + serverName - Server name indication(SNI) to be used. If this is not present, hostname from the target URL will be used
 public type ClientSecureSocket record {|
     boolean enable = true;
     crypto:TrustStore|string cert?;
@@ -115,7 +115,7 @@ public type ClientSecureSocket record {|
     boolean shareSession = true;
     decimal handshakeTimeout?;
     decimal sessionTimeout?;
-    string sniHostName?;
+    string serverName?;
 |};
 
 # Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Add support for configuring server name to be used in the SSL SNI extension](https://github.com/ballerina-platform/ballerina-library/issues/7435)
 
 ### Added
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -486,6 +486,7 @@ public final class HttpConstants {
     public static final BString SECURESOCKET_CONFIG_VERIFY_CLIENT = StringUtils.fromString("verifyClient");
     public static final BString SECURESOCKET_CONFIG_CERT_VALIDATION_TYPE_OCSP_STAPLING =
             StringUtils.fromString("OCSP_STAPLING");
+    public static final BString SECURESOCKET_CONFIG_SNI_HOST_NAME = StringUtils.fromString("serverName");
 
     //Socket Config
     public static final BString SOCKET_CONFIG = StringUtils.fromString("socketConfig");

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -1900,6 +1900,12 @@ public class HttpUtil {
         Parameter enableSessionCreationParam = new Parameter(HttpConstants.SECURESOCKET_CONFIG_SHARE_SESSION.getValue(),
                                                              enableSessionCreation);
         paramList.add(enableSessionCreationParam);
+        String sniHostName = "null".equals(String.valueOf(secureSocket.getStringValue(
+                HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME))) ? null
+                : String.valueOf(secureSocket.getStringValue(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME));
+        Parameter sniHostNameParam = new Parameter(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME.getValue(),
+                sniHostName);
+        paramList.add(sniHostNameParam);
     }
 
     private static BMap<BString, Object> getBMapValueIfPresent(BMap<BString, Object> map, BString key) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -1900,12 +1900,11 @@ public class HttpUtil {
         Parameter enableSessionCreationParam = new Parameter(HttpConstants.SECURESOCKET_CONFIG_SHARE_SESSION.getValue(),
                                                              enableSessionCreation);
         paramList.add(enableSessionCreationParam);
-        String sniHostName = "null".equals(String.valueOf(secureSocket.getStringValue(
-                HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME))) ? null
-                : String.valueOf(secureSocket.getStringValue(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME));
-        Parameter sniHostNameParam = new Parameter(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME.getValue(),
-                sniHostName);
-        paramList.add(sniHostNameParam);
+        if (secureSocket.containsKey(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME)) {
+            Parameter sniHostNameParam = new Parameter(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME.getValue(),
+                    String.valueOf(secureSocket.getStringValue(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME)));
+            paramList.add(sniHostNameParam);
+        }
     }
 
     private static BMap<BString, Object> getBMapValueIfPresent(BMap<BString, Object> map, BString key) {

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contract/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contract/Constants.java
@@ -43,7 +43,7 @@ public final class Constants {
     public static final String CLIENT_SUPPORT_CIPHERS = "ciphers";
     public static final String CLIENT_SUPPORT_SSL_PROTOCOLS = "sslEnabledProtocols";
     public static final String CLIENT_ENABLE_SESSION_CREATION = "shareSession";
-    public static final String SNI_SERVER_NAME = "sniHostName";
+    public static final String SNI_SERVER_NAME = "serverName";
     public static final String MUTUAL_SSL_PASSED = "passed";
     public static final String MUTUAL_SSL_FAILED = "failed";
     public static final String MUTUAL_SSL_DISABLED = "disabled";

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contract/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contract/Constants.java
@@ -43,6 +43,7 @@ public final class Constants {
     public static final String CLIENT_SUPPORT_CIPHERS = "ciphers";
     public static final String CLIENT_SUPPORT_SSL_PROTOCOLS = "sslEnabledProtocols";
     public static final String CLIENT_ENABLE_SESSION_CREATION = "shareSession";
+    public static final String SNI_SERVER_NAME = "sniHostName";
     public static final String MUTUAL_SSL_PASSED = "passed";
     public static final String MUTUAL_SSL_FAILED = "failed";
     public static final String MUTUAL_SSL_DISABLED = "disabled";

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/SslConfiguration.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/SslConfiguration.java
@@ -39,6 +39,7 @@ import static io.ballerina.stdlib.http.transport.contract.Constants.SERVER_SUPPO
 import static io.ballerina.stdlib.http.transport.contract.Constants.SERVER_SUPPORTED_SNIMATCHERS;
 import static io.ballerina.stdlib.http.transport.contract.Constants.SERVER_SUPPORT_CIPHERS;
 import static io.ballerina.stdlib.http.transport.contract.Constants.SERVER_SUPPORT_SSL_PROTOCOLS;
+import static io.ballerina.stdlib.http.transport.contract.Constants.SNI_SERVER_NAME;
 import static io.ballerina.stdlib.http.transport.contract.Constants.TLS_PROTOCOL;
 /**
  * SSL configuration for HTTP connection.
@@ -276,6 +277,9 @@ public class SslConfiguration {
                         break;
                     case CLIENT_ENABLE_SESSION_CREATION:
                         sslConfig.setEnableSessionCreation(Boolean.parseBoolean(parameter.getValue()));
+                        break;
+                    case SNI_SERVER_NAME:
+                        sslConfig.setSniHostName(parameter.getValue());
                         break;
                     default:
                         //do nothing

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/Util.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/Util.java
@@ -419,7 +419,7 @@ public class Util {
         SslHandler sslHandler = sslContext.newHandler(socketChannel.alloc(), host, port);
         SSLEngine sslEngine = sslHandler.engine();
         sslHandlerFactory.addCommonConfigs(sslEngine);
-        setSniServerName(sslConfig, host, sslHandlerFactory, sslEngine);
+        configureSniServerName(sslConfig, host, sslHandlerFactory, sslEngine);
         if (sslConfig.isHostNameVerificationEnabled()) {
             setHostNameVerfication(sslEngine);
         }
@@ -514,7 +514,7 @@ public class Util {
         if (sslConfig != null) {
             sslEngine = sslHandlerFactory.buildClientSSLEngine(host, port);
             sslEngine.setUseClientMode(true);
-            setSniServerName(sslConfig, host, sslHandlerFactory, sslEngine);
+            configureSniServerName(sslConfig, host, sslHandlerFactory, sslEngine);
             if (hostNameVerificationEnabled) {
                 sslHandlerFactory.setHostNameVerfication(sslEngine);
             }
@@ -522,12 +522,10 @@ public class Util {
         return sslEngine;
     }
 
-    private static void setSniServerName(SSLConfig sslConfig, String host, SSLHandlerFactory sslHandlerFactory, SSLEngine sslEngine) {
-        if (sslConfig.getSniHostName().isEmpty()) {
-            sslHandlerFactory.setSNIServerNames(sslEngine, host);
-        } else {
-            sslHandlerFactory.setSNIServerNames(sslEngine, sslConfig.getSniHostName());
-        }
+    private static void configureSniServerName(SSLConfig sslConfig, String host, SSLHandlerFactory sslHandlerFactory,
+                                               SSLEngine sslEngine) {
+        sslHandlerFactory.setSNIServerNames(sslEngine,
+                sslConfig.getSniHostName() != null ? sslConfig.getSniHostName() : host);
     }
 
     /**

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/Util.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/Util.java
@@ -419,7 +419,7 @@ public class Util {
         SslHandler sslHandler = sslContext.newHandler(socketChannel.alloc(), host, port);
         SSLEngine sslEngine = sslHandler.engine();
         sslHandlerFactory.addCommonConfigs(sslEngine);
-        sslHandlerFactory.setSNIServerNames(sslEngine, host);
+        setSniServerName(sslConfig, host, sslHandlerFactory, sslEngine);
         if (sslConfig.isHostNameVerificationEnabled()) {
             setHostNameVerfication(sslEngine);
         }
@@ -514,12 +514,20 @@ public class Util {
         if (sslConfig != null) {
             sslEngine = sslHandlerFactory.buildClientSSLEngine(host, port);
             sslEngine.setUseClientMode(true);
-            sslHandlerFactory.setSNIServerNames(sslEngine, host);
+            setSniServerName(sslConfig, host, sslHandlerFactory, sslEngine);
             if (hostNameVerificationEnabled) {
                 sslHandlerFactory.setHostNameVerfication(sslEngine);
             }
         }
         return sslEngine;
+    }
+
+    private static void setSniServerName(SSLConfig sslConfig, String host, SSLHandlerFactory sslHandlerFactory, SSLEngine sslEngine) {
+        if (sslConfig.getSniHostName().isEmpty()) {
+            sslHandlerFactory.setSNIServerNames(sslEngine, host);
+        } else {
+            sslHandlerFactory.setSNIServerNames(sslEngine, sslConfig.getSniHostName());
+        }
     }
 
     /**

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/ssl/SSLConfig.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/ssl/SSLConfig.java
@@ -64,6 +64,7 @@ public class SSLConfig {
     private long handshakeTimeOut;
     private boolean disableSsl = false;
     private boolean useJavaDefaults = false;
+    private String sniHostName;
 
     public SSLConfig() {}
 
@@ -177,6 +178,14 @@ public class SSLConfig {
             LOG.debug("Enable Session Creation {}", enableSessionCreation);
         }
         this.enableSessionCreation = enableSessionCreation;
+    }
+
+    public void setSniHostName(String sniHostName) {
+        this.sniHostName = sniHostName;
+    }
+
+    public String getSniHostName() {
+        return sniHostName;
     }
 
     public String[] getEnableProtocols() {

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/HttpClientChannelInitializer.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/HttpClientChannelInitializer.java
@@ -213,11 +213,8 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
             SslContext sslCtx = sslHandlerFactory.createHttp2TLSContextForClient(false);
             SslHandler sslHandler = sslCtx.newHandler(ch.alloc(), httpRoute.getHost(), httpRoute.getPort());
             SSLEngine sslEngine = sslHandler.engine();
-            if (sslConfig.getSniHostName().isEmpty()) {
-                sslHandlerFactory.setSNIServerNames(sslEngine, httpRoute.getHost());
-            } else {
-                sslHandlerFactory.setSNIServerNames(sslEngine, sslConfig.getSniHostName());
-            }
+            sslHandlerFactory.setSNIServerNames(sslEngine,
+                    sslConfig.getSniHostName() != null ? sslConfig.getSniHostName() : httpRoute.getHost());
             if (sslConfig.isHostNameVerificationEnabled()) {
                 setHostNameVerfication(sslEngine);
             }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/HttpClientChannelInitializer.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/HttpClientChannelInitializer.java
@@ -213,7 +213,11 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
             SslContext sslCtx = sslHandlerFactory.createHttp2TLSContextForClient(false);
             SslHandler sslHandler = sslCtx.newHandler(ch.alloc(), httpRoute.getHost(), httpRoute.getPort());
             SSLEngine sslEngine = sslHandler.engine();
-            sslHandlerFactory.setSNIServerNames(sslEngine, httpRoute.getHost());
+            if (sslConfig.getSniHostName().isEmpty()) {
+                sslHandlerFactory.setSNIServerNames(sslEngine, httpRoute.getHost());
+            } else {
+                sslHandlerFactory.setSNIServerNames(sslEngine, sslConfig.getSniHostName());
+            }
             if (sslConfig.isHostNameVerificationEnabled()) {
                 setHostNameVerfication(sslEngine);
             }


### PR DESCRIPTION
## Purpose
Add support for configuring the server name to be used in the SSL SNI extension.
Related issue: https://github.com/ballerina-platform/ballerina-library/issues/7435

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [x] Checked native-image compatibility
- [x] Checked the impact on OpenAPI generation
