### PR TITLE
[2201.9.x] Add TLSv1.3 supported ciphers in the default supported ciphers

### DIFF
--- a/ballerina-tests/http-security-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-security-tests/tests/test_service_ports.bal
@@ -22,3 +22,6 @@ const int http2SslGeneralPort = 9107;
 
 const int http2SniListenerPort = 9207;
 const int http1SniListenerPort = 9208;
+
+const int tls12Port = 9249;
+const int tls13Port = 9250;

--- a/ballerina-tests/http2-tests/tests/http2_ssl_protocol_test.bal
+++ b/ballerina-tests/http2-tests/tests/http2_ssl_protocol_test.bal
@@ -1,6 +1,6 @@
-// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org).
 //
-// WSO2 Inc. licenses this file to you under the Apache License,
+// WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.
 // You may obtain a copy of the License at
@@ -20,7 +20,6 @@ import ballerina/test;
 import ballerina/http_test_common as common;
 
 http:ListenerConfiguration sslProtocol12ServiceConfig = {
-    httpVersion: http:HTTP_1_1,
     secureSocket: {
         key: {
             path: common:KEYSTORE_PATH,
@@ -43,7 +42,6 @@ service /protocol on sslProtocol12Listener {
 }
 
 http:ListenerConfiguration sslProtocol13ServiceConfig = {
-    httpVersion: http:HTTP_1_1,
     secureSocket: {
         key: {
             path: common:KEYSTORE_PATH,
@@ -79,7 +77,7 @@ public function testTLS12() returns error? {
         name: http:TLS,
         versions: ["TLSv1.2"]
     };
-    http:Client clientEP = check new (string `https://localhost:${tls12Port}`, secureSocket = sslConfig, httpVersion = http:HTTP_1_1);
+    http:Client clientEP = check new (string `https://localhost:${tls12Port}`, secureSocket = sslConfig);
     string resp = check clientEP->/protocol/protocolResource;
     test:assertEquals(resp, "Hello, World!");
 }
@@ -91,7 +89,7 @@ public function testTLS13() returns error? {
         name: http:TLS,
         versions: ["TLSv1.3"]
     };
-    http:Client clientEP = check new (string `https://localhost:${tls13Port}`, secureSocket = sslConfig, httpVersion = http:HTTP_1_1);
+    http:Client clientEP = check new (string `https://localhost:${tls13Port}`, secureSocket = sslConfig);
     string resp = check clientEP->/protocol/protocolResource;
     test:assertEquals(resp, "Hello, World!");
 }
@@ -103,12 +101,12 @@ public function testSslProtocol() returns error? {
         name: http:TLS,
         versions: ["TLSv1.2", "TLSv1.3"]
     };
-    http:Client clientEP = check new (string `https://localhost:${tls13Port}`, secureSocket = sslConfig, httpVersion = http:HTTP_1_1);
+    http:Client clientEP = check new (string `https://localhost:${tls13Port}`, secureSocket = sslConfig);
     string resp = check clientEP->/protocol/protocolResource;
     test:assertEquals(resp, "Hello, World!");
 
     sslConfig.protocol.versions = ["TLSv1.3", "TLSv1.2"];
-    clientEP = check new (string `https://localhost:${tls12Port}`, secureSocket = sslConfig, httpVersion = http:HTTP_1_1);
+    clientEP = check new (string `https://localhost:${tls12Port}`, secureSocket = sslConfig);
     resp = check clientEP->/protocol/protocolResource;
     test:assertEquals(resp, "Hello, World!");
 }
@@ -120,7 +118,7 @@ public function testSslProtocolConflict() returns error? {
         name: http:TLS,
         versions: ["TLSv1.2"]
     };
-    http:Client clientEP = check new (string `https://localhost:${tls13Port}`, secureSocket = sslConfig, httpVersion = http:HTTP_1_1);
+    http:Client clientEP = check new (string `https://localhost:${tls13Port}`, secureSocket = sslConfig);
     http:Response|error resp = clientEP->/protocol/protocolResource;
     if resp is http:Response {
         test:assertFail(msg = "Found unexpected output: Expected an error");
@@ -129,7 +127,7 @@ public function testSslProtocolConflict() returns error? {
     }
 
     sslConfig.protocol.versions = ["TLSv1.3"];
-    clientEP = check new (string `https://localhost:${tls12Port}`, secureSocket = sslConfig, httpVersion = http:HTTP_1_1);
+    clientEP = check new (string `https://localhost:${tls12Port}`, secureSocket = sslConfig);
     resp = clientEP->/protocol/protocolResource;
     if resp is http:Response {
         test:assertFail(msg = "Found unexpected output: Expected an error");

--- a/ballerina-tests/http2-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http2-tests/tests/test_service_ports.bal
@@ -63,3 +63,6 @@ const int reuseRequestTestPort = 9528;
 const int connectionNativeTestPort = 9014;
 const int http2ClientContinueTestPort = 9630;
 const int headerParamBindingTestPort = 9631;
+
+const int tls12Port = 9249;
+const int tls13Port = 9250;

--- a/ballerina/http_service_endpoint.bal
+++ b/ballerina/http_service_endpoint.bal
@@ -240,7 +240,8 @@ public type ListenerSecureSocket record {|
                         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
                         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
                         "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-                        "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"];
+                        "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384",
+                        "TLS_CHACHA20_POLY1305_SHA256", "TLS_AES_128_GCM_SHA256"];
     boolean shareSession = true;
     decimal handshakeTimeout?;
     decimal sessionTimeout?;

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,14 @@
-
 # Change Log
 This file contains all the notable changes done to the Ballerina HTTP package through the releases.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- [Add TLSv1.3 supported cipher suites to the default configuration](https://github.com/ballerina-platform/ballerina-library/issues/7658)
 
 ## [2.11.8] - 2025-02-19
 


### PR DESCRIPTION
## Purpose

> $Subject

Part of: https://github.com/ballerina-platform/ballerina-library/issues/7658

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
- [ ] Checked native-image compatibility
- [ ] ~Checked the impact on OpenAPI generation~
