### PR TITLE
[2201.5.x] Add support for configuring server name to be used in the SSL SNI extension

### DIFF
--- a/ballerina-tests/http-security-tests/Ballerina.toml
+++ b/ballerina-tests/http-security-tests/Ballerina.toml
@@ -1,14 +1,14 @@
 [package]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.7.8"
+version = "2.7.19"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.7.8"
+version = "2.7.19"
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.7.8.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.7.19.jar"

--- a/ballerina-tests/http-security-tests/Ballerina.toml
+++ b/ballerina-tests/http-security-tests/Ballerina.toml
@@ -1,14 +1,14 @@
 [package]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.7.19"
+version = "2.7.9"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.7.19"
+version = "2.7.9"
 
 [[platform.java11.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.7.19.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.7.9-SNAPSHOT.jar"

--- a/ballerina-tests/http-security-tests/Dependencies.toml
+++ b/ballerina-tests/http-security-tests/Dependencies.toml
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.7.19"
+version = "2.7.9"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.7.19"
+version = "2.7.9"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.7.19"
+version = "2.7.9"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-security-tests/Dependencies.toml
+++ b/ballerina-tests/http-security-tests/Dependencies.toml
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.7.8"
+version = "2.7.19"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.7.8"
+version = "2.7.19"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.7.8"
+version = "2.7.19"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-security-tests/tests/http2_ssl_test.bal
+++ b/ballerina-tests/http-security-tests/tests/http2_ssl_test.bal
@@ -36,8 +36,7 @@ http:ClientConfiguration http2SslClientConf1 = {
         cert: {
             path: common:TRUSTSTORE_PATH,
             password: "ballerina"
-        },
-        sniHostName: "localhost2"
+        }
     }
 };
 

--- a/ballerina-tests/http-security-tests/tests/http2_ssl_test.bal
+++ b/ballerina-tests/http-security-tests/tests/http2_ssl_test.bal
@@ -36,7 +36,8 @@ http:ClientConfiguration http2SslClientConf1 = {
         cert: {
             path: common:TRUSTSTORE_PATH,
             password: "ballerina"
-        }
+        },
+        sniHostName: "localhost2"
     }
 };
 

--- a/ballerina-tests/http-security-tests/tests/ssl_disable_ssl_test.bal
+++ b/ballerina-tests/http-security-tests/tests/ssl_disable_ssl_test.bal
@@ -61,19 +61,3 @@ public function testSslDisabledClient1() returns error? {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
 }
-
-http:ClientConfiguration disableSslClientConf2 = {
-    secureSocket: {
-    }
-};
-
-@test:Config {}
-public function testSslDisabledClient2() {
-    http:Client|error httpClient = new ("https://localhost:9238", disableSslClientConf2);
-    string expectedErrMsg = "Need to configure cert with client SSL certificates file";
-    if (httpClient is error) {
-        test:assertEquals(httpClient.message(), expectedErrMsg);
-    } else {
-        test:assertFail(msg = "Expected mutual SSL error not found");
-    }
-}

--- a/ballerina-tests/http-security-tests/tests/ssl_sni_host_name_test.bal
+++ b/ballerina-tests/http-security-tests/tests/ssl_sni_host_name_test.bal
@@ -106,3 +106,25 @@ public function testSniFailure() returns error? {
         test:assertFail("Test `testSniFailure` is expecting an error. But received a success response");
     }
 }
+
+@test:Config {}
+public function testSniWhenUsingDefaultCerts() returns error? {
+    http:Client httpClient = check new("https://www.google.com", http2SniClientConf3);
+    string|error resp = httpClient->get("/");
+    // This response is success because even though we send a wrong server name, google.com sends the default cert which
+    // is valid and trusted by the client.
+    if resp is error {
+        test:assertFail("Found unexpected output: " +  resp.message());
+    }
+}
+
+@test:Config {}
+public function testSniFailureWhenUsingDefaultCerts() returns error? {
+    http:Client clientEP = check new ("https://127.0.0.1:9208", http2SniClientConf3);
+    string|error resp = clientEP->get("/http1SniService/");
+    if resp is error {
+        common:assertTrueTextPayload(resp.message(), "SSL connection failed:javax.net.ssl.SSLHandshakeException:");
+    } else {
+        test:assertFail("Test `testSniFailureWhenUsingDefaultCerts` is expecting an error. But received a success response");
+    }
+}

--- a/ballerina-tests/http-security-tests/tests/ssl_sni_host_name_test.bal
+++ b/ballerina-tests/http-security-tests/tests/ssl_sni_host_name_test.bal
@@ -1,0 +1,80 @@
+// Copyright (c) 2024 WSO2 Inc. (http://www.wso2.org).
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/test;
+import ballerina/http_test_common as common;
+
+listener http:Listener http2SniListener = new (9207, http2SslServiceConf);
+
+http:ListenerConfiguration http1SniServiceConf = {
+    httpVersion: http:HTTP_1_1,
+    secureSocket: {
+        key: {
+            path: common:KEYSTORE_PATH,
+            password: "ballerina"
+        }
+    }
+};
+
+listener http:Listener http1SniListener = new (9208, http1SniServiceConf);
+
+service /http2SniService on http2SniListener {
+    resource function get .() returns string {
+        return "Sni works with HTTP_2!";
+    }
+}
+
+service /http1SniService on http1SniListener {
+    resource function get .() returns string {
+        return "Sni works with HTTP_1.1!";
+    }
+}
+
+http:ClientConfiguration http2SniClientConf = {
+    secureSocket: {
+        cert: {
+            path: common:TRUSTSTORE_PATH,
+            password: "ballerina"
+        },
+        serverName: "localhost"
+    }
+};
+
+http:ClientConfiguration http1SniClientConf = {
+    httpVersion: http:HTTP_1_1,
+    secureSocket: {
+        cert: {
+            path: common:TRUSTSTORE_PATH,
+            password: "ballerina"
+        },
+        serverName: "localhost"
+    }
+};
+
+@test:Config {enable: true}
+public function testHttp2Sni() returns error? {
+    http:Client clientEP = check new ("https://127.0.0.1:9207", http2SniClientConf);
+    string resp = check clientEP->get("/http2SniService/");
+    common:assertTextPayload(resp, "Sni works with HTTP_2!");
+}
+
+@test:Config {enable: true}
+public function testHttp1Sni() returns error? {
+    http:Client clientEP = check new ("https://127.0.0.1:9208", http1SniClientConf);
+    string resp = check clientEP->get("/http1SniService/");
+    common:assertTextPayload(resp, "Sni works with HTTP_1.1!");
+}

--- a/ballerina-tests/http-security-tests/tests/ssl_sni_host_name_test.bal
+++ b/ballerina-tests/http-security-tests/tests/ssl_sni_host_name_test.bal
@@ -65,16 +65,44 @@ http:ClientConfiguration http1SniClientConf = {
     }
 };
 
+http:ClientConfiguration http1SniClientConf2 = {
+    httpVersion: http:HTTP_1_1,
+    secureSocket: {
+        cert: {
+            path: common:TRUSTSTORE_PATH,
+            password: "ballerina"
+        },
+        serverName: "xxxx"
+    }
+};
+
+http:ClientConfiguration http2SniClientConf3 = {
+    secureSocket: {
+        serverName: "localhost"
+    }
+};
+
 @test:Config {}
-public function testHttp2Sni() returns error? {
+public function testHttp2WithSni() returns error? {
     http:Client clientEP = check new ("https://127.0.0.1:9207", http2SniClientConf);
     string resp = check clientEP->get("/http2SniService/");
     common:assertTextPayload(resp, "Sni works with HTTP_2!");
 }
 
 @test:Config {}
-public function testHttp1Sni() returns error? {
+public function testHttp1WithSni() returns error? {
     http:Client clientEP = check new ("https://127.0.0.1:9208", http1SniClientConf);
     string resp = check clientEP->get("/http1SniService/");
     common:assertTextPayload(resp, "Sni works with HTTP_1.1!");
+}
+
+@test:Config {}
+public function testSniFailure() returns error? {
+    http:Client clientEP = check new ("https://127.0.0.1:9208", http1SniClientConf2);
+    string|error resp = clientEP->get("/http1SniService/");
+    if resp is error {
+        test:assertEquals(resp.message(), "SSL connection failed:No subject alternative names present /127.0.0.1:9208");
+    } else {
+        test:assertFail("Test `testSniFailure` is expecting an error. But received a success response");
+    }
 }

--- a/ballerina-tests/http-security-tests/tests/ssl_sni_host_name_test.bal
+++ b/ballerina-tests/http-security-tests/tests/ssl_sni_host_name_test.bal
@@ -65,14 +65,14 @@ http:ClientConfiguration http1SniClientConf = {
     }
 };
 
-@test:Config {enable: true}
+@test:Config {}
 public function testHttp2Sni() returns error? {
     http:Client clientEP = check new ("https://127.0.0.1:9207", http2SniClientConf);
     string resp = check clientEP->get("/http2SniService/");
     common:assertTextPayload(resp, "Sni works with HTTP_2!");
 }
 
-@test:Config {enable: true}
+@test:Config {}
 public function testHttp1Sni() returns error? {
     http:Client clientEP = check new ("https://127.0.0.1:9208", http1SniClientConf);
     string resp = check clientEP->get("/http1SniService/");

--- a/ballerina-tests/http-security-tests/tests/ssl_sni_host_name_test.bal
+++ b/ballerina-tests/http-security-tests/tests/ssl_sni_host_name_test.bal
@@ -18,7 +18,7 @@ import ballerina/http;
 import ballerina/test;
 import ballerina/http_test_common as common;
 
-listener http:Listener http2SniListener = new (9207, http2SslServiceConf);
+listener http:Listener http2SniListener = new (http2SniListenerPort, http2SslServiceConf);
 
 http:ListenerConfiguration http1SniServiceConf = {
     httpVersion: http:HTTP_1_1,
@@ -30,7 +30,7 @@ http:ListenerConfiguration http1SniServiceConf = {
     }
 };
 
-listener http:Listener http1SniListener = new (9208, http1SniServiceConf);
+listener http:Listener http1SniListener = new (http1SniListenerPort, http1SniServiceConf);
 
 service /http2SniService on http2SniListener {
     resource function get .() returns string {

--- a/ballerina-tests/http-security-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-security-tests/tests/test_service_ports.bal
@@ -19,3 +19,6 @@ const int stsPort = 9445;
 
 const int http2GeneralPort = 9100;
 const int http2SslGeneralPort = 9107;
+
+const int http2SniListenerPort = 9207;
+const int http1SniListenerPort = 9208;

--- a/ballerina-tests/http-test-common/Ballerina.toml
+++ b/ballerina-tests/http-test-common/Ballerina.toml
@@ -1,4 +1,4 @@
 [package]
 org = "ballerina"
 name = "http_test_common"
-version = "2.7.19"
+version = "2.7.9"

--- a/ballerina-tests/http-test-common/Ballerina.toml
+++ b/ballerina-tests/http-test-common/Ballerina.toml
@@ -1,4 +1,4 @@
 [package]
 org = "ballerina"
 name = "http_test_common"
-version = "2.7.8"
+version = "2.7.19"

--- a/ballerina-tests/http-test-common/Dependencies.toml
+++ b/ballerina-tests/http-test-common/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.5.0"
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.7.19"
+version = "2.7.9"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "mime"},

--- a/ballerina-tests/http-test-common/Dependencies.toml
+++ b/ballerina-tests/http-test-common/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.5.0"
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.7.8"
+version = "2.7.19"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "mime"},

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.7.8"
+version = "2.7.9"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -12,8 +12,8 @@ distribution = "2201.5.0"
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.7.8"
-path = "../native/build/libs/http-native-2.7.8.jar"
+version = "2.7.9"
+path = "../native/build/libs/http-native-2.7.9-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.7.20"
+version = "2.7.9"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -12,8 +12,8 @@ distribution = "2201.5.0"
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.7.20"
-path = "../native/build/libs/http-native-2.7.20.jar"
+version = "2.7.9"
+path = "../native/build/libs/http-native-2.7.9-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.7.9"
+version = "2.7.19"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -12,8 +12,8 @@ distribution = "2201.5.0"
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.7.9"
-path = "../native/build/libs/http-native-2.7.9-SNAPSHOT.jar"
+version = "2.7.19"
+path = "../native/build/libs/http-native-2.7.19.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.7.9"
+version = "2.7.20"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -12,8 +12,8 @@ distribution = "2201.5.0"
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.7.9"
-path = "../native/build/libs/http-native-2.7.9-SNAPSHOT.jar"
+version = "2.7.20"
+path = "../native/build/libs/http-native-2.7.20.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.7.19"
+version = "2.7.9"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -12,8 +12,8 @@ distribution = "2201.5.0"
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.7.19"
-path = "../native/build/libs/http-native-2.7.19.jar"
+version = "2.7.9"
+path = "../native/build/libs/http-native-2.7.9-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.7.8.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.7.9-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.7.20.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.7.9-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.7.19.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.7.9-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.7.9-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.7.19.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.7.9-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.7.20.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -77,7 +77,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.7.9"
+version = "2.7.19"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -77,7 +77,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.7.20"
+version = "2.7.9"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -51,7 +51,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.3.0"
+version = "2.3.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -63,13 +63,11 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "os"},
-	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "time"}
 ]
 modules = [
@@ -79,7 +77,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.7.8"
+version = "2.7.9"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -110,7 +108,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -240,7 +238,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -254,7 +252,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -304,7 +302,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.4.0"
+version = "1.4.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.string"}
@@ -316,7 +314,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -325,7 +323,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -336,7 +334,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -77,7 +77,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.7.9"
+version = "2.7.20"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -77,7 +77,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.7.19"
+version = "2.7.9"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/ballerina/http_client_config.bal
+++ b/ballerina/http_client_config.bal
@@ -94,6 +94,7 @@ public type RetryConfig record {|
 # + shareSession - Enable/disable new SSL session creation
 # + handshakeTimeout - SSL handshake time out
 # + sessionTimeout - SSL session time out
+# + sniHostName - Server name indication(SNI) to be used. If this is not present, hostname from the target URL will be used
 public type ClientSecureSocket record {|
     boolean enable = true;
     crypto:TrustStore|string cert?;
@@ -112,6 +113,7 @@ public type ClientSecureSocket record {|
     boolean shareSession = true;
     decimal handshakeTimeout?;
     decimal sessionTimeout?;
+    string sniHostName?;
 |};
 
 # Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.

--- a/ballerina/http_client_config.bal
+++ b/ballerina/http_client_config.bal
@@ -94,7 +94,7 @@ public type RetryConfig record {|
 # + shareSession - Enable/disable new SSL session creation
 # + handshakeTimeout - SSL handshake time out
 # + sessionTimeout - SSL session time out
-# + sniHostName - Server name indication(SNI) to be used. If this is not present, hostname from the target URL will be used
+# + serverName - Server name indication(SNI) to be used. If this is not present, hostname from the target URL will be used
 public type ClientSecureSocket record {|
     boolean enable = true;
     crypto:TrustStore|string cert?;
@@ -113,7 +113,7 @@ public type ClientSecureSocket record {|
     boolean shareSession = true;
     decimal handshakeTimeout?;
     decimal sessionTimeout?;
-    string sniHostName?;
+    string serverName?;
 |};
 
 # Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 # Change Log
 This file contains all the notable changes done to the Ballerina HTTP package through the releases.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.7.8] - 2024-10-16
@@ -257,7 +257,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Fix missing error of invalid inbound request parameter for forward() method](https://github.com/ballerina-platform/ballerina-standard-library/issues/311)
 - [Fix HTTP Circuit Breaker failure when status codes are not provided in the configuration](https://github.com/ballerina-platform/ballerina-standard-library/issues/339)
 - [Fix HTTP FailOver client failure when status codes are overridden by an empty array](https://github.com/ballerina-platform/ballerina-standard-library/issues/1598)
-- [Fix already built incompatible payload thrown error](https://github.com/ballerina-platform/ballerina-standard-library/issues/1600) 
+- [Fix already built incompatible payload thrown error](https://github.com/ballerina-platform/ballerina-standard-library/issues/1600)
 - [Optional Types Not Supported in HTTP Client Request Operation Target Type](https://github.com/ballerina-platform/ballerina-standard-library/issues/1433)
 
 ### Changed

--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,11 @@
 # Change Log
 This file contains all the notable changes done to the Ballerina HTTP package through the releases.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project  adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+- [Add support for configuring server name to be used in the SSL SNI extension](https://github.com/ballerina-platform/ballerina-library/issues/7435)
 
 ## [2.7.8] - 2024-10-16
 
@@ -257,7 +260,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Fix missing error of invalid inbound request parameter for forward() method](https://github.com/ballerina-platform/ballerina-standard-library/issues/311)
 - [Fix HTTP Circuit Breaker failure when status codes are not provided in the configuration](https://github.com/ballerina-platform/ballerina-standard-library/issues/339)
 - [Fix HTTP FailOver client failure when status codes are overridden by an empty array](https://github.com/ballerina-platform/ballerina-standard-library/issues/1598)
-- [Fix already built incompatible payload thrown error](https://github.com/ballerina-platform/ballerina-standard-library/issues/1600)
+- [Fix already built incompatible payload thrown error](https://github.com/ballerina-platform/ballerina-standard-library/issues/1600) 
 - [Optional Types Not Supported in HTTP Client Request Operation Target Type](https://github.com/ballerina-platform/ballerina-standard-library/issues/1433)
 
 ### Changed

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
 - [Add support for configuring server name to be used in the SSL SNI extension](https://github.com/ballerina-platform/ballerina-library/issues/7435)
+
+### Fixed
+- [Fix the issue of not being able to configure only server name in the secureSocket config](https://github.com/ballerina-platform/ballerina-library/issues/7443)
 
 ## [2.7.8] - 2024-10-16
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -451,6 +451,7 @@ public class HttpConstants {
     public static final BString SECURESOCKET_CONFIG_VERIFY_CLIENT = StringUtils.fromString("verifyClient");
     public static final BString SECURESOCKET_CONFIG_CERT_VALIDATION_TYPE_OCSP_STAPLING =
             StringUtils.fromString("OCSP_STAPLING");
+    public static final BString SECURESOCKET_CONFIG_SNI_HOST_NAME = StringUtils.fromString("serverName");
 
     //Socket Config
     public static final BString SOCKET_CONFIG = StringUtils.fromString("socketConfig");

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -1840,6 +1840,12 @@ public class HttpUtil {
         Parameter enableSessionCreationParam = new Parameter(HttpConstants.SECURESOCKET_CONFIG_SHARE_SESSION.getValue(),
                                                              enableSessionCreation);
         paramList.add(enableSessionCreationParam);
+        String sniHostName = "null".equals(String.valueOf(secureSocket.getStringValue(
+                HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME))) ? null
+                : String.valueOf(secureSocket.getStringValue(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME));
+        Parameter sniHostNameParam = new Parameter(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME.getValue(),
+                sniHostName);
+        paramList.add(sniHostNameParam);
     }
 
     private static BMap<BString, Object> getBMapValueIfPresent(BMap<BString, Object> map, BString key) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -1840,12 +1840,11 @@ public class HttpUtil {
         Parameter enableSessionCreationParam = new Parameter(HttpConstants.SECURESOCKET_CONFIG_SHARE_SESSION.getValue(),
                                                              enableSessionCreation);
         paramList.add(enableSessionCreationParam);
-        String sniHostName = "null".equals(String.valueOf(secureSocket.getStringValue(
-                HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME))) ? null
-                : String.valueOf(secureSocket.getStringValue(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME));
-        Parameter sniHostNameParam = new Parameter(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME.getValue(),
-                sniHostName);
-        paramList.add(sniHostNameParam);
+        if (secureSocket.containsKey(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME)) {
+            Parameter sniHostNameParam = new Parameter(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME.getValue(),
+                    String.valueOf(secureSocket.getStringValue(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME)));
+            paramList.add(sniHostNameParam);
+        }
     }
 
     private static BMap<BString, Object> getBMapValueIfPresent(BMap<BString, Object> map, BString key) {

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -1384,13 +1384,15 @@ public class HttpUtil {
         }
         Object cert = secureSocket.get(HttpConstants.SECURESOCKET_CONFIG_CERT);
         if (cert == null) {
+            senderConfiguration.useJavaDefaults();
             BMap<BString, Object> key = getBMapValueIfPresent(secureSocket, HttpConstants.SECURESOCKET_CONFIG_KEY);
             if (key != null) {
                 senderConfiguration.useJavaDefaults();
-            } else {
-                throw createHttpError("Need to configure cert with client SSL certificates file",
-                        HttpErrorType.SSL_ERROR);
             }
+//            else {
+//                throw createHttpError("Need to configure cert with client SSL certificates file",
+//                        HttpErrorType.SSL_ERROR);
+//            }
         } else {
             evaluateCertField(cert, senderConfiguration);
         }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -1385,14 +1385,6 @@ public class HttpUtil {
         Object cert = secureSocket.get(HttpConstants.SECURESOCKET_CONFIG_CERT);
         if (cert == null) {
             senderConfiguration.useJavaDefaults();
-            BMap<BString, Object> key = getBMapValueIfPresent(secureSocket, HttpConstants.SECURESOCKET_CONFIG_KEY);
-            if (key != null) {
-                senderConfiguration.useJavaDefaults();
-            }
-//            else {
-//                throw createHttpError("Need to configure cert with client SSL certificates file",
-//                        HttpErrorType.SSL_ERROR);
-//            }
         } else {
             evaluateCertField(cert, senderConfiguration);
         }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contract/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contract/Constants.java
@@ -43,7 +43,7 @@ public final class Constants {
     public static final String CLIENT_SUPPORT_CIPHERS = "ciphers";
     public static final String CLIENT_SUPPORT_SSL_PROTOCOLS = "sslEnabledProtocols";
     public static final String CLIENT_ENABLE_SESSION_CREATION = "shareSession";
-    public static final String SNI_SERVER_NAME = "sniHostName";
+    public static final String SNI_SERVER_NAME = "serverName";
     public static final String MUTUAL_SSL_PASSED = "passed";
     public static final String MUTUAL_SSL_FAILED = "failed";
     public static final String MUTUAL_SSL_DISABLED = "disabled";

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contract/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contract/Constants.java
@@ -43,6 +43,7 @@ public final class Constants {
     public static final String CLIENT_SUPPORT_CIPHERS = "ciphers";
     public static final String CLIENT_SUPPORT_SSL_PROTOCOLS = "sslEnabledProtocols";
     public static final String CLIENT_ENABLE_SESSION_CREATION = "shareSession";
+    public static final String SNI_SERVER_NAME = "sniHostName";
     public static final String MUTUAL_SSL_PASSED = "passed";
     public static final String MUTUAL_SSL_FAILED = "failed";
     public static final String MUTUAL_SSL_DISABLED = "disabled";

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/SslConfiguration.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/SslConfiguration.java
@@ -245,27 +245,7 @@ public class SslConfiguration {
     }
 
     private SSLConfig getSSLConfigForSender() {
-        if (parameters != null) {
-            for (Parameter parameter : parameters) {
-                switch (parameter.getName()) {
-                    case CLIENT_SUPPORT_CIPHERS:
-                        sslConfig.setCipherSuites(parameter.getValue());
-                        break;
-                    case CLIENT_SUPPORT_SSL_PROTOCOLS:
-                        sslConfig.setEnableProtocols(parameter.getValue());
-                        break;
-                    case CLIENT_ENABLE_SESSION_CREATION:
-                        sslConfig.setEnableSessionCreation(Boolean.parseBoolean(parameter.getValue()));
-                        break;
-                    case SNI_SERVER_NAME:
-                        sslConfig.setSniHostName(parameter.getValue());
-                        break;
-                    default:
-                        //do nothing
-                        break;
-                }
-            }
-        }
+        setSslParameters();
         if (sslConfig.isDisableSsl() || sslConfig.useJavaDefaults()) {
             return sslConfig;
         }
@@ -287,5 +267,29 @@ public class SslConfiguration {
         String tlsStoreType = sslConfig.getTLSStoreType() != null ? sslConfig.getTLSStoreType() : JKS;
         sslConfig.setTLSStoreType(tlsStoreType);
         return sslConfig;
+    }
+
+    private void setSslParameters() {
+        if (parameters != null) {
+            for (Parameter parameter : parameters) {
+                switch (parameter.getName()) {
+                    case CLIENT_SUPPORT_CIPHERS:
+                        sslConfig.setCipherSuites(parameter.getValue());
+                        break;
+                    case CLIENT_SUPPORT_SSL_PROTOCOLS:
+                        sslConfig.setEnableProtocols(parameter.getValue());
+                        break;
+                    case CLIENT_ENABLE_SESSION_CREATION:
+                        sslConfig.setEnableSessionCreation(Boolean.parseBoolean(parameter.getValue()));
+                        break;
+                    case SNI_SERVER_NAME:
+                        sslConfig.setSniHostName(parameter.getValue());
+                        break;
+                    default:
+                        //do nothing
+                        break;
+                }
+            }
+        }
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/SslConfiguration.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/SslConfiguration.java
@@ -245,27 +245,6 @@ public class SslConfiguration {
     }
 
     private SSLConfig getSSLConfigForSender() {
-        if (sslConfig.isDisableSsl() || sslConfig.useJavaDefaults()) {
-            return sslConfig;
-        }
-        if ((sslConfig.getTrustStore() == null || sslConfig.getTrustStorePass() == null) && (
-                sslConfig.getClientTrustCertificates() == null)) {
-            throw new IllegalArgumentException("TrustStoreFile or TrustStorePassword not defined for HTTPS/WS scheme");
-        }
-        if (sslConfig.getTrustStore() != null) {
-            if (!sslConfig.getTrustStore().exists()) {
-                throw new IllegalArgumentException("TrustStore File " + sslConfig.getTrustStore() + " not found");
-            }
-            sslConfig.setCertPass(sslConfig.getKeyStorePass());
-        } else if (!sslConfig.getClientTrustCertificates().exists()) {
-            throw new IllegalArgumentException("Key file or server certificates file not found");
-        }
-        sslConfig.setTrustStore(sslConfig.getTrustStore()).setTrustStorePass(sslConfig.getTrustStorePass());
-        String sslProtocol = sslConfig.getSSLProtocol() != null ? sslConfig.getSSLProtocol() : TLS_PROTOCOL;
-        sslConfig.setSSLProtocol(sslProtocol);
-        String tlsStoreType = sslConfig.getTLSStoreType() != null ? sslConfig.getTLSStoreType() : JKS;
-        sslConfig.setTLSStoreType(tlsStoreType);
-
         if (parameters != null) {
             for (Parameter parameter : parameters) {
                 switch (parameter.getName()) {
@@ -287,6 +266,26 @@ public class SslConfiguration {
                 }
             }
         }
+        if (sslConfig.isDisableSsl() || sslConfig.useJavaDefaults()) {
+            return sslConfig;
+        }
+        if ((sslConfig.getTrustStore() == null || sslConfig.getTrustStorePass() == null) && (
+                sslConfig.getClientTrustCertificates() == null)) {
+            throw new IllegalArgumentException("TrustStoreFile or TrustStorePassword not defined for HTTPS/WS scheme");
+        }
+        if (sslConfig.getTrustStore() != null) {
+            if (!sslConfig.getTrustStore().exists()) {
+                throw new IllegalArgumentException("TrustStore File " + sslConfig.getTrustStore() + " not found");
+            }
+            sslConfig.setCertPass(sslConfig.getKeyStorePass());
+        } else if (!sslConfig.getClientTrustCertificates().exists()) {
+            throw new IllegalArgumentException("Key file or server certificates file not found");
+        }
+        sslConfig.setTrustStore(sslConfig.getTrustStore()).setTrustStorePass(sslConfig.getTrustStorePass());
+        String sslProtocol = sslConfig.getSSLProtocol() != null ? sslConfig.getSSLProtocol() : TLS_PROTOCOL;
+        sslConfig.setSSLProtocol(sslProtocol);
+        String tlsStoreType = sslConfig.getTLSStoreType() != null ? sslConfig.getTLSStoreType() : JKS;
+        sslConfig.setTLSStoreType(tlsStoreType);
         return sslConfig;
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/SslConfiguration.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/SslConfiguration.java
@@ -39,6 +39,7 @@ import static io.ballerina.stdlib.http.transport.contract.Constants.SERVER_SUPPO
 import static io.ballerina.stdlib.http.transport.contract.Constants.SERVER_SUPPORTED_SNIMATCHERS;
 import static io.ballerina.stdlib.http.transport.contract.Constants.SERVER_SUPPORT_CIPHERS;
 import static io.ballerina.stdlib.http.transport.contract.Constants.SERVER_SUPPORT_SSL_PROTOCOLS;
+import static io.ballerina.stdlib.http.transport.contract.Constants.SNI_SERVER_NAME;
 import static io.ballerina.stdlib.http.transport.contract.Constants.TLS_PROTOCOL;
 /**
  * SSL configuration for HTTP connection.
@@ -276,6 +277,9 @@ public class SslConfiguration {
                         break;
                     case CLIENT_ENABLE_SESSION_CREATION:
                         sslConfig.setEnableSessionCreation(Boolean.parseBoolean(parameter.getValue()));
+                        break;
+                    case SNI_SERVER_NAME:
+                        sslConfig.setSniHostName(parameter.getValue());
                         break;
                     default:
                         //do nothing

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/Util.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/Util.java
@@ -411,7 +411,7 @@ public class Util {
         SslHandler sslHandler = sslContext.newHandler(socketChannel.alloc(), host, port);
         SSLEngine sslEngine = sslHandler.engine();
         sslHandlerFactory.addCommonConfigs(sslEngine);
-        setSniServerName(sslConfig, host, sslHandlerFactory, sslEngine);
+        configureSniServerName(sslConfig, host, sslHandlerFactory, sslEngine);
         if (sslConfig.isHostNameVerificationEnabled()) {
             setHostNameVerfication(sslEngine);
         }
@@ -506,7 +506,7 @@ public class Util {
         if (sslConfig != null) {
             sslEngine = sslHandlerFactory.buildClientSSLEngine(host, port);
             sslEngine.setUseClientMode(true);
-            setSniServerName(sslConfig, host, sslHandlerFactory, sslEngine);
+            configureSniServerName(sslConfig, host, sslHandlerFactory, sslEngine);
             if (hostNameVerificationEnabled) {
                 sslHandlerFactory.setHostNameVerfication(sslEngine);
             }
@@ -514,12 +514,10 @@ public class Util {
         return sslEngine;
     }
 
-    private static void setSniServerName(SSLConfig sslConfig, String host, SSLHandlerFactory sslHandlerFactory, SSLEngine sslEngine) {
-        if (sslConfig.getSniHostName().isEmpty()) {
-            sslHandlerFactory.setSNIServerNames(sslEngine, host);
-        } else {
-            sslHandlerFactory.setSNIServerNames(sslEngine, sslConfig.getSniHostName());
-        }
+    private static void configureSniServerName(SSLConfig sslConfig, String host, SSLHandlerFactory sslHandlerFactory,
+                                               SSLEngine sslEngine) {
+        sslHandlerFactory.setSNIServerNames(sslEngine,
+                sslConfig.getSniHostName() != null ? sslConfig.getSniHostName() : host);
     }
 
     /**

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/Util.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/Util.java
@@ -514,7 +514,7 @@ public class Util {
         return sslEngine;
     }
 
-    private static void configureSniServerName(SSLConfig sslConfig, String host, SSLHandlerFactory sslHandlerFactory,
+    public static void configureSniServerName(SSLConfig sslConfig, String host, SSLHandlerFactory sslHandlerFactory,
                                                SSLEngine sslEngine) {
         sslHandlerFactory.setSNIServerNames(sslEngine,
                 sslConfig.getSniHostName() != null ? sslConfig.getSniHostName() : host);

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/Util.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/Util.java
@@ -411,7 +411,7 @@ public class Util {
         SslHandler sslHandler = sslContext.newHandler(socketChannel.alloc(), host, port);
         SSLEngine sslEngine = sslHandler.engine();
         sslHandlerFactory.addCommonConfigs(sslEngine);
-        sslHandlerFactory.setSNIServerNames(sslEngine, host);
+        setSniServerName(sslConfig, host, sslHandlerFactory, sslEngine);
         if (sslConfig.isHostNameVerificationEnabled()) {
             setHostNameVerfication(sslEngine);
         }
@@ -506,12 +506,20 @@ public class Util {
         if (sslConfig != null) {
             sslEngine = sslHandlerFactory.buildClientSSLEngine(host, port);
             sslEngine.setUseClientMode(true);
-            sslHandlerFactory.setSNIServerNames(sslEngine, host);
+            setSniServerName(sslConfig, host, sslHandlerFactory, sslEngine);
             if (hostNameVerificationEnabled) {
                 sslHandlerFactory.setHostNameVerfication(sslEngine);
             }
         }
         return sslEngine;
+    }
+
+    private static void setSniServerName(SSLConfig sslConfig, String host, SSLHandlerFactory sslHandlerFactory, SSLEngine sslEngine) {
+        if (sslConfig.getSniHostName().isEmpty()) {
+            sslHandlerFactory.setSNIServerNames(sslEngine, host);
+        } else {
+            sslHandlerFactory.setSNIServerNames(sslEngine, sslConfig.getSniHostName());
+        }
     }
 
     /**

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/ssl/SSLConfig.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/ssl/SSLConfig.java
@@ -64,6 +64,7 @@ public class SSLConfig {
     private long handshakeTimeOut;
     private boolean disableSsl = false;
     private boolean useJavaDefaults = false;
+    private String sniHostName;
 
     public SSLConfig() {}
 
@@ -177,6 +178,14 @@ public class SSLConfig {
             LOG.debug("Enable Session Creation {}", enableSessionCreation);
         }
         this.enableSessionCreation = enableSessionCreation;
+    }
+
+    public void setSniHostName(String sniHostName) {
+        this.sniHostName = sniHostName;
+    }
+
+    public String getSniHostName() {
+        return sniHostName;
     }
 
     public String[] getEnableProtocols() {

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/HttpClientChannelInitializer.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/HttpClientChannelInitializer.java
@@ -206,11 +206,8 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
             SslContext sslCtx = sslHandlerFactory.createHttp2TLSContextForClient(false);
             SslHandler sslHandler = sslCtx.newHandler(ch.alloc(), httpRoute.getHost(), httpRoute.getPort());
             SSLEngine sslEngine = sslHandler.engine();
-            if (sslConfig.getSniHostName().isEmpty()) {
-                sslHandlerFactory.setSNIServerNames(sslEngine, httpRoute.getHost());
-            } else {
-                sslHandlerFactory.setSNIServerNames(sslEngine, sslConfig.getSniHostName());
-            }
+            sslHandlerFactory.setSNIServerNames(sslEngine,
+                    sslConfig.getSniHostName() != null ? sslConfig.getSniHostName() : httpRoute.getHost());
             if (sslConfig.isHostNameVerificationEnabled()) {
                 setHostNameVerfication(sslEngine);
             }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/HttpClientChannelInitializer.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/HttpClientChannelInitializer.java
@@ -206,7 +206,11 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
             SslContext sslCtx = sslHandlerFactory.createHttp2TLSContextForClient(false);
             SslHandler sslHandler = sslCtx.newHandler(ch.alloc(), httpRoute.getHost(), httpRoute.getPort());
             SSLEngine sslEngine = sslHandler.engine();
-            sslHandlerFactory.setSNIServerNames(sslEngine, httpRoute.getHost());
+            if (sslConfig.getSniHostName().isEmpty()) {
+                sslHandlerFactory.setSNIServerNames(sslEngine, httpRoute.getHost());
+            } else {
+                sslHandlerFactory.setSNIServerNames(sslEngine, sslConfig.getSniHostName());
+            }
             if (sslConfig.isHostNameVerificationEnabled()) {
                 setHostNameVerfication(sslEngine);
             }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/HttpClientChannelInitializer.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/HttpClientChannelInitializer.java
@@ -206,8 +206,7 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
             SslContext sslCtx = sslHandlerFactory.createHttp2TLSContextForClient(false);
             SslHandler sslHandler = sslCtx.newHandler(ch.alloc(), httpRoute.getHost(), httpRoute.getPort());
             SSLEngine sslEngine = sslHandler.engine();
-            sslHandlerFactory.setSNIServerNames(sslEngine,
-                    sslConfig.getSniHostName() != null ? sslConfig.getSniHostName() : httpRoute.getHost());
+            Util.configureSniServerName(sslConfig, httpRoute.getHost(), sslHandlerFactory, sslEngine);
             if (sslConfig.isHostNameVerificationEnabled()) {
                 setHostNameVerfication(sslEngine);
             }


### PR DESCRIPTION
## Purpose
Add support for configuring the server name to be used in the SSL SNI extension.
Related issue: https://github.com/ballerina-platform/ballerina-library/issues/7435

Introduced a new field named `serverName` in the `secureSocket` config under `ClientConfiguration`. 

## Examples

```ballerina
http:ClientConfiguration clientConf = {
    secureSocket: {
        cert: {
            path: common:TRUSTSTORE_PATH,
            password: "ballerina"
        },
        serverName: "localhost"
    }
};
```

@shafreenAnfar @TharmiganK I used `serverName` as the field name as it is the name that has been used in the Go language as well. If you have any concerns with the name, please suggest.

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [x] Checked native-image compatibility
- [x] Checked the impact on OpenAPI generation
