### PR TITLE
Add HTTP default listener

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -14,6 +14,11 @@ name = "http.httpscerr"
 description = "This module provides status code error types."
 export = true
 
+[[package.modules]]
+name = "http.default"
+description = "This module provides the default HTTP listener."
+export = true
+
 [platform.java21]
 graalvmCompatible = true
 

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -115,6 +115,7 @@ dependencies = [
 ]
 modules = [
 	{org = "ballerina", packageName = "http", moduleName = "http"},
+	{org = "ballerina", packageName = "http", moduleName = "http.default"},
 	{org = "ballerina", packageName = "http", moduleName = "http.httpscerr"}
 ]
 

--- a/ballerina/modules/default/README.md
+++ b/ballerina/modules/default/README.md
@@ -1,0 +1,38 @@
+## Overview
+
+This module provides a default HTTP listener implementation. The default HTTP listener is a built-in listener that
+can be used to attach multiple services. Additionally, the default listener configuration can be customized.
+
+### Usage
+
+Following is an example of using the default HTTP listener to start an HTTP server.
+
+```ballerina
+import ballerina/http.default;
+
+service /api on default:httpListener {
+
+    resource function get greeting() returns string {
+        return "Hello, World!";
+    }
+}
+```
+
+The default listener port is defaulted to 9090. The port can be changed in the `Config.toml` file.
+
+```toml
+[ballerina.http.default]
+listenerPort = 8080
+```
+
+Additionally, you can configure all the listener configurations. Example configuration for changing
+the HTTP version to 1.1 and enable SSL.
+
+```toml
+[ballerina.http.default.listenerConfig]
+httpVersion = "1.1"
+
+[ballerina.http.default.listenerConfig.secureSocket.key]
+path = "resources/certs/key.pem"
+password = "password"
+```

--- a/ballerina/modules/default/README.md
+++ b/ballerina/modules/default/README.md
@@ -1,11 +1,10 @@
 ## Overview
 
-This module provides a default HTTP listener implementation. The default HTTP listener is a built-in listener that
-can be used to attach multiple services. Additionally, the default listener configuration can be customized.
+This module provides a built-in HTTP listener that serves as the default listener for attaching HTTP servers. It supports the attachment of multiple services, making it ideal for centralized deployment. Additionally, it allows for the customization of its port and configuration, offering versatility for various use cases.
 
-### Usage
+## Usage Example
 
-Following is an example of using the default HTTP listener to start an HTTP server.
+The following example demonstrates how to use the default HTTP listener to create an HTTP server:
 
 ```ballerina
 import ballerina/http.default;
@@ -18,15 +17,20 @@ service /api on default:httpListener {
 }
 ```
 
-The default listener port is defaulted to 9090. The port can be changed in the `Config.toml` file.
+## Customizing the Listener Port
+
+By default, the listener uses port 9090. To change this, specify the desired port in the `Config.toml` file as shown below:
 
 ```toml
 [ballerina.http.default]
 listenerPort = 8080
 ```
 
-Additionally, you can configure all the listener configurations. Example configuration for changing
-the HTTP version to 1.1 and enable SSL.
+## Configuring the Listener
+
+You can customize all [HTTP listener configuration](https://central.ballerina.io/ballerina/http/latest#ListenerConfiguration) in the `Config.toml` file. For detailed instructions on configuring variables, refer to the [Configurability](https://ballerina.io/learn/provide-values-to-configurable-variables/) guide.
+
+The following example configures the HTTP listener to use HTTP/1.1 and enables SSL:
 
 ```toml
 [ballerina.http.default.listenerConfig]

--- a/ballerina/modules/default/listener.bal
+++ b/ballerina/modules/default/listener.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 WSO2 Inc. (http://www.wso2.org).
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+# Represents the port that the default HTTP listener should be bound to.
+# The default port is 9090
+public configurable int listenerPort = 9090;
+
+# Represents the listener configuration that should be used by the default HTTP listener
+public configurable http:ListenerConfiguration listenerConfig = {};
+
+# Represents the default HTTP listener that can be used by multiple services
+public listener http:Listener httpListener = check new (listenerPort, listenerConfig);

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -14,6 +14,11 @@ name = "http.httpscerr"
 description = "This module provides status code error types."
 export = true
 
+[[package.modules]]
+name = "http.default"
+description = "This module provides the default HTTP listener."
+export = true
+
 [platform.java21]
 graalvmCompatible = true
 

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Add static code rules](https://github.com/ballerina-platform/ballerina-library/issues/7283)
 - [Add relax data binding support for service and client data binding](https://github.com/ballerina-platform/ballerina-library/issues/7366)
 - [Add support for configuring server name to be used in the SSL SNI extension](https://github.com/ballerina-platform/ballerina-library/issues/7435)
+- [Add default HTTP listener](https://github.com/ballerina-platform/ballerina-library/issues/7514)
 
 ### Fixed
 


### PR DESCRIPTION
## Purpose

> $Subject

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/7514

Mock central page: https://central.ballerina.io/tharmigank/http.default/0.5.0

## Examples

```ballerina
import ballerina/http.default;

service /api on default:httpListener {

    resource function get greeting() returns string {
        return "Hello, World!";
    }
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] ~Added tests~
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
- [ ] ~Checked the impact on OpenAPI generation~
