### PR TITLE
[2201.9.x] Fix rest path parameter generation with decoded value

### DIFF
--- a/ballerina-tests/http-dispatching-tests/tests/service_dispatching_uri_template_matching.bal
+++ b/ballerina-tests/http-dispatching-tests/tests/service_dispatching_uri_template_matching.bal
@@ -383,6 +383,11 @@ service /encodedUri on utmTestEP {
 }
 
 service /restParam on utmTestEP {
+
+    resource function 'default 'string/[string... aaa]() returns json {
+        return {aaa: aaa};
+    }
+
     resource function 'default 'int/[int... aaa](http:Caller caller) returns error? {
         http:Response res = new;
         json responseJson = {aaa: aaa};
@@ -1020,6 +1025,16 @@ function testEncodedPathParams() {
     if response is http:Response {
         common:assertJsonValue(response.getJsonPayload(), "xxx", "123");
         common:assertJsonValue(response.getJsonPayload(), "yyy", "456");
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}
+
+@test:Config {}
+function testRestParamWithEncodedPathSegments() {
+http:Response|error response = utmClient->get("/restParam/string/path%2Fseg/path%20seg/path%2Fseg+123");
+    if response is http:Response {
+        common:assertJsonValue(response.getJsonPayload(), "aaa", ["path/seg", "path seg", "path/seg+123"]);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - [Fix the issue of not being able to configure only server name in the secureSocket config](https://github.com/ballerina-platform/ballerina-library/issues/7443)
+- [Fix rest path parameter generation with decoded path segments](https://github.com/ballerina-platform/ballerina-library/issues/7430)
 
 ## [2.11.6] - 2024-11-26
 


### PR DESCRIPTION
## Purpose

> $Subject

Related to: https://github.com/ballerina-platform/ballerina-library/issues/7430

## Examples

N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
- [ ] Checked native-image compatibility
- [ ] ~Checked the impact on OpenAPI generation~
