### PR TITLE
[2201.11.x] Invalidate HTTP2 connections from the pool during eviction

### DIFF
--- a/ballerina-tests/http-client-tests/tests/client_connection_eviction.bal
+++ b/ballerina-tests/http-client-tests/tests/client_connection_eviction.bal
@@ -72,10 +72,7 @@ function testConnectionEvictionInHttpSecureClient() returns error? {
         runtime:sleep(5);
     }
 
-    json|error response = h1ClientHttps->/path;
-    if response is error {
-        test:assertFail("Expected a successful response, but got an error: " + response.message());
-    }
+    json response = check h1ClientHttps->/path;
     test:assertEquals(response, {message: "Hello from backend!"});
 }
 
@@ -89,9 +86,6 @@ function testConnectionEvictionInHttpClient() returns error? {
         runtime:sleep(5);
     }
 
-    json|error response = h1cClient->/path;
-    if response is error {
-        test:assertFail("Expected a successful response, but got an error: " + response.message());
-    }
+    json response = check h1cClient->/path;
     test:assertEquals(response, {message: "Hello from backend!"});
 }

--- a/ballerina-tests/http-client-tests/tests/client_connection_eviction.bal
+++ b/ballerina-tests/http-client-tests/tests/client_connection_eviction.bal
@@ -1,0 +1,155 @@
+// Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/lang.runtime;
+import ballerina/test;
+import ballerina/http_test_common as common;
+
+// HTTPS listener for H2 tests
+listener http:Listener httpsListener = new (https_port, secureSocket = {
+    'key: {
+        certFile: common:CERT_FILE,
+        'keyFile: common:KEY_FILE
+    }
+});
+
+// HTTP listener for H2C tests
+listener http:Listener httpListener = new (http_port);
+
+// HTTP/1.1 HTTPS listener for H1 tests
+listener http:Listener https11Listener = new (http11_https_port,
+    httpVersion = http:HTTP_1_1,
+    secureSocket = {
+        'key: {
+            certFile: common:CERT_FILE,
+            'keyFile: common:KEY_FILE
+        }
+    }
+);
+
+// HTTP/1.1 HTTP listener for H1C tests
+listener http:Listener http11Listener = new (http11_http_port, httpVersion = http:HTTP_1_1);
+
+service /api on httpsListener, httpListener, https11Listener, http11Listener {
+    resource function get path() returns json => {message: "Hello from backend!"};
+}
+
+// Common pool configuration for all tests
+http:PoolConfiguration poolConfig = {
+    maxActiveConnections: 5,
+    maxIdleConnections: 2,
+    waitTime: 5,
+    maxActiveStreamsPerConnection: 2,
+    minEvictableIdleTime: 3,
+    timeBetweenEvictionRuns: 2
+};
+
+// H2 client -> H2 server (HTTPS)
+final http:Client h2ClientHttps = check new (string`https://localhost:${https_port}/api`, config = {
+    poolConfig: poolConfig,
+    secureSocket: {
+        cert: common:CERT_FILE
+    }
+});
+
+// H2C client -> H2C server (HTTP)
+final http:Client h2cClient = check new (string`http://localhost:${http_port}/api`, config = {
+    poolConfig: poolConfig
+});
+
+// H1 client -> H1 server (HTTPS)
+final http:Client h1ClientHttps = check new (string`https://localhost:${http11_https_port}/api`, config = {
+    httpVersion: http:HTTP_1_1,
+    poolConfig: poolConfig,
+    secureSocket: {
+        cert: common:CERT_FILE
+    }
+});
+
+// H1C client -> H1C server (HTTP)
+final http:Client h1cClient = check new (string`http://localhost:${http11_http_port}/api`, config = {
+    httpVersion: http:HTTP_1_1,
+    poolConfig: poolConfig
+});
+
+@test:Config {
+    groups: ["clientConnectionEviction"]
+}
+function testConnectionEvictionInClientH2H2Scenario() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check h2ClientHttps->/path;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = h2ClientHttps->/path;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+@test:Config {
+    groups: ["clientConnectionEviction"]
+}
+function testConnectionEvictionInClientH2CH2CScenario() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check h2cClient->/path;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = h2cClient->/path;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+@test:Config {
+    groups: ["clientConnectionEviction"]
+}
+function testConnectionEvictionInClientH1H1Scenario() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check h1ClientHttps->/path;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = h1ClientHttps->/path;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+@test:Config {
+    groups: ["clientConnectionEviction"]
+}
+function testConnectionEvictionInClientH1CH1CScenario() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check h1cClient->/path;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = h1cClient->/path;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+    test:assertEquals(response, {message: "Hello from backend!"});
+}

--- a/ballerina-tests/http-client-tests/tests/passthrough_client_connection_eviction.bal
+++ b/ballerina-tests/http-client-tests/tests/passthrough_client_connection_eviction.bal
@@ -100,11 +100,7 @@ function testConnectionEvictionInH1PassthroughToH1Backend() returns error? {
         runtime:sleep(5);
     }
 
-    json|error response = passthroughH1TestClient->/h1;
-    if response is error {
-        test:assertFail("Expected a successful response, but got an error: " + response.message());
-    }
-
+    json response = check passthroughH1TestClient->/h1;
     test:assertEquals(response, {message: "Hello from backend!"});
 }
 
@@ -118,11 +114,7 @@ function testConnectionEvictionInH1PassthroughToH1CBackend() returns error? {
         runtime:sleep(5);
     }
 
-    json|error response = passthroughH1TestClient->/h1c;
-    if response is error {
-        test:assertFail("Expected a successful response, but got an error: " + response.message());
-    }
-
+    json response = check passthroughH1TestClient->/h1c;
     test:assertEquals(response, {message: "Hello from backend!"});
 }
 
@@ -136,11 +128,7 @@ function testConnectionEvictionInH1CPassthroughToH1Backend() returns error? {
         runtime:sleep(5);
     }
 
-    json|error response = passthroughH1CTestClient->/h1;
-    if response is error {
-        test:assertFail("Expected a successful response, but got an error: " + response.message());
-    }
-
+    json response = check passthroughH1CTestClient->/h1;
     test:assertEquals(response, {message: "Hello from backend!"});
 }
 
@@ -154,10 +142,6 @@ function testConnectionEvictionInH1CPassthroughToH1CBackend() returns error? {
         runtime:sleep(5);
     }
 
-    json|error response = passthroughH1CTestClient->/h1c;
-    if response is error {
-        test:assertFail("Expected a successful response, but got an error: " + response.message());
-    }
-
+    json response = check passthroughH1CTestClient->/h1c;
     test:assertEquals(response, {message: "Hello from backend!"});
 }

--- a/ballerina-tests/http-client-tests/tests/passthrough_client_connection_eviction.bal
+++ b/ballerina-tests/http-client-tests/tests/passthrough_client_connection_eviction.bal
@@ -1,0 +1,437 @@
+// Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/lang.runtime;
+import ballerina/test;
+import ballerina/http_test_common as common;
+
+// HTTPS listener for H2 tests
+listener http:Listener httpsBackendListener = new (backend_https_port, secureSocket = {
+    'key: {
+        certFile: common:CERT_FILE,
+        'keyFile: common:KEY_FILE
+    }
+});
+
+// HTTP listener for H2C tests
+listener http:Listener httpBackendListener = new (backend_http_port);
+
+// HTTP/1.1 HTTPS listener for H1 tests
+listener http:Listener https11BackendListener = new (backend_http11_https_port,
+    httpVersion = http:HTTP_1_1,
+    secureSocket = {
+        'key: {
+            certFile: common:CERT_FILE,
+            'keyFile: common:KEY_FILE
+        }
+    }
+);
+
+// HTTP/1.1 HTTP listener for H1C tests
+listener http:Listener http11BackendListener = new (backend_http11_http_port, httpVersion = http:HTTP_1_1);
+
+service /api on httpsBackendListener, httpBackendListener, https11BackendListener, http11BackendListener {
+    resource function get path() returns json => {message: "Hello from backend!"};
+}
+
+// Passthrough listeners on different ports and protocols
+listener http:Listener passthroughH2Listener = new (https_passthrough_port, secureSocket = {
+    'key: {
+        certFile: common:CERT_FILE,
+        'keyFile: common:KEY_FILE
+    }
+});
+
+listener http:Listener passthroughH2CListener = new (http_passthrough_port);
+
+listener http:Listener passthroughH1Listener = new (http11_https_passthrough_port,
+    httpVersion = http:HTTP_1_1,
+    secureSocket = {
+        'key: {
+            certFile: common:CERT_FILE,
+            'keyFile: common:KEY_FILE
+        }
+    }
+);
+
+listener http:Listener passthroughH1CListener = new (http11_http_passthrough_port, httpVersion = http:HTTP_1_1);
+
+// Pool configuration for backend clients inside passthrough services
+http:PoolConfiguration passthroughPoolConfig = {
+    maxActiveConnections: 5,
+    maxIdleConnections: 2,
+    waitTime: 5,
+    maxActiveStreamsPerConnection: 2,
+    minEvictableIdleTime: 5,
+    timeBetweenEvictionRuns: 2
+};
+
+// Clients for passthrough services to connect to backends
+final http:Client backendH2Client = check new (string `https://localhost:${backend_https_port}/api`, config = {
+    poolConfig: passthroughPoolConfig,
+    secureSocket: {
+        cert: common:CERT_FILE
+    }
+});
+
+final http:Client backendH2CClient = check new (string `http://localhost:${backend_http_port}/api`, config = {
+    poolConfig: passthroughPoolConfig
+});
+
+final http:Client backendH1Client = check new (string `https://localhost:${backend_http11_https_port}/api`, config = {
+    httpVersion: http:HTTP_1_1,
+    poolConfig: passthroughPoolConfig,
+    secureSocket: {
+        cert: common:CERT_FILE
+    }
+});
+
+final http:Client backendH1CClient = check new (string `http://localhost:${backend_http11_http_port}/api`, config = {
+    httpVersion: http:HTTP_1_1,
+    poolConfig: passthroughPoolConfig
+});
+
+// Passthrough service on H2 (HTTPS) connecting to H2 backend
+service /passthrough on passthroughH2Listener, passthroughH2CListener, passthroughH1Listener, passthroughH1CListener {
+    resource function get h2() returns json|error {
+        return backendH2Client->/path;
+    }
+
+    resource function get h2c() returns json|error {
+        return backendH2CClient->/path;
+    }
+
+    resource function get h1() returns json|error {
+        return backendH1Client->/path;
+    }
+
+    resource function get h1c() returns json|error {
+        return backendH1CClient->/path;
+    }
+}
+
+// Test clients to connect to passthrough services
+final http:Client passthroughH2TestClient = check new (string `https://localhost:${https_passthrough_port}/passthrough`, config = {
+    secureSocket: {
+        cert: common:CERT_FILE
+    }
+});
+
+final http:Client passthroughH2CTestClient = check new (string `http://localhost:${http_passthrough_port}/passthrough`, config = {});
+
+final http:Client passthroughH1TestClient = check new (string `https://localhost:${http11_https_passthrough_port}/passthrough`, config = {
+    httpVersion: http:HTTP_1_1,
+    secureSocket: {
+        cert: common:CERT_FILE
+    }
+});
+
+final http:Client passthroughH1CTestClient = check new (string `http://localhost:${http11_http_passthrough_port}/passthrough`, config = {
+    httpVersion: http:HTTP_1_1
+});
+
+// Test cases for H2 passthrough service connecting to all backend types
+@test:Config {
+    groups: ["clientConnectionEvictionInPassthrough"]
+}
+function testConnectionEvictionInH2PassthroughToH2Backend() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check passthroughH2TestClient->/h2;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = passthroughH2TestClient->/h2;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+@test:Config {
+    groups: ["clientConnectionEvictionInPassthrough"]
+}
+function testConnectionEvictionInH2PassthroughToH2CBackend() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check passthroughH2TestClient->/h2c;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = passthroughH2TestClient->/h2c;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+@test:Config {
+    groups: ["clientConnectionEvictionInPassthrough"]
+}
+function testConnectionEvictionInH2PassthroughToH1Backend() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check passthroughH2TestClient->/h1;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = passthroughH2TestClient->/h1;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+@test:Config {
+    groups: ["clientConnectionEvictionInPassthrough"]
+}
+function testConnectionEvictionInH2PassthroughToH1CBackend() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check passthroughH2TestClient->/h1c;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = passthroughH2TestClient->/h1c;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+// Test cases for H2C passthrough service connecting to all backend types
+@test:Config {
+    groups: ["clientConnectionEvictionInPassthrough"]
+}
+function testConnectionEvictionInH2CPassthroughToH2Backend() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check passthroughH2CTestClient->/h2;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = passthroughH2CTestClient->/h2;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+@test:Config {
+    groups: ["clientConnectionEvictionInPassthrough"]
+}
+function testConnectionEvictionInH2CPassthroughToH2CBackend() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check passthroughH2CTestClient->/h2c;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = passthroughH2CTestClient->/h2c;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+@test:Config {
+    groups: ["clientConnectionEvictionInPassthrough"]
+}
+function testConnectionEvictionInH2CPassthroughToH1Backend() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check passthroughH2CTestClient->/h1;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = passthroughH2CTestClient->/h1;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+@test:Config {
+    groups: ["clientConnectionEvictionInPassthrough"]
+}
+function testConnectionEvictionInH2CPassthroughToH1CBackend() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check passthroughH2CTestClient->/h1c;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = passthroughH2CTestClient->/h1c;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+// Test cases for H1 passthrough service connecting to all backend types
+@test:Config {
+    groups: ["clientConnectionEvictionInPassthrough"]
+}
+function testConnectionEvictionInH1PassthroughToH2Backend() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check passthroughH1TestClient->/h2;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = passthroughH1TestClient->/h2;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+@test:Config {
+    groups: ["clientConnectionEvictionInPassthrough"]
+}
+function testConnectionEvictionInH1PassthroughToH2CBackend() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check passthroughH1TestClient->/h2c;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = passthroughH1TestClient->/h2c;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+@test:Config {
+    groups: ["clientConnectionEvictionInPassthrough"]
+}
+function testConnectionEvictionInH1PassthroughToH1Backend() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check passthroughH1TestClient->/h1;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = passthroughH1TestClient->/h1;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+@test:Config {
+    groups: ["clientConnectionEvictionInPassthrough"]
+}
+function testConnectionEvictionInH1PassthroughToH1CBackend() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check passthroughH1TestClient->/h1c;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = passthroughH1TestClient->/h1c;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+// Test cases for H1C passthrough service connecting to all backend types
+@test:Config {
+    groups: ["clientConnectionEvictionInPassthrough"]
+}
+function testConnectionEvictionInH1CPassthroughToH2Backend() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check passthroughH1CTestClient->/h2;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = passthroughH1CTestClient->/h2;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+@test:Config {
+    groups: ["clientConnectionEvictionInPassthrough"]
+}
+function testConnectionEvictionInH1CPassthroughToH2CBackend() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check passthroughH1CTestClient->/h2c;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = passthroughH1CTestClient->/h2c;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+@test:Config {
+    groups: ["clientConnectionEvictionInPassthrough"]
+}
+function testConnectionEvictionInH1CPassthroughToH1Backend() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check passthroughH1CTestClient->/h1;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = passthroughH1CTestClient->/h1;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+
+    test:assertEquals(response, {message: "Hello from backend!"});
+}
+
+@test:Config {
+    groups: ["clientConnectionEvictionInPassthrough"]
+}
+function testConnectionEvictionInH1CPassthroughToH1CBackend() returns error? {
+    foreach int i in 0 ... 4 {
+        json _ = check passthroughH1CTestClient->/h1c;
+        // Wait until the connection becomes IDLE and evicted
+        runtime:sleep(5);
+    }
+
+    json|error response = passthroughH1CTestClient->/h1c;
+    if response is error {
+        test:assertFail("Expected a successful response, but got an error: " + response.message());
+    }
+
+    test:assertEquals(response, {message: "Hello from backend!"});
+}

--- a/ballerina-tests/http-client-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-client-tests/tests/test_service_ports.bal
@@ -43,17 +43,11 @@ const int statusCodeBindingPort2 = 9610;
 
 const int resBindingAdvancedPort = 9611;
 
-const int https_port = 9620;
-const int http_port = 9621;
 const int http11_https_port = 9622;
 const int http11_http_port = 9623;
 
-const int https_passthrough_port = 9624;
-const int http_passthrough_port = 9625;
 const int http11_https_passthrough_port = 9626;
 const int http11_http_passthrough_port = 9627;
 
-const int backend_https_port = 9628;
-const int backend_http_port = 9629;
 const int backend_http11_https_port = 9630;
-const int backend_http11_http_port = 9631;
+const int backend_http11_http_port = 9632;

--- a/ballerina-tests/http-client-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-client-tests/tests/test_service_ports.bal
@@ -42,3 +42,18 @@ const int statusCodeBindingPort1 = 9609;
 const int statusCodeBindingPort2 = 9610;
 
 const int resBindingAdvancedPort = 9611;
+
+const int https_port = 9620;
+const int http_port = 9621;
+const int http11_https_port = 9622;
+const int http11_http_port = 9623;
+
+const int https_passthrough_port = 9624;
+const int http_passthrough_port = 9625;
+const int http11_https_passthrough_port = 9626;
+const int http11_http_passthrough_port = 9627;
+
+const int backend_https_port = 9628;
+const int backend_http_port = 9629;
+const int backend_http11_https_port = 9630;
+const int backend_http11_http_port = 9631;

--- a/ballerina-tests/http2-tests/tests/http2_client_connection_eviction.bal
+++ b/ballerina-tests/http2-tests/tests/http2_client_connection_eviction.bal
@@ -67,10 +67,7 @@ function testConnectionEvictionInHttp2SecureClient() returns error? {
         runtime:sleep(5);
     }
 
-    json|error response = h2ClientHttps->/path;
-    if response is error {
-        test:assertFail("Expected a successful response, but got an error: " + response.message());
-    }
+    json response = check h2ClientHttps->/path;
     test:assertEquals(response, {message: "Hello from backend!"});
 }
 
@@ -84,9 +81,6 @@ function testConnectionEvictionInHttp2Client() returns error? {
         runtime:sleep(5);
     }
 
-    json|error response = h2cClient->/path;
-    if response is error {
-        test:assertFail("Expected a successful response, but got an error: " + response.message());
-    }
+    json response = check h2cClient->/path;
     test:assertEquals(response, {message: "Hello from backend!"});
 }

--- a/ballerina-tests/http2-tests/tests/http2_passthrough_client_connection_eviction.bal
+++ b/ballerina-tests/http2-tests/tests/http2_passthrough_client_connection_eviction.bal
@@ -89,11 +89,7 @@ function testConnectionEvictionInH2PassthroughToH2Backend() returns error? {
         runtime:sleep(5);
     }
 
-    json|error response = passthroughH2TestClient->/h2;
-    if response is error {
-        test:assertFail("Expected a successful response, but got an error: " + response.message());
-    }
-
+    json response = check passthroughH2TestClient->/h2;
     test:assertEquals(response, {message: "Hello from backend!"});
 }
 
@@ -107,11 +103,7 @@ function testConnectionEvictionInH2PassthroughToH2CBackend() returns error? {
         runtime:sleep(5);
     }
 
-    json|error response = passthroughH2TestClient->/h2c;
-    if response is error {
-        test:assertFail("Expected a successful response, but got an error: " + response.message());
-    }
-
+    json response = check passthroughH2TestClient->/h2c;
     test:assertEquals(response, {message: "Hello from backend!"});
 }
 
@@ -125,11 +117,7 @@ function testConnectionEvictionInH2CPassthroughToH2Backend() returns error? {
         runtime:sleep(5);
     }
 
-    json|error response = passthroughH2CTestClient->/h2;
-    if response is error {
-        test:assertFail("Expected a successful response, but got an error: " + response.message());
-    }
-
+    json response = check passthroughH2CTestClient->/h2;
     test:assertEquals(response, {message: "Hello from backend!"});
 }
 
@@ -143,10 +131,6 @@ function testConnectionEvictionInH2CPassthroughToH2CBackend() returns error? {
         runtime:sleep(5);
     }
 
-    json|error response = passthroughH2CTestClient->/h2c;
-    if response is error {
-        test:assertFail("Expected a successful response, but got an error: " + response.message());
-    }
-
+    json response = check passthroughH2CTestClient->/h2c;
     test:assertEquals(response, {message: "Hello from backend!"});
 }

--- a/ballerina-tests/http2-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http2-tests/tests/test_service_ports.bal
@@ -66,3 +66,12 @@ const int headerParamBindingTestPort = 9631;
 
 const int tls12Port = 9249;
 const int tls13Port = 9250;
+
+const int https_port = 9620;
+const int http_port = 9621;
+
+const int https_passthrough_port = 9624;
+const int http_passthrough_port = 9625;
+
+const int backend_https_port = 9628;
+const int backend_http_port = 9629;

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.13.6"
+version = "2.13.7"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -20,8 +20,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.13.6"
-path = "../native/build/libs/http-native-2.13.6.jar"
+version = "2.13.7"
+path = "../native/build/libs/http-native-2.13.7-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.13.6.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.13.7-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.2.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -88,7 +88,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.13.6"
+version = "2.13.7"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ This file contains all the notable changes done to the Ballerina HTTP package th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [Fix IDLE connection eviction issues with HTTP/2 connections](https://github.com/ballerina-platform/ballerina-library/issues/8129)
+
 ## [2.13.6] - 2025-04-21
 
 ### Fixed

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/channel/TargetChannel.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/channel/TargetChannel.java
@@ -32,6 +32,7 @@ import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.apache.commons.pool.impl.GenericObjectPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +60,7 @@ public class TargetChannel {
     private final ChannelFuture channelFuture;
     private final HandlerExecutor handlerExecutor;
     private final ConnectionAvailabilityFuture connectionAvailabilityFuture;
+    private GenericObjectPool pool;
 
     public TargetChannel(HttpClientChannelInitializer httpClientChannelInitializer, ChannelFuture channelFuture,
                          HttpRoute httpRoute, ConnectionAvailabilityFuture connectionAvailabilityFuture) {
@@ -70,7 +72,7 @@ public class TargetChannel {
             http2ClientChannel =
                     new Http2ClientChannel(httpClientChannelInitializer.getHttp2ConnectionManager(),
                                            httpClientChannelInitializer.getConnection(),
-                                           httpRoute, channelFuture.channel());
+                                           httpRoute, channelFuture.channel(), this);
         }
         this.connectionAvailabilityFuture = connectionAvailabilityFuture;
     }
@@ -164,5 +166,21 @@ public class TargetChannel {
 
     public HttpRoute getHttpRoute() {
         return httpRoute;
+    }
+
+    public void setPool(GenericObjectPool pool) {
+        this.pool = pool;
+    }
+
+    public void invalidate() {
+        if (pool != null) {
+            try {
+                pool.invalidateObject(this);
+            } catch (Exception e) {
+                LOG.error("Error while invalidating the channel: {}", this, e);
+            }
+        } else {
+            LOG.warn("Pool is not set for the channel: {}", this);
+        }
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/channel/TargetChannel.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/channel/TargetChannel.java
@@ -173,14 +173,14 @@ public class TargetChannel {
     }
 
     public void invalidate() {
-        if (pool != null) {
-            try {
-                pool.invalidateObject(this);
-            } catch (Exception e) {
-                LOG.error("Error while invalidating the channel: {}", this, e);
-            }
-        } else {
-            LOG.warn("Pool is not set for the channel: {}", this);
+        if (pool == null) {
+            LOG.warn("Pool is not set for the channel: {}. Cannot invalidate.", this);
+            return;
+        }
+        try {
+            pool.invalidateObject(this);
+        } catch (Exception e) {
+            LOG.error("Error while invalidating the channel: {}", this, e);
         }
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/channel/pool/ConnectionManager.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/channel/pool/ConnectionManager.java
@@ -159,6 +159,7 @@ public class ConnectionManager {
                                            GenericObjectPool trgHlrConnPool,
                                            String trgHlrConnPoolId) throws Exception {
         TargetChannel targetChannel = (TargetChannel) trgHlrConnPool.borrowObject();
+        targetChannel.setPool(trgHlrConnPool);
         if (sourceHandler != null) {
             targetChannel.setCorrelatedSource(sourceHandler);
         } else if (http2SourceHandler != null) {

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/channel/pool/PoolableTargetChannelFactoryPerSrcHndlr.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/channel/pool/PoolableTargetChannelFactoryPerSrcHndlr.java
@@ -17,6 +17,7 @@ package io.ballerina.stdlib.http.transport.contractimpl.sender.channel.pool;
 
 
 import io.ballerina.stdlib.http.transport.contractimpl.sender.channel.TargetChannel;
+import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import org.apache.commons.pool.PoolableObjectFactory;
 import org.apache.commons.pool.impl.GenericObjectPool;
@@ -58,12 +59,15 @@ public class PoolableTargetChannelFactoryPerSrcHndlr implements PoolableObjectFa
 
     @Override
     public void destroyObject(Object o) throws Exception {
-        if (((TargetChannel) o).getChannel().isActive()) {
+        TargetChannel targetChannel = (TargetChannel) o;
+        Channel nettyChannel = targetChannel.getChannel();
+        if (nettyChannel != null && nettyChannel.isActive()) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Original Channel {} is returned to the pool. ", ((TargetChannel) o).getChannel().id());
+                LOG.debug("Original Channel {} is returned to the pool. ", nettyChannel.id());
             }
             this.genericObjectPool.returnObject(o);
         } else {
+            // HTTP/2 channels go here when the channel is destroyed
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Original Channel is destroyed. ");
             }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/http2/Http2ClientChannel.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/http2/Http2ClientChannel.java
@@ -21,6 +21,7 @@ package io.ballerina.stdlib.http.transport.contractimpl.sender.http2;
 import io.ballerina.stdlib.http.transport.contract.Constants;
 import io.ballerina.stdlib.http.transport.contractimpl.common.HttpRoute;
 import io.ballerina.stdlib.http.transport.contractimpl.common.states.Http2MessageStateContext;
+import io.ballerina.stdlib.http.transport.contractimpl.sender.channel.TargetChannel;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -65,9 +66,10 @@ public class Http2ClientChannel {
     private long timeSinceMarkedAsStale = 0;
     private AtomicLong timeSinceMarkedAsIdle = new AtomicLong(0);
     private AtomicBoolean isStale = new AtomicBoolean(false);
+    private TargetChannel targetChannel;
 
     public Http2ClientChannel(Http2ConnectionManager http2ConnectionManager, Http2Connection connection,
-                              HttpRoute httpRoute, Channel channel) {
+                              HttpRoute httpRoute, Channel channel, TargetChannel targetChannel) {
         this.http2ConnectionManager = http2ConnectionManager;
         this.channel = channel;
         this.connection = connection;
@@ -77,6 +79,7 @@ public class Http2ClientChannel {
         dataEventListeners = new HashMap<>();
         inFlightMessages = new ConcurrentHashMap<>();
         promisedMessages = new ConcurrentHashMap<>();
+        this.targetChannel = targetChannel;
     }
 
     /**
@@ -363,5 +366,13 @@ public class Http2ClientChannel {
 
     HttpRoute getHttpRoute() {
         return httpRoute;
+    }
+
+    public void invalidate() {
+        if (targetChannel != null) {
+            targetChannel.invalidate();
+        } else {
+            LOG.warn("Target channel is not set for the Http2ClientChannel: {}", this);
+        }
     }
 }


### PR DESCRIPTION
## Purpose

> $Subject

Related to: https://github.com/ballerina-platform/ballerina-library/issues/8129

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [x] Checked native-image compatibility
- [ ] Checked the impact on OpenAPI generation
