### PR TITLE
Relaxed the Set-Cookie parser to better handle IETF specs and "non-st…

### DIFF
--- a/ballerina/cookie_utils.bal
+++ b/ballerina/cookie_utils.bal
@@ -21,35 +21,33 @@ import ballerina/time;
 // Returns the cookie object from the string value of the "Set-Cookie" header.
 isolated function parseSetCookieHeader(string cookieStringValue) returns Cookie {
     string cookieValue = cookieStringValue;
-    string[] result = re`;\s`.split(cookieValue);
+    string[] result = re`;`.split(cookieValue).'map(n => n.trim());
     string[] nameValuePair = re`=`.split(result[0]);
     string cookieName = nameValuePair[0];
     string cookieVal = nameValuePair[1];
     CookieOptions options = {};
     foreach var item in result {
         nameValuePair = re`=`.split(item);
-        match nameValuePair[0] {
-            DOMAIN_ATTRIBUTE => {
-                options.domain = nameValuePair[1];
+        if nameValuePair[0].equalsIgnoreCaseAscii(DOMAIN_ATTRIBUTE) {
+            options.domain = nameValuePair[1];
+        }
+        if nameValuePair[0].equalsIgnoreCaseAscii(PATH_ATTRIBUTE) {
+            options.path = nameValuePair[1];
+        }
+        if nameValuePair[0].equalsIgnoreCaseAscii(MAX_AGE_ATTRIBUTE) {
+            int|error age = ints:fromString(nameValuePair[1]);
+            if age is int {
+                options.maxAge = age;
             }
-            PATH_ATTRIBUTE => {
-                options.path = nameValuePair[1];
-            }
-            MAX_AGE_ATTRIBUTE => {
-                int|error age = ints:fromString(nameValuePair[1]);
-                if age is int {
-                    options.maxAge = age;
-                }
-            }
-            EXPIRES_ATTRIBUTE => {
-                options.expires = nameValuePair[1];
-            }
-            SECURE_ATTRIBUTE => {
-                options.secure = true;
-            }
-            HTTP_ONLY_ATTRIBUTE => {
-                options.httpOnly = true;
-            }
+        }
+        if nameValuePair[0].equalsIgnoreCaseAscii(EXPIRES_ATTRIBUTE) {
+            options.expires = nameValuePair[1];
+        }
+        if nameValuePair[0].equalsIgnoreCaseAscii(SECURE_ATTRIBUTE) {
+            options.secure = true;
+        }
+        if nameValuePair[0].equalsIgnoreCaseAscii(HTTP_ONLY_ATTRIBUTE) {
+            options.httpOnly = true;
         }
     }
     Cookie cookie = new (cookieName, cookieVal, options);

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@ This file contains all the notable changes done to the Ballerina HTTP package th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Fixed
+- Relaxed the Set-Cookie parser to better handle IETF specs and "non-standard" servers.
+
 ## [2.14.0] - 2025-03-12
 
 ### Changed


### PR DESCRIPTION
## Purpose
Current implementation of `parseSetCookieHeader` is too strict. Specifically:
- it splits by `;\s`
- checks attributes with case-sensitive

According to https://datatracker.ietf.org/doc/html/rfc6265#section-5.2, clients must be able to handle a more relaxed scenario, that is:
- splits by `;`
- checks attributes with case-insensitive

This change relaxes the parser to better suit the IETF specs. Should work better across more servers.

## Examples

## Checklist
- [ ] Linked to an issue
- [X] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
- [ ] Checked the impact on OpenAPI generation
