### PR TITLE
Fix the issue of not being able to configure only server name in the secureSocket config

### DIFF
--- a/ballerina-tests/http-security-tests/tests/ssl_disable_ssl_test.bal
+++ b/ballerina-tests/http-security-tests/tests/ssl_disable_ssl_test.bal
@@ -61,19 +61,3 @@ public function testSslDisabledClient1() returns error? {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
 }
-
-http:ClientConfiguration disableSslClientConf2 = {
-    secureSocket: {
-    }
-};
-
-@test:Config {}
-public function testSslDisabledClient2() {
-    http:Client|error httpClient = new ("https://localhost:9238", disableSslClientConf2);
-    string expectedErrMsg = "Need to configure cert with client SSL certificates file";
-    if (httpClient is error) {
-        test:assertEquals(httpClient.message(), expectedErrMsg);
-    } else {
-        test:assertFail(msg = "Expected mutual SSL error not found");
-    }
-}

--- a/ballerina-tests/http-security-tests/tests/ssl_sni_host_name_test.bal
+++ b/ballerina-tests/http-security-tests/tests/ssl_sni_host_name_test.bal
@@ -100,3 +100,25 @@ public function testSniFailure() returns error? {
         test:assertFail("Test `testSniFailure` is expecting an error. But received a success response");
     }
 }
+
+@test:Config {}
+public function testSniWhenUsingDefaultCerts() returns error? {
+    http:Client httpClient = check new("https://www.google.com", http2SniClientConf3);
+    string|error resp = httpClient->get("/");
+    // This response is success because even though we send a wrong server name, google.com sends the default cert which
+    // is valid and trusted by the client.
+    if resp is error {
+        test:assertFail("Found unexpected output: " +  resp.message());
+    }
+}
+
+@test:Config {}
+public function testSniFailureWhenUsingDefaultCerts() returns error? {
+    http:Client clientEP = check new ("https://127.0.0.1:9208", http2SniClientConf3);
+    string|error resp = clientEP->get("/http1SniService/");
+    if resp is error {
+        common:assertTrueTextPayload(resp.message(), "SSL connection failed:javax.net.ssl.SSLHandshakeException:");
+    } else {
+        test:assertFail("Test `testSniFailureWhenUsingDefaultCerts` is expecting an error. But received a success response");
+    }
+}

--- a/ballerina-tests/http-security-tests/tests/ssl_sni_host_name_test.bal
+++ b/ballerina-tests/http-security-tests/tests/ssl_sni_host_name_test.bal
@@ -76,6 +76,12 @@ http:ClientConfiguration http1SniClientConf2 = {
     }
 };
 
+http:ClientConfiguration http2SniClientConf3 = {
+    secureSocket: {
+        serverName: "localhost"
+    }
+};
+
 @test:Config {}
 public function testHttp2WithSni() returns error? {
     http:Client clientEP = check new ("https://127.0.0.1:9207", http2SniClientConf);

--- a/ballerina-tests/http-security-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-security-tests/tests/test_service_ports.bal
@@ -19,3 +19,6 @@ const int stsPort = 9445;
 
 const int http2GeneralPort = 9100;
 const int http2SslGeneralPort = 9107;
+
+const int http2SniListenerPort = 9207;
+const int http1SniListenerPort = 9208;

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- [Add support for configuring server name to be used in the SSL SNI extension](https://github.com/ballerina-platform/ballerina-library/issues/7435)
 
 ### Added
 
@@ -18,12 +17,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Migrate client and service data binding lang utils usage into data.jsondata module utils `toJson` and `parserAsType`](https://github.com/ballerina-platform/ballerina-library/issues/6747)
 - [Add static code rules](https://github.com/ballerina-platform/ballerina-library/issues/7283)
 - [Add relax data binding support for service and client data binding](https://github.com/ballerina-platform/ballerina-library/issues/7366)
+- [Add support for configuring server name to be used in the SSL SNI extension](https://github.com/ballerina-platform/ballerina-library/issues/7435)
 
 ### Fixed
 
 - [Address CVE-2024-7254 vulnerability](https://github.com/ballerina-platform/ballerina-library/issues/7013)
 - [Fix duplicating `Content-Type` header via the `addHeader` method](https://github.com/ballerina-platform/ballerina-library/issues/7268)
 - [Update netty version](https://github.com/ballerina-platform/ballerina-library/issues/7358)
+- [Fix the issue of not being able to configure only server name in the secureSocket config](https://github.com/ballerina-platform/ballerina-library/issues/7443)
 
 ## [2.12.0] - 2024-08-20
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -1409,13 +1409,15 @@ public class HttpUtil {
         }
         Object cert = secureSocket.get(HttpConstants.SECURESOCKET_CONFIG_CERT);
         if (cert == null) {
+            senderConfiguration.useJavaDefaults();
             BMap<BString, Object> key = getBMapValueIfPresent(secureSocket, HttpConstants.SECURESOCKET_CONFIG_KEY);
             if (key != null) {
                 senderConfiguration.useJavaDefaults();
-            } else {
-                throw createHttpError("Need to configure cert with client SSL certificates file",
-                        HttpErrorType.SSL_ERROR);
             }
+//            else {
+//                throw createHttpError("Need to configure cert with client SSL certificates file",
+//                        HttpErrorType.SSL_ERROR);
+//            }
         } else {
             evaluateCertField(cert, senderConfiguration);
         }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -1410,14 +1410,6 @@ public class HttpUtil {
         Object cert = secureSocket.get(HttpConstants.SECURESOCKET_CONFIG_CERT);
         if (cert == null) {
             senderConfiguration.useJavaDefaults();
-            BMap<BString, Object> key = getBMapValueIfPresent(secureSocket, HttpConstants.SECURESOCKET_CONFIG_KEY);
-            if (key != null) {
-                senderConfiguration.useJavaDefaults();
-            }
-//            else {
-//                throw createHttpError("Need to configure cert with client SSL certificates file",
-//                        HttpErrorType.SSL_ERROR);
-//            }
         } else {
             evaluateCertField(cert, senderConfiguration);
         }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -1900,12 +1900,11 @@ public class HttpUtil {
         Parameter enableSessionCreationParam = new Parameter(HttpConstants.SECURESOCKET_CONFIG_SHARE_SESSION.getValue(),
                                                              enableSessionCreation);
         paramList.add(enableSessionCreationParam);
-        String sniHostName = "null".equals(String.valueOf(secureSocket.getStringValue(
-                HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME))) ? null
-                : String.valueOf(secureSocket.getStringValue(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME));
-        Parameter sniHostNameParam = new Parameter(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME.getValue(),
-                sniHostName);
-        paramList.add(sniHostNameParam);
+        if (secureSocket.containsKey(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME)) {
+            Parameter sniHostNameParam = new Parameter(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME.getValue(),
+                    String.valueOf(secureSocket.getStringValue(HttpConstants.SECURESOCKET_CONFIG_SNI_HOST_NAME)));
+            paramList.add(sniHostNameParam);
+        }
     }
 
     private static BMap<BString, Object> getBMapValueIfPresent(BMap<BString, Object> map, BString key) {

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/SslConfiguration.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/SslConfiguration.java
@@ -245,27 +245,7 @@ public class SslConfiguration {
     }
 
     private SSLConfig getSSLConfigForSender() {
-        if (parameters != null) {
-            for (Parameter parameter : parameters) {
-                switch (parameter.getName()) {
-                    case CLIENT_SUPPORT_CIPHERS:
-                        sslConfig.setCipherSuites(parameter.getValue());
-                        break;
-                    case CLIENT_SUPPORT_SSL_PROTOCOLS:
-                        sslConfig.setEnableProtocols(parameter.getValue());
-                        break;
-                    case CLIENT_ENABLE_SESSION_CREATION:
-                        sslConfig.setEnableSessionCreation(Boolean.parseBoolean(parameter.getValue()));
-                        break;
-                    case SNI_SERVER_NAME:
-                        sslConfig.setSniHostName(parameter.getValue());
-                        break;
-                    default:
-                        //do nothing
-                        break;
-                }
-            }
-        }
+        setSslParameters();
         if (sslConfig.isDisableSsl() || sslConfig.useJavaDefaults()) {
             return sslConfig;
         }
@@ -287,5 +267,29 @@ public class SslConfiguration {
         String tlsStoreType = sslConfig.getTLSStoreType() != null ? sslConfig.getTLSStoreType() : JKS;
         sslConfig.setTLSStoreType(tlsStoreType);
         return sslConfig;
+    }
+
+    private void setSslParameters() {
+        if (parameters != null) {
+            for (Parameter parameter : parameters) {
+                switch (parameter.getName()) {
+                    case CLIENT_SUPPORT_CIPHERS:
+                        sslConfig.setCipherSuites(parameter.getValue());
+                        break;
+                    case CLIENT_SUPPORT_SSL_PROTOCOLS:
+                        sslConfig.setEnableProtocols(parameter.getValue());
+                        break;
+                    case CLIENT_ENABLE_SESSION_CREATION:
+                        sslConfig.setEnableSessionCreation(Boolean.parseBoolean(parameter.getValue()));
+                        break;
+                    case SNI_SERVER_NAME:
+                        sslConfig.setSniHostName(parameter.getValue());
+                        break;
+                    default:
+                        //do nothing
+                        break;
+                }
+            }
+        }
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/SslConfiguration.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/SslConfiguration.java
@@ -245,27 +245,6 @@ public class SslConfiguration {
     }
 
     private SSLConfig getSSLConfigForSender() {
-        if (sslConfig.isDisableSsl() || sslConfig.useJavaDefaults()) {
-            return sslConfig;
-        }
-        if ((sslConfig.getTrustStore() == null || sslConfig.getTrustStorePass() == null) && (
-                sslConfig.getClientTrustCertificates() == null)) {
-            throw new IllegalArgumentException("TrustStoreFile or TrustStorePassword not defined for HTTPS/WS scheme");
-        }
-        if (sslConfig.getTrustStore() != null) {
-            if (!sslConfig.getTrustStore().exists()) {
-                throw new IllegalArgumentException("TrustStore File " + sslConfig.getTrustStore() + " not found");
-            }
-            sslConfig.setCertPass(sslConfig.getKeyStorePass());
-        } else if (!sslConfig.getClientTrustCertificates().exists()) {
-            throw new IllegalArgumentException("Key file or server certificates file not found");
-        }
-        sslConfig.setTrustStore(sslConfig.getTrustStore()).setTrustStorePass(sslConfig.getTrustStorePass());
-        String sslProtocol = sslConfig.getSSLProtocol() != null ? sslConfig.getSSLProtocol() : TLS_PROTOCOL;
-        sslConfig.setSSLProtocol(sslProtocol);
-        String tlsStoreType = sslConfig.getTLSStoreType() != null ? sslConfig.getTLSStoreType() : JKS;
-        sslConfig.setTLSStoreType(tlsStoreType);
-
         if (parameters != null) {
             for (Parameter parameter : parameters) {
                 switch (parameter.getName()) {
@@ -287,6 +266,26 @@ public class SslConfiguration {
                 }
             }
         }
+        if (sslConfig.isDisableSsl() || sslConfig.useJavaDefaults()) {
+            return sslConfig;
+        }
+        if ((sslConfig.getTrustStore() == null || sslConfig.getTrustStorePass() == null) && (
+                sslConfig.getClientTrustCertificates() == null)) {
+            throw new IllegalArgumentException("TrustStoreFile or TrustStorePassword not defined for HTTPS/WS scheme");
+        }
+        if (sslConfig.getTrustStore() != null) {
+            if (!sslConfig.getTrustStore().exists()) {
+                throw new IllegalArgumentException("TrustStore File " + sslConfig.getTrustStore() + " not found");
+            }
+            sslConfig.setCertPass(sslConfig.getKeyStorePass());
+        } else if (!sslConfig.getClientTrustCertificates().exists()) {
+            throw new IllegalArgumentException("Key file or server certificates file not found");
+        }
+        sslConfig.setTrustStore(sslConfig.getTrustStore()).setTrustStorePass(sslConfig.getTrustStorePass());
+        String sslProtocol = sslConfig.getSSLProtocol() != null ? sslConfig.getSSLProtocol() : TLS_PROTOCOL;
+        sslConfig.setSSLProtocol(sslProtocol);
+        String tlsStoreType = sslConfig.getTLSStoreType() != null ? sslConfig.getTLSStoreType() : JKS;
+        sslConfig.setTLSStoreType(tlsStoreType);
         return sslConfig;
     }
 }


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/ballerina-platform/ballerina-library/issues/7443
Fixes: https://github.com/ballerina-platform/ballerina-library/issues/6679

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [x] Checked native-image compatibility
- [x] Checked the impact on OpenAPI generation
