### PR TITLE
[2201.8.x] Fix `Set-Cookie` parser inconsistencies

### DIFF
--- a/ballerina-tests/http-advanced-tests/Ballerina.toml
+++ b/ballerina-tests/http-advanced-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_advanced_tests"
-version = "2.10.21"
+version = "2.10.22"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.21"
+version = "2.10.22"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.21.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.22-SNAPSHOT.jar"

--- a/ballerina-tests/http-advanced-tests/Dependencies.toml
+++ b/ballerina-tests/http-advanced-tests/Dependencies.toml
@@ -72,7 +72,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -105,7 +105,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_advanced_tests"
-version = "2.10.21"
+version = "2.10.22"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},
@@ -125,7 +125,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-advanced-tests/tests/http_cookies_test.bal
+++ b/ballerina-tests/http-advanced-tests/tests/http_cookies_test.bal
@@ -15,27 +15,37 @@
 // under the License.
 
 import ballerina/file;
-// import ballerina/log;
 import ballerina/test;
 import ballerina/http;
 import ballerina/http_test_common as common;
 
-listener http:Listener CookieTestserverEP = new (9253, httpVersion = http:HTTP_1_1);
+listener http:Listener CookieTestServerEP = new (cookieTestPort1, httpVersion = http:HTTP_1_1);
 
-service /cookie on CookieTestserverEP {
+http:ListenerConfiguration http2SslServiceConf = {
+    secureSocket: {
+        key: {
+            path: common:KEYSTORE_PATH,
+            password: "ballerina"
+        }
+    }
+};
+
+listener http:Listener CookieTestHTTPSServerEP = new (cookieTestPort2, http2SslServiceConf);
+
+service /cookie on CookieTestServerEP {
 
     resource function get addPersistentAndSessionCookies(http:Caller caller, http:Request req) returns error? {
 
         http:Cookie cookie1 = new("SID001", "239d4dmnmsddd34",
             path = "/cookie/addPersistentAndSessionCookies",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = true,
             secure = false,
             expires = "2030-06-26 05:46:22");
 
         http:Cookie cookie2 = new("SID002", "178gd4dmnmsddd34",
             path = "/cookie/addPersistentAndSessionCookies",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = true,
             secure = false,
             expires = "2030-07-15 05:46:22");
@@ -43,7 +53,7 @@ service /cookie on CookieTestserverEP {
 
         http:Cookie cookie3 = new("SID003", "895gd4dmnmsddd34",
             path = "/cookie/addPersistentAndSessionCookies",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = true,
             secure = false);
 
@@ -68,12 +78,12 @@ service /cookie on CookieTestserverEP {
         // Creates the cookies.
         http:Cookie cookie1 = new("SID002", "239d4dmnmsddd34",
             path = "/cookie",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = true);
 
         http:Cookie cookie2 = new("SID002", "178gd4dmnmsddd34",
             path = "/cookie",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = false);
 
         http:Response res = new;
@@ -94,12 +104,12 @@ service /cookie on CookieTestserverEP {
         // Creates the cookies.
         http:Cookie cookie1 = new("SID001", "239d4dmnmsddd34",
             path = "/cookie",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = true);
 
         http:Cookie cookie2 = new("SID002", "178gd4dmnmsddd34",
             path = "/cookie/removeSessionCookie",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = true,
             secure = false);
 
@@ -123,14 +133,14 @@ service /cookie on CookieTestserverEP {
     resource function get sendSimilarPersistentCookies(http:Caller caller, http:Request req) returns error? {
         http:Cookie cookie1 = new("SID001", "239d4dmnmsddd34",
             path = "/cookie/sendSimilarPersistentCookies",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = false,
             secure = false,
             expires = "2030-06-26 05:46:22");
 
         http:Cookie cookie3 = new("SID001", "895gd4dmnmsddd34",
             path = "/cookie/sendSimilarPersistentCookies",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = true,
             secure = false,
             expires = "2030-06-26 05:46:22");
@@ -153,13 +163,13 @@ service /cookie on CookieTestserverEP {
             returns error? {
         http:Cookie cookie2 = new("SID003", "895gd4dmnmsddd34",
             path = "/cookie/sendSimilarPersistentAndSessionCookies_1",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = true,
             secure = false);
 
         http:Cookie cookie3 = new("SID003", "aeaa895gd4dmnmsddd34",
             path = "/cookie/sendSimilarPersistentAndSessionCookies_1",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = false,
             secure = false,
             expires = "2030-07-15 05:46:22");
@@ -182,14 +192,14 @@ service /cookie on CookieTestserverEP {
             returns error? {
         http:Cookie cookie2 = new("SID003", "aeaa895gd4dmnmsddd34",
             path = "/cookie/sendSimilarPersistentAndSessionCookies_2",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = false,
             secure = false,
             expires = "2030-07-15 05:46:22");
 
         http:Cookie cookie3 = new("SID003", "895gd4dmnmsddd34",
             path = "/cookie/sendSimilarPersistentAndSessionCookies_2",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = true,
             secure = false);
 
@@ -211,13 +221,13 @@ service /cookie on CookieTestserverEP {
         // Creates the cookies.
         http:Cookie cookie1 = new("SID001", "239d4dmnmsddd34",
             path = "/cookie/removePersistentCookieByServer",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = true,
             expires = "2030-07-15 05:46:22");
 
         http:Cookie cookie2 = new("SID002", "178gd4dmnmsddd34",
             path = "/cookie/removePersistentCookieByServer",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = true,
             secure = false);
 
@@ -253,21 +263,21 @@ service /cookie on CookieTestserverEP {
             returns error? {
         http:Cookie cookie1 = new("SID001", "239d4dmnmsddd34",
             path = "/cookie/addPersistentAndSessionCookiesDefault",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = true,
             secure = false,
             expires = "2030-06-26 05:46:22");
 
         http:Cookie cookie2 = new("SID002", "178gd4dmnmsddd34",
             path = "/cookie/addPersistentAndSessionCookiesDefault",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = true,
             secure = false,
             expires = "2030-07-15 05:46:22");
 
         http:Cookie cookie3 = new("SID003", "895gd4dmnmsddd34",
             path = "/cookie/addPersistentAndSessionCookiesDefault",
-            domain = "localhost:9253",
+            domain = string `localhost:${cookieTestPort1}`,
             httpOnly = true,
             secure = false);
 
@@ -289,7 +299,7 @@ service /cookie on CookieTestserverEP {
     }
 }
 
-service /cookieDemo on CookieTestserverEP {
+service /cookieDemo on CookieTestServerEP {
     resource function post login(http:Request req) returns http:Response|http:BadRequest {
         json|error details = req.getJsonPayload();
         if details is json {
@@ -329,11 +339,73 @@ service /cookieDemo on CookieTestserverEP {
     }
 }
 
+service /cookies on CookieTestServerEP {
+
+    resource function get path(http:Request req) returns http:Response|string {
+        http:Cookie[] userCookie = from http:Cookie cookie in req.getCookies()
+            where cookie.name == "user"
+            limit 1
+            select cookie;
+        if userCookie.length() == 0 {
+            http:Cookie cookie = new ("user", "ballerina", {path: "/cookies"});
+            http:Response res = new;
+            res.addCookie(cookie);
+            return res;
+        }
+        return userCookie[0].value;
+    }
+
+    resource function get .(http:Request req) returns http:Response|string {
+        http:Cookie[] userCookie = from http:Cookie cookie in req.getCookies()
+            where cookie.name == "user"
+            limit 1
+            select cookie;
+        if userCookie.length() == 0 {
+            http:Cookie cookie = new ("user", "ballerina", {path: "/cookies"});
+            http:Response res = new;
+            res.addCookie(cookie);
+            return res;
+        }
+        return userCookie[0].value;
+    }
+}
+
+service /cookies on CookieTestHTTPSServerEP {
+
+    resource function get path(http:Request req) returns http:Response|string {
+        http:Cookie[] userCookie = from http:Cookie cookie in req.getCookies()
+            where cookie.name == "user"
+            limit 1
+            select cookie;
+        if userCookie.length() == 0 {
+            http:Cookie cookie = new ("user", "ballerina", {path: "/cookies"});
+            http:Response res = new;
+            res.addCookie(cookie);
+            return res;
+        }
+        return userCookie[0].value;
+    }
+
+    resource function get .(http:Request req) returns http:Response|string {
+        http:Cookie[] userCookie = from http:Cookie cookie in req.getCookies()
+            where cookie.name == "user"
+            limit 1
+            select cookie;
+        if userCookie.length() == 0 {
+            http:Cookie cookie = new ("user", "ballerina", {path: "/cookies"});
+            http:Response res = new;
+            res.addCookie(cookie);
+            return res;
+        }
+        return userCookie[0].value;
+    }
+}
+
 // Test to send requests by cookie client for first, second and third times
 @test:Config {}
 public isolated function testSendRequestsByCookieClient() returns error? {
     http:CsvPersistentCookieHandler myPersistentStore = new("./cookie-test-data/client-1.csv");
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true, persistentCookieHandler: myPersistentStore });
     // Server sends the cookies in the response for the first request.
     http:Response|error response = cookieClientEndpoint->get("/cookie/addPersistentAndSessionCookies");
@@ -353,7 +425,7 @@ public isolated function testSendRequestsByCookieClient() returns error? {
 @test:Config {}
 public isolated function testRemoveSessionCookieByClient() returns error? {
     http:CsvPersistentCookieHandler myPersistentStore = new("./cookie-test-data/client-2.csv");
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true, persistentCookieHandler: myPersistentStore });
     // Server sends cookies in the response for the first request.
     http:Response|error response = cookieClientEndpoint->get("/cookie/addPersistentAndSessionCookies");
@@ -361,7 +433,7 @@ public isolated function testRemoveSessionCookieByClient() returns error? {
     http:CookieStore? myCookieStore = cookieClientEndpoint.getCookieStore();
     if myCookieStore is http:CookieStore {
         http:CookieHandlingError? removeResult =
-                myCookieStore.removeCookie("SID003", "localhost:9253", "/cookie/addPersistentAndSessionCookies");
+                myCookieStore.removeCookie("SID003", string `localhost:${cookieTestPort1}`, "/cookie/addPersistentAndSessionCookies");
         if removeResult is http:CookieHandlingError {
             // log:printError("Error retrieving", 'error = removeResult);
         }
@@ -380,7 +452,7 @@ public isolated function testRemoveSessionCookieByClient() returns error? {
 // cookie in the cookie store
 @test:Config {}
 public isolated function testAddSimilarSessionCookies() returns error? {
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true });
     // Server sends similar session cookies in the response for the first request.
     http:Response|error response = cookieClientEndpoint->get("/cookie/addSimilarSessionCookie");
@@ -397,7 +469,7 @@ public isolated function testAddSimilarSessionCookies() returns error? {
 @test:Config {}
 public isolated function testRemoveSessionCookieByServer() returns error? {
     http:CsvPersistentCookieHandler myPersistentStore = new("./cookies-test-data/client-4.csv");
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true, persistentCookieHandler: myPersistentStore });
     // Server sends the session cookies in the response for the first request.
     http:Response|error response = cookieClientEndpoint->get("/cookie/removeSessionCookie");
@@ -416,7 +488,7 @@ public isolated function testRemoveSessionCookieByServer() returns error? {
 @test:Config {}
 public isolated function testSendRequestsByClient() returns error? {
     http:CsvPersistentCookieHandler myPersistentStore = new("./cookie-test-data/client-6.csv");
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1,
         retryConfig = {
             interval: 3,
@@ -453,7 +525,7 @@ public isolated function testSendRequestsByClient() returns error? {
 @test:Config {}
 public function testRemovePersistentCookieByClient() returns error? {
     http:CsvPersistentCookieHandler myPersistentStore = new("./cookie-test-data/client-7.csv");
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true, persistentCookieHandler: myPersistentStore });
     // Server sends the cookies in the response for the first request.
     http:Response|error response = cookieClientEndpoint->get("/cookie/addPersistentAndSessionCookies");
@@ -461,7 +533,7 @@ public function testRemovePersistentCookieByClient() returns error? {
     http:CookieStore? myCookieStore = cookieClientEndpoint.getCookieStore();
     if myCookieStore is http:CookieStore {
         http:CookieHandlingError? removeResult =
-            myCookieStore.removeCookie("SID001", "localhost:9253", "/cookie/addPersistentAndSessionCookies");
+            myCookieStore.removeCookie("SID001", string `localhost:${cookieTestPort1}`, "/cookie/addPersistentAndSessionCookies");
         if removeResult is http:CookieHandlingError {
             // log:printError("Error retrieving", 'error = removeResult);
         }
@@ -481,7 +553,7 @@ public function testRemovePersistentCookieByClient() returns error? {
 @test:Config {}
 public function testAddSimilarPersistentCookies() returns error? {
     http:CsvPersistentCookieHandler myPersistentStore = new("./cookie-test-data/client-8.csv");
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true, persistentCookieHandler: myPersistentStore });
     // Server sends similar persistent cookies in the response for the first request.
     http:Response|error response = cookieClientEndpoint->get("/cookie/sendSimilarPersistentCookies");
@@ -500,7 +572,7 @@ public function testAddSimilarPersistentCookies() returns error? {
 @test:Config {}
 public function testSendSimilarPersistentAndSessionCookies_1() returns error? {
     http:CsvPersistentCookieHandler myPersistentStore = new("./cookie-test-data/client-9.csv");
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true, persistentCookieHandler: myPersistentStore });
     // Server sends a session cookie and a similar persistent cookie in the response for the first request.
     http:Response|error response = cookieClientEndpoint->get("/cookie/sendSimilarPersistentAndSessionCookies_1");
@@ -519,7 +591,7 @@ public function testSendSimilarPersistentAndSessionCookies_1() returns error? {
 @test:Config {}
 public function testSendSimilarPersistentAndSessionCookies_2() returns error? {
     http:CsvPersistentCookieHandler myPersistentStore = new("./cookie-test-data/client-10.csv");
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true, persistentCookieHandler: myPersistentStore });
     // Server sends a persistent cookie and a similar session cookie in the response for the first request.
     http:Response|error response = cookieClientEndpoint->get("/cookie/sendSimilarPersistentAndSessionCookies_2");
@@ -537,7 +609,7 @@ public function testSendSimilarPersistentAndSessionCookies_2() returns error? {
 @test:Config {}
 public function testRemovePersistentCookieByServer() returns error? {
     http:CsvPersistentCookieHandler myPersistentStore = new("./cookie-test-data/client-11.csv");
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true, persistentCookieHandler: myPersistentStore });
     // Server sends cookies in the response for the first request.
     http:Response|error response = cookieClientEndpoint->get("/cookie/removePersistentCookieByServer");
@@ -556,7 +628,7 @@ public function testRemovePersistentCookieByServer() returns error? {
 // Test to send persistent cookies when the persistentCookieHandler is not configured
 @test:Config {}
 public function testSendPersistentCookiesWithoutPersistentCookieHandler() returns error? {
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true });
     // Server sends the cookies in the response for the first request.
     http:Response|error response = cookieClientEndpoint->get("/cookie/addPersistentAndSessionCookies");
@@ -574,7 +646,7 @@ public function testSendPersistentCookiesWithoutPersistentCookieHandler() return
 // Test the cookie validation when using the getCookies()
 @test:Config {}
 public function testCookieValidation() returns error? {
-    http:Client clientEP = check new("http://localhost:9253", httpVersion = http:HTTP_1_1);
+    http:Client clientEP = check new(string `http://localhost:${cookieTestPort1}`, httpVersion = http:HTTP_1_1);
     http:Response|error response = clientEP->get("/cookie/validateCookie", {"Cookie":"user=John; asd=; =sdsdfsf; =gffg; "});
     if response is http:Response {
         common:assertTextPayload(response.getTextPayload(), "Valid cookies: user=John,asd=,");
@@ -587,7 +659,7 @@ public function testCookieValidation() returns error? {
 // Test to send persistent cookies when the persistentCookieHandler is not configured
 @test:Config {}
 public function testPostSendPersistentCookiesWithoutPersistentCookieHandler() returns error? {
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true });
     // Server sends the cookies in the response for the first request.
     http:Response|error response = cookieClientEndpoint->post("/cookie/addPersistentAndSessionCookiesDefault", "");
@@ -604,7 +676,7 @@ public function testPostSendPersistentCookiesWithoutPersistentCookieHandler() re
 
 @test:Config {}
 public function testPutSendPersistentCookiesWithoutPersistentCookieHandler() returns error? {
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true });
     // Server sends the cookies in the response for the first request.
     http:Response|error response = cookieClientEndpoint->put("/cookie/addPersistentAndSessionCookiesDefault", "");
@@ -621,7 +693,7 @@ public function testPutSendPersistentCookiesWithoutPersistentCookieHandler() ret
 
 @test:Config {}
 public function testPatchSendPersistentCookiesWithoutPersistentCookieHandler() returns error? {
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true });
     // Server sends the cookies in the response for the first request.
     http:Response|error response = cookieClientEndpoint->patch("/cookie/addPersistentAndSessionCookiesDefault", "");
@@ -638,7 +710,7 @@ public function testPatchSendPersistentCookiesWithoutPersistentCookieHandler() r
 
 @test:Config {}
 public function testDeleteSendPersistentCookiesWithoutPersistentCookieHandler() returns error? {
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true });
     // Server sends the cookies in the response for the first request.
     http:Response|error response = cookieClientEndpoint->delete("/cookie/addPersistentAndSessionCookiesDefault", "");
@@ -655,7 +727,7 @@ public function testDeleteSendPersistentCookiesWithoutPersistentCookieHandler() 
 
 @test:Config {}
 public function testHeadSendPersistentCookiesWithoutPersistentCookieHandler() returns error? {
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true });
     // Server sends the cookies in the response for the first request.
     http:Response|error response = cookieClientEndpoint->head("/cookie/addPersistentAndSessionCookiesDefault");
@@ -670,7 +742,7 @@ public function testHeadSendPersistentCookiesWithoutPersistentCookieHandler() re
 
 @test:Config {}
 public function testOptionsSendPersistentCookiesWithoutPersistentCookieHandler() returns error? {
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true });
     // Server sends the cookies in the response for the first request.
     http:Response|error response = cookieClientEndpoint->options("/cookie/addPersistentAndSessionCookiesDefault");
@@ -687,7 +759,7 @@ public function testOptionsSendPersistentCookiesWithoutPersistentCookieHandler()
 
 @test:Config {}
 public function testExecuteSendPersistentCookiesWithoutPersistentCookieHandler() returns error? {
-    http:Client cookieClientEndpoint = check new("http://localhost:9253", 
+    http:Client cookieClientEndpoint = check new(string `http://localhost:${cookieTestPort1}`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true });
     // Server sends the cookies in the response for the first request.
     http:Response|error response = cookieClientEndpoint->execute("GET",
@@ -705,7 +777,7 @@ public function testExecuteSendPersistentCookiesWithoutPersistentCookieHandler()
 
 @test:Config {}
 public function testCaseSensitiveDomain() returns error? {
-    http:Client httpClient = check new("http://localhost:9253/cookieDemo", 
+    http:Client httpClient = check new(string `http://localhost:${cookieTestPort1}/cookieDemo`, 
         httpVersion = http:HTTP_1_1, cookieConfig = { enabled: true });
     http:Request request = new;
     json jsonPart = {
@@ -722,4 +794,47 @@ public function testCaseSensitiveDomain() returns error? {
         test:assertEquals(welcomeResp, "Welcome back John");
     }
     return;
+}
+
+@test:Config {}
+public function testCookieWithEmptyPath() returns error? {
+    http:Client httpClient = check new (string `http://localhost:${cookieTestPort1}/cookies`, cookieConfig = {enabled: true});
+    http:Response _ = check httpClient->get("");
+    string result = check httpClient->get("");
+    test:assertEquals(result, "ballerina");
+
+    httpClient = check new (string `http://localhost:${cookieTestPort1}/cookies/path`, cookieConfig = {enabled: true});
+    http:Response _ = check httpClient->get("");
+    result = check httpClient->get("");
+    test:assertEquals(result, "ballerina");
+
+    httpClient = check new (string `localhost:${cookieTestPort1}/cookies`, cookieConfig = {enabled: true});
+    http:Response _ = check httpClient->get("");
+    result = check httpClient->get("");
+    test:assertEquals(result, "ballerina");
+
+    httpClient = check new (string `localhost:${cookieTestPort1}/cookies/path`, cookieConfig = {enabled: true});
+    http:Response _ = check httpClient->get("");
+    result = check httpClient->get("");
+    test:assertEquals(result, "ballerina");
+
+    httpClient = check new (string `https://localhost:${cookieTestPort2}/cookies`, cookieConfig = {enabled: true}, secureSocket = {enable: false});
+    http:Response _ = check httpClient->get("");
+    result = check httpClient->get("");
+    test:assertEquals(result, "ballerina");
+
+    httpClient = check new (string `https://localhost:${cookieTestPort2}/cookies/path`, cookieConfig = {enabled: true}, secureSocket = {enable: false});
+    http:Response _ = check httpClient->get("");
+    result = check httpClient->get("");
+    test:assertEquals(result, "ballerina");
+
+    httpClient = check new (string `localhost:${cookieTestPort2}/cookies`, cookieConfig = {enabled: true}, secureSocket = {enable: false});
+    http:Response _ = check httpClient->get("");
+    result = check httpClient->get("");
+    test:assertEquals(result, "ballerina");
+
+    httpClient = check new (string `localhost:${cookieTestPort2}/cookies/path`, cookieConfig = {enabled: true}, secureSocket = {enable: false});
+    http:Response _ = check httpClient->get("");
+    result = check httpClient->get("");
+    test:assertEquals(result, "ballerina");
 }

--- a/ballerina-tests/http-advanced-tests/tests/http_set_cookie_parser_test.bal
+++ b/ballerina-tests/http-advanced-tests/tests/http_set_cookie_parser_test.bal
@@ -1,0 +1,94 @@
+// Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/test;
+
+service /api on new http:Listener(setCookieParserPort) {
+
+    resource function get cookieAttributesWithoutSpaces() returns http:Ok {
+        return {
+            body: {
+                "message": "Hello"
+            },
+            headers: {
+                "Set-Cookie": "cookie=value;Path=/;HttpOnly"
+            }
+        };
+    }
+
+    resource function get caseInsensitiveCookieAttribute() returns http:Ok {
+        return {
+            body: {
+                "message": "Hello"
+            },
+            headers: {
+                "Set-Cookie": "cookie=value; path=/api;httponly; secure"
+            }
+        };
+    }
+}
+
+@test:Config
+function testSetCookieWithCookieAttributesWithoutSpaces() returns error? {
+    http:Client clientEp = check new (string `localhost:${setCookieParserPort}`,
+        cookieConfig = {
+            enabled: true
+        }
+    );
+
+    http:CookieStore? cookieStore = clientEp.getCookieStore();
+    if cookieStore !is http:CookieStore {
+        test:assertFail("Failed to get cookie store");
+    }
+    test:assertTrue(cookieStore.getCookiesByName("cookie").length() == 0, msg = "Cookie store should be empty before request");
+
+    json resp = check clientEp->/api/cookieAttributesWithoutSpaces;
+    test:assertEquals(resp.message, "Hello", msg = "Response message mismatch");
+    test:assertTrue(cookieStore.getCookiesByName("cookie").length() == 1, msg = "Cookie store should have one cookie");
+
+    http:Cookie cookie = cookieStore.getCookiesByName("cookie")[0];
+    test:assertEquals(cookie.name, "cookie", msg = "Cookie name mismatch");
+    test:assertEquals(cookie.value, "value", msg = "Cookie value mismatch");
+    test:assertEquals(cookie.path, "/", msg = "Cookie path mismatch");
+    test:assertEquals(cookie.httpOnly, true, msg = "Cookie httpOnly mismatch");
+}
+
+@test:Config
+function testSetCookieWithCaseInsensitiveCookieAttribute() returns error? {
+    http:Client clientEp = check new (string `localhost:${setCookieParserPort}`,
+        cookieConfig = {
+            enabled: true
+        }
+    );
+
+    http:CookieStore? cookieStore = clientEp.getCookieStore();
+    if cookieStore !is http:CookieStore {
+        test:assertFail("Failed to get cookie store");
+    }
+    test:assertTrue(cookieStore.getCookiesByName("cookie").length() == 0, msg = "Cookie store should be empty before request");
+
+    json resp = check clientEp->/api/caseInsensitiveCookieAttribute;
+    test:assertEquals(resp.message, "Hello", msg = "Response message mismatch");
+    test:assertTrue(cookieStore.getCookiesByName("cookie").length() == 1, msg = "Cookie store should have one cookie");
+
+    http:Cookie cookie = cookieStore.getCookiesByName("cookie")[0];
+    test:assertEquals(cookie.name, "cookie", msg = "Cookie name mismatch");
+    test:assertEquals(cookie.value, "value", msg = "Cookie value mismatch");
+    test:assertEquals(cookie.path, "/api", msg = "Cookie path mismatch");
+    test:assertEquals(cookie.httpOnly, true, msg = "Cookie httpOnly mismatch");
+    test:assertEquals(cookie.secure, true, msg = "Cookie secure mismatch");
+}

--- a/ballerina-tests/http-advanced-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-advanced-tests/tests/test_service_ports.bal
@@ -42,3 +42,4 @@ const int statusCodeErrorUseCasePort = 9090;
 const int statusCodeErrorPort = 9092;
 
 const int identicalCookiePort = 9093;
+const int setCookieParserPort = 9094;

--- a/ballerina-tests/http-advanced-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-advanced-tests/tests/test_service_ports.bal
@@ -42,4 +42,7 @@ const int statusCodeErrorUseCasePort = 9090;
 const int statusCodeErrorPort = 9092;
 
 const int identicalCookiePort = 9093;
+
+const int cookieTestPort1 = 9253;
+const int cookieTestPort2 = 9254;
 const int setCookieParserPort = 9094;

--- a/ballerina-tests/http-client-tests/Ballerina.toml
+++ b/ballerina-tests/http-client-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_client_tests"
-version = "2.10.21"
+version = "2.10.22"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.21"
+version = "2.10.22"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.21.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.22-SNAPSHOT.jar"

--- a/ballerina-tests/http-client-tests/Dependencies.toml
+++ b/ballerina-tests/http-client-tests/Dependencies.toml
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_client_tests"
-version = "2.10.21"
+version = "2.10.22"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-dispatching-tests/Ballerina.toml
+++ b/ballerina-tests/http-dispatching-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_dispatching_tests"
-version = "2.10.21"
+version = "2.10.22"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.21"
+version = "2.10.22"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.21.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.22-SNAPSHOT.jar"

--- a/ballerina-tests/http-dispatching-tests/Dependencies.toml
+++ b/ballerina-tests/http-dispatching-tests/Dependencies.toml
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_dispatching_tests"
-version = "2.10.21"
+version = "2.10.22"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
@@ -124,7 +124,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-interceptor-tests/Ballerina.toml
+++ b/ballerina-tests/http-interceptor-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_interceptor_tests"
-version = "2.10.21"
+version = "2.10.22"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.21"
+version = "2.10.22"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.21.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.22-SNAPSHOT.jar"

--- a/ballerina-tests/http-interceptor-tests/Dependencies.toml
+++ b/ballerina-tests/http-interceptor-tests/Dependencies.toml
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_interceptor_tests"
-version = "2.10.21"
+version = "2.10.22"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -115,7 +115,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-misc-tests/Ballerina.toml
+++ b/ballerina-tests/http-misc-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_misc_tests"
-version = "2.10.21"
+version = "2.10.22"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.21"
+version = "2.10.22"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.21.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.22-SNAPSHOT.jar"

--- a/ballerina-tests/http-misc-tests/Dependencies.toml
+++ b/ballerina-tests/http-misc-tests/Dependencies.toml
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_misc_tests"
-version = "2.10.21"
+version = "2.10.22"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -118,7 +118,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-resiliency-tests/Ballerina.toml
+++ b/ballerina-tests/http-resiliency-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_resiliency_tests"
-version = "2.10.21"
+version = "2.10.22"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.21"
+version = "2.10.22"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.21.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.22-SNAPSHOT.jar"

--- a/ballerina-tests/http-resiliency-tests/Dependencies.toml
+++ b/ballerina-tests/http-resiliency-tests/Dependencies.toml
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -99,7 +99,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_resiliency_tests"
-version = "2.10.21"
+version = "2.10.22"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -116,7 +116,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-security-tests/Ballerina.toml
+++ b/ballerina-tests/http-security-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.10.21"
+version = "2.10.22"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.21"
+version = "2.10.22"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.21.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.22-SNAPSHOT.jar"

--- a/ballerina-tests/http-security-tests/Dependencies.toml
+++ b/ballerina-tests/http-security-tests/Dependencies.toml
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.10.21"
+version = "2.10.22"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "http"},
@@ -120,7 +120,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-service-tests/Ballerina.toml
+++ b/ballerina-tests/http-service-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_service_tests"
-version = "2.10.21"
+version = "2.10.22"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.21"
+version = "2.10.22"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.21.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.22-SNAPSHOT.jar"

--- a/ballerina-tests/http-service-tests/Dependencies.toml
+++ b/ballerina-tests/http-service-tests/Dependencies.toml
@@ -69,7 +69,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_service_tests"
-version = "2.10.21"
+version = "2.10.22"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http-test-common/Ballerina.toml
+++ b/ballerina-tests/http-test-common/Ballerina.toml
@@ -1,4 +1,4 @@
 [package]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.21"
+version = "2.10.22"

--- a/ballerina-tests/http-test-common/Dependencies.toml
+++ b/ballerina-tests/http-test-common/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.8.0"
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.21"
+version = "2.10.22"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "mime"},

--- a/ballerina-tests/http2-tests/Ballerina.toml
+++ b/ballerina-tests/http2-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http2_tests"
-version = "2.10.21"
+version = "2.10.22"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.10.21"
+version = "2.10.22"
 
 [platform.java17]
 graalvmCompatible = true
 
 [[platform.java17.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.10.21.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.10.22-SNAPSHOT.jar"

--- a/ballerina-tests/http2-tests/Dependencies.toml
+++ b/ballerina-tests/http2-tests/Dependencies.toml
@@ -69,7 +69,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -102,7 +102,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http2_tests"
-version = "2.10.21"
+version = "2.10.22"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
@@ -121,7 +121,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.10.21"
+version = "2.10.22"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.10.21"
+version = "2.10.22"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -16,8 +16,8 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.10.21"
-path = "../native/build/libs/http-native-2.10.21.jar"
+version = "2.10.22"
+path = "../native/build/libs/http-native-2.10.22-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.10.21.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.10.22-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -25,7 +25,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.7.0"
+version = "3.7.1"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -76,7 +76,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.10.21"
+version = "2.10.22"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -108,7 +108,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.6.0"
+version = "1.6.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -283,7 +283,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.2.0"
+version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/cookie_http_client.bal
+++ b/ballerina/cookie_http_client.bal
@@ -43,7 +43,7 @@ client isolated class CookieClient {
     # + return - The `client` or an `http:ClientError` if the initialization failed
     isolated function init(string url, CookieConfig cookieConfig, HttpClient httpClient,
             CookieStore? cookieStore) returns ClientError? {
-        self.url = url;
+        self.url = getURLWithScheme(url, httpClient);
         CookieInferredConfig cookieInferredConfig = {
             enabled: cookieConfig.enabled,
             maxCookiesPerDomain: cookieConfig.maxCookiesPerDomain,

--- a/ballerina/cookie_utils.bal
+++ b/ballerina/cookie_utils.bal
@@ -21,35 +21,33 @@ import ballerina/time;
 // Returns the cookie object from the string value of the "Set-Cookie" header.
 isolated function parseSetCookieHeader(string cookieStringValue) returns Cookie {
     string cookieValue = cookieStringValue;
-    string[] result = re`;\s`.split(cookieValue);
+    string[] result = re`;`.split(cookieValue).'map(n => n.trim());
     string[] nameValuePair = re`=`.split(result[0]);
     string cookieName = nameValuePair[0];
     string cookieVal = nameValuePair[1];
     CookieOptions options = {};
     foreach var item in result {
         nameValuePair = re`=`.split(item);
-        match nameValuePair[0] {
-            DOMAIN_ATTRIBUTE => {
-                options.domain = nameValuePair[1];
+        if nameValuePair[0].equalsIgnoreCaseAscii(DOMAIN_ATTRIBUTE) {
+            options.domain = nameValuePair[1];
+        }
+        if nameValuePair[0].equalsIgnoreCaseAscii(PATH_ATTRIBUTE) {
+            options.path = nameValuePair[1];
+        }
+        if nameValuePair[0].equalsIgnoreCaseAscii(MAX_AGE_ATTRIBUTE) {
+            int|error age = ints:fromString(nameValuePair[1]);
+            if age is int {
+                options.maxAge = age;
             }
-            PATH_ATTRIBUTE => {
-                options.path = nameValuePair[1];
-            }
-            MAX_AGE_ATTRIBUTE => {
-                int|error age = ints:fromString(nameValuePair[1]);
-                if age is int {
-                    options.maxAge = age;
-                }
-            }
-            EXPIRES_ATTRIBUTE => {
-                options.expires = nameValuePair[1];
-            }
-            SECURE_ATTRIBUTE => {
-                options.secure = true;
-            }
-            HTTP_ONLY_ATTRIBUTE => {
-                options.httpOnly = true;
-            }
+        }
+        if nameValuePair[0].equalsIgnoreCaseAscii(EXPIRES_ATTRIBUTE) {
+            options.expires = nameValuePair[1];
+        }
+        if nameValuePair[0].equalsIgnoreCaseAscii(SECURE_ATTRIBUTE) {
+            options.secure = true;
+        }
+        if nameValuePair[0].equalsIgnoreCaseAscii(HTTP_ONLY_ATTRIBUTE) {
+            options.httpOnly = true;
         }
     }
     Cookie cookie = new (cookieName, cookieVal, options);

--- a/ballerina/http_client_endpoint.bal
+++ b/ballerina/http_client_endpoint.bal
@@ -44,7 +44,6 @@ public client isolated class Client {
     # + config - The configurations to be used when initializing the `client`
     # + return - The `client` or an `http:ClientError` if the initialization failed
     public isolated function init(string url, *ClientConfiguration config) returns ClientError? {
-        self.url = url;
         var cookieConfigVal = config.cookieConfig;
         if cookieConfigVal is CookieConfig {
             if cookieConfigVal.enabled {
@@ -52,6 +51,7 @@ public client isolated class Client {
             }
         }
         self.httpClient = check initialize(url, config, self.cookieStore);
+        self.url = getURLWithScheme(url, self.httpClient);
         self.requireValidation = config.validation;
         return;
     }
@@ -706,4 +706,9 @@ isolated function createResponseError(int statusCode, string reasonPhrase, map<s
     } else {
         return error RemoteServerError(reasonPhrase, statusCode = statusCode, headers = headers, body = body);
     }
+}
+
+// Add proper scheme to the URL if it is not present.
+isolated function getURLWithScheme(string url, HttpClient httpClient) returns string {
+    return isAbsolute(url) ? url : (httpClient is HttpSecureClient ? HTTPS_SCHEME + url : HTTP_SCHEME + url);
 }

--- a/ballerina/redirect_http_client.bal
+++ b/ballerina/redirect_http_client.bal
@@ -59,7 +59,7 @@ client isolated class RedirectClient {
     # + return - The `client` or an `http:ClientError` if the initialization failed
     isolated function init(string url, ClientConfiguration config, FollowRedirects redirectConfig, HttpClient httpClient)
             returns ClientError? {
-        self.url = url;
+        self.url = getURLWithScheme(url, httpClient);
         RedirectInferredConfig redirectInferredConfig = {
             httpVersion: config.httpVersion,
             http1Settings: config.http1Settings,

--- a/ballerina/resiliency_http_circuit_breaker.bal
+++ b/ballerina/resiliency_http_circuit_breaker.bal
@@ -141,7 +141,7 @@ client isolated class CircuitBreakerClient {
             return error GenericClientError("Circuit breaker 'timeWindow' value should be greater" +
                 " than the 'bucketSize' value.");
         }
-        self.url = url;
+        self.url = getURLWithScheme(url, httpClient);
         self.circuitBreakerInferredConfig = circuitBreakerInferredConfig.cloneReadOnly();
         self.httpClient = httpClient;
         self.circuitHealth = circuitHealth.clone();

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- [Fix cookie path resolution logic](https://github.com/ballerina-platform/ballerina-library/issues/6788)
 - [Fix inconsistencies in the `Set-Cookie` parser method](https://github.com/ballerina-platform/ballerina-library/issues/7807)
 
 ## [2.10.21] - 2025-03-05

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ This file contains all the notable changes done to the Ballerina HTTP package th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [Fix inconsistencies in the `Set-Cookie` parser method](https://github.com/ballerina-platform/ballerina-library/issues/7807)
+
 ## [2.10.21] - 2025-03-05
 
 ### Fixed


### PR DESCRIPTION
## Purpose

> $Subject

Part of https://github.com/ballerina-platform/ballerina-library/issues/7807

## Examples

N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
- [ ] ~Checked the impact on OpenAPI generation~
