### PR TITLE
Introduce an API to convert response to status response record

### DIFF
--- a/ballerina-tests/http-misc-tests/http_response_status_record_test.bal
+++ b/ballerina-tests/http-misc-tests/http_response_status_record_test.bal
@@ -1,0 +1,87 @@
+// Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/test;
+
+@test:Config
+function testGetStatusRecWithSuccessRes() returns error? {
+    http:Response res = new;
+    res.statusCode = 200;
+    res.setTextPayload("Hello, World!");
+    res.setHeader("Server", "Ballerina");
+    res.setHeader("Header-1", "Value-1");
+    res.setHeader("Header-2", "Value-2");
+
+    http:StatusCodeRecord statusRec = check res.getStatusCodeRecord();
+    test:assertEquals(statusRec.status, 200, msg = "Status code mismatched");
+    test:assertEquals(statusRec.headers, {
+                                             "content-type": "text/plain",
+                                             "Server": "Ballerina",
+                                             "Header-1": "Value-1",
+                                             "Header-2": "Value-2"
+                                         }, msg = "Headers mismatched");
+    test:assertEquals(statusRec?.body, "Hello, World!", msg = "Payload mismatched");
+}
+
+@test:Config
+function testGetStatusRecWithNoContent() returns error? {
+    http:Response res = new;
+    res.statusCode = 204;
+    res.setHeader("Server", "Ballerina");
+    res.setHeader("Header-1", "Value-1");
+    res.setHeader("Header-2", "Value-2");
+
+    http:StatusCodeRecord statusRec = check res.getStatusCodeRecord();
+    test:assertEquals(statusRec.status, 204, msg = "Status code mismatched");
+    test:assertEquals(statusRec.headers, {
+                                             "Server": "Ballerina",
+                                             "Header-1": "Value-1",
+                                             "Header-2": "Value-2"
+                                         }, msg = "Headers mismatched");
+    test:assertEquals(statusRec?.body, (), msg = "Payload mismatched");
+}
+
+@test:Config
+function testGetStatusRecWithNoContentAndNoHeaders() returns error? {
+    http:Response res = new;
+    res.statusCode = 204;
+
+    http:StatusCodeRecord statusRec = check res.getStatusCodeRecord();
+    test:assertEquals(statusRec.status, 204, msg = "Status code mismatched");
+    test:assertEquals(statusRec.headers, {}, msg = "Headers mismatched");
+    test:assertEquals(statusRec?.body, (), msg = "Payload mismatched");
+}
+
+@test:Config
+function testGetStatusRecWithFailureRes() returns error? {
+    http:Response res = new;
+    res.statusCode = 500;
+    res.setTextPayload("Internal Server Error");
+    res.setHeader("Server", "Ballerina");
+    res.setHeader("Header-1", "Value-1");
+    res.setHeader("Header-2", "Value-2");
+
+    http:StatusCodeRecord statusRec = check res.getStatusCodeRecord();
+    test:assertEquals(statusRec.status, 500, msg = "Status code mismatched");
+    test:assertEquals(statusRec.headers, {
+                                             "content-type": "text/plain",
+                                             "Server": "Ballerina",
+                                             "Header-1": "Value-1",
+                                             "Header-2": "Value-2"
+                                         }, msg = "Headers mismatched");
+    test:assertEquals(statusRec?.body, "Internal Server Error", msg = "Payload mismatched");
+}

--- a/ballerina/http_response.bal
+++ b/ballerina/http_response.bal
@@ -23,6 +23,16 @@ import ballerina/jballerina.java;
 import ballerina/log;
 import ballerina/data.jsondata;
 
+# Defines a status code response record type
+public type StatusCodeRecord record {|
+    # The status code
+    int status;
+    # The headers of the response
+    map<string|int|boolean|string[]|int[]|boolean[]> headers?;
+    # The response body
+    anydata body?;
+|};
+
 # Represents an HTTP response.
 #
 # + statusCode - The response status code
@@ -583,6 +593,18 @@ public class Response {
             }
         }
         return cookiesInResponse;
+    }
+
+    # Gets the status code response record from the response.
+    #
+    # + return - The status code response record
+    public isolated function getStatusCodeRecord() returns StatusCodeRecord|error {
+        StatusCodeResponse res = check externProcessResponseNew(self, StatusCodeResponse, false, false);
+        return {
+            status: res.status.code,
+            headers: res.headers,
+            body: res?.body
+        };
     }
 
     isolated function buildStatusCodeResponse(typedesc<anydata>? payloadType, typedesc<StatusCodeResponse> statusCodeResType,

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Add TLSv1.3 supported cipher suites to the default configuration](https://github.com/ballerina-platform/ballerina-library/issues/7658)
 
+### Added
+
+- [Add an API to convert response object to status response record](https://github.com/ballerina-platform/ballerina-library/issues/7667)
+
 ## [2.13.3] - 2025-02-20
 
 ### Added


### PR DESCRIPTION
## Purpose

> $Subject

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/7667

API:
```bal
# Gets the status code response record from the response.
#
# + return - The status code response record
public isolated function getStatusCodeRecord() returns StatusCodeRecord|error
```

Structure of the status code response:
```bal
# Defines a status code response record type
public type StatusCodeRecord record {|
    # The status code
    int status;
    # The headers of the response
    map<string|int|boolean|string[]|int[]|boolean[]> headers?;
    # The response body
    anydata body?;
|};
```

## Example

```bal
http:Client clientEP = check new ("localhost:9090/api");
http:Response res = check clientEP->/path;
http:StatusCodeRecord statusCodeRes = check res.getStatusCodeRecord();
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
- [ ] Checked native-image compatibility
- [ ] ~Checked the impact on OpenAPI generation~
