### PR TITLE
[2201.7.x] Fix rest path parameter generation with decoded value

### DIFF
--- a/ballerina-tests/http-dispatching-tests/tests/service_dispatching_uri_template_matching.bal
+++ b/ballerina-tests/http-dispatching-tests/tests/service_dispatching_uri_template_matching.bal
@@ -383,6 +383,11 @@ service /encodedUri on utmTestEP {
 }
 
 service /restParam on utmTestEP {
+
+    resource function 'default 'string/[string... aaa]() returns json {
+        return {aaa: aaa};
+    }
+
     resource function 'default 'int/[int... aaa](http:Caller caller) returns error? {
         http:Response res = new;
         json responseJson = {aaa: aaa};
@@ -1020,6 +1025,16 @@ function testEncodedPathParams() {
     if response is http:Response {
         common:assertJsonValue(response.getJsonPayload(), "xxx", "123");
         common:assertJsonValue(response.getJsonPayload(), "yyy", "456");
+    } else {
+        test:assertFail(msg = "Found unexpected output type: " + response.message());
+    }
+}
+
+@test:Config {}
+function testRestParamWithEncodedPathSegments() {
+http:Response|error response = utmClient->get("/restParam/string/path%2Fseg/path%20seg/path%2Fseg+123");
+    if response is http:Response {
+        common:assertJsonValue(response.getJsonPayload(), "aaa", ["path/seg", "path seg", "path/seg+123"]);
     } else {
         test:assertFail(msg = "Found unexpected output type: " + response.message());
     }

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - [Fix the issue of not being able to configure only server name in the secureSocket config](https://github.com/ballerina-platform/ballerina-library/issues/7443)
+- [Fix rest path parameter generation with decoded path segments](https://github.com/ballerina-platform/ballerina-library/issues/7430)
 
 ## [2.9.10] - 2024-10-21
 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllPathParams.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/service/signature/AllPathParams.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static io.ballerina.stdlib.http.api.HttpConstants.EXTRA_PATH_INDEX;
 import static io.ballerina.stdlib.http.api.HttpConstants.PERCENTAGE;
@@ -79,17 +80,16 @@ public class AllPathParams implements Parameter {
             if (argumentValue.endsWith(PERCENTAGE)) {
                 argumentValue = argumentValue.replaceAll(PERCENTAGE, PERCENTAGE_ENCODED);
             }
-            argumentValue = URLDecoder.decode(argumentValue.replaceAll(PLUS_SIGN, PLUS_SIGN_ENCODED),
-                    StandardCharsets.UTF_8);
 
             Object castedPathValue;
             try {
                 Object parsedValue;
                 if (pathParam.isArray()) {
-                    String[] segments = argumentValue.substring(1).split(HttpConstants.SINGLE_SLASH);
+                    String[] segments = Stream.of(argumentValue.substring(1).split(HttpConstants.SINGLE_SLASH))
+                            .map(AllPathParams::decodePathSegment).toArray(String[]::new);
                     parsedValue = castParamArray(paramTypeTag, segments);
                 } else {
-                    parsedValue = castParam(paramTypeTag, argumentValue);
+                    parsedValue = castParam(paramTypeTag, decodePathSegment(argumentValue));
                 }
                 castedPathValue = ValueUtils.convert(parsedValue, paramType);
             } catch (Exception ex) {
@@ -106,6 +106,10 @@ public class AllPathParams implements Parameter {
             paramFeed[index++] = pathParam.validateConstraints(castedPathValue);
             paramFeed[index] = true;
         }
+    }
+
+    private static String decodePathSegment(String pathSegment) {
+        return URLDecoder.decode(pathSegment.replaceAll(PLUS_SIGN, PLUS_SIGN_ENCODED), StandardCharsets.UTF_8);
     }
 
     private static void updateWildcardToken(String wildcardToken, int wildCardIndex,


### PR DESCRIPTION
## Purpose

> $Subject

Related to: https://github.com/ballerina-platform/ballerina-library/issues/7430

## Examples

N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
- [ ] Checked native-image compatibility
- [ ] ~Checked the impact on OpenAPI generation~
