### PR TITLE
[2201.12.x] Prevent auth headers in redirected requests when disallowed

### DIFF
--- a/ballerina-tests/http-misc-tests/tests/Config.toml
+++ b/ballerina-tests/http-misc-tests/tests/Config.toml
@@ -1,3 +1,8 @@
 [http_misc_tests]
 keystore = "../resources/certsandkeys/ballerinaKeystore.p12"
 truststore = "../resources/certsandkeys/ballerinaTruststore.p12"
+
+[[ballerina.auth.users]]
+username="alice"
+password="xxx"
+scopes=["write", "update"]

--- a/ballerina-tests/http-misc-tests/tests/http_redirects_test.bal
+++ b/ballerina-tests/http-misc-tests/tests/http_redirects_test.bal
@@ -20,9 +20,9 @@ import ballerina/mime;
 import ballerina/test;
 import ballerina/http_test_common as common;
 
-listener http:Listener serviceEndpoint2 = new (9102, httpVersion = http:HTTP_1_1);
+listener http:Listener serviceEndpoint2 = new (redirectTestPort1, httpVersion = http:HTTP_1_1);
 
-listener http:Listener serviceEndpoint3 = new (9103, httpVersion = http:HTTP_1_1);
+listener http:Listener serviceEndpoint3 = new (redirectTestPort2, httpVersion = http:HTTP_1_1);
 
 http:ListenerConfiguration httpsEPConfig = {
     httpVersion: http:HTTP_1_1,
@@ -34,7 +34,7 @@ http:ListenerConfiguration httpsEPConfig = {
     }
 };
 
-listener http:Listener httpsEP = new (9104, httpsEPConfig);
+listener http:Listener httpsEP = new (redirectTestPort3, httpsEPConfig);
 
 http:ClientConfiguration endPoint1Config = {
     httpVersion: http:HTTP_1_1,
@@ -64,11 +64,11 @@ http:ClientConfiguration endPoint5Config = {
     }
 };
 
-final http:Client endPoint1 = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1, followRedirects = {enabled: true, maxCount: 3});
-final http:Client endPoint2 = check new ("http://localhost:9103", endPoint2Config);
-final http:Client endPoint3 = check new ("http://localhost:9102", endPoint3Config);
-final http:Client endPoint4 = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
-final http:Client endPoint5 = check new ("https://localhost:9104", endPoint5Config);
+final http:Client endPoint1 = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1, followRedirects = {enabled: true, maxCount: 3});
+final http:Client endPoint2 = check new (string `http://localhost:${redirectTestPort2}`, endPoint2Config);
+final http:Client endPoint3 = check new (string `http://localhost:${redirectTestPort1}`, endPoint3Config);
+final http:Client endPoint4 = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
+final http:Client endPoint5 = check new (string `https://localhost:${redirectTestPort3}`, endPoint5Config);
 
 service /testRedirectService on serviceEndpoint3 {
 
@@ -231,7 +231,7 @@ service /testRedirectService on serviceEndpoint3 {
             httpVersion: http:HTTP_1_1,
             followRedirects: {enabled: true, allowAuthHeaders: true}
         };
-        http:Client endPoint4 = check new ("http://localhost:9103", endPoint4Config);
+        http:Client endPoint4 = check new (string `http://localhost:${redirectTestPort2}`, endPoint4Config);
         http:Request req = new;
         req.setHeader("Proxy-Authorization", "Basic YWxhZGRpbjpvcGVuc2VzYW1l");
         req.setTextPayload("Payload redirected");
@@ -255,7 +255,7 @@ service /testRedirectService on serviceEndpoint3 {
             httpVersion: http:HTTP_1_1,
             followRedirects: {enabled: true, allowAuthHeaders: true}
         };
-        http:Client endPoint4 = check new ("http://localhost:9103", endPoint4Config);
+        http:Client endPoint4 = check new (string `http://localhost:${redirectTestPort2}`, endPoint4Config);
         http:Response|error response = endPoint4->head("/redirect1/handleHead", {"X-Redirect-Action": "HTTP_TEMPORARY_REDIRECT"});
         if response is http:Response {
             var value = response.getHeader("X-Redirect-Details");
@@ -276,7 +276,7 @@ service /testRedirectService on serviceEndpoint3 {
             httpVersion: http:HTTP_1_1,
             followRedirects: {enabled: true, allowAuthHeaders: true}
         };
-        http:Client endPoint4 = check new ("http://localhost:9103", endPoint4Config);
+        http:Client endPoint4 = check new (string `http://localhost:${redirectTestPort2}`, endPoint4Config);
         http:Request req = new;
         req.setHeader("Proxy-Authorization", "Basic YWxhZGRpbjpvcGVuc2VzYW1l");
         req.setTextPayload("Payload redirected");
@@ -300,7 +300,7 @@ service /testRedirectService on serviceEndpoint3 {
             httpVersion: http:HTTP_1_1,
             followRedirects: {enabled: true, allowAuthHeaders: true}
         };
-        http:Client endPoint4 = check new ("http://localhost:9103", endPoint4Config);
+        http:Client endPoint4 = check new (string `http://localhost:${redirectTestPort2}`, endPoint4Config);
         http:Request req = new;
         req.setHeader("Proxy-Authorization", "Basic YWxhZGRpbjpvcGVuc2VzYW1l");
         req.setTextPayload("Payload redirected");
@@ -324,7 +324,7 @@ service /testRedirectService on serviceEndpoint3 {
             httpVersion: http:HTTP_1_1,
             followRedirects: {enabled: true, allowAuthHeaders: true}
         };
-        http:Client endPoint4 = check new ("http://localhost:9103", endPoint4Config);
+        http:Client endPoint4 = check new (string `http://localhost:${redirectTestPort2}`, endPoint4Config);
         http:Request req = new;
         req.setHeader("Proxy-Authorization", "Basic YWxhZGRpbjpvcGVuc2VzYW1l");
         req.setTextPayload("Payload redirected");
@@ -348,7 +348,7 @@ service /testRedirectService on serviceEndpoint3 {
             httpVersion: http:HTTP_1_1,
             followRedirects: {enabled: true, allowAuthHeaders: true}
         };
-        http:Client endPoint4 = check new ("http://localhost:9103", endPoint4Config);
+        http:Client endPoint4 = check new (string `http://localhost:${redirectTestPort2}`, endPoint4Config);
         http:Response|error response = endPoint4->options("/redirect1/handleOptions");
         if response is http:Response {
             var value = response.getHeader("Allow");
@@ -384,7 +384,7 @@ service /testRedirectService on serviceEndpoint3 {
     }
 
     resource function get testMultipart(http:Caller caller, http:Request req) returns error? {
-        http:Client endPoint3 = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1, followRedirects = {enabled: true});
+        http:Client endPoint3 = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1, followRedirects = {enabled: true});
         mime:Entity jsonBodyPart = new;
         jsonBodyPart.setContentDisposition(common:getContentDispositionForFormData("json part"));
         jsonBodyPart.setJson({"name": "wso2"});
@@ -412,7 +412,7 @@ service /redirect1 on serviceEndpoint3 {
 
     resource function get .(http:Caller caller, http:Request req) returns error? {
         http:Response res = new;
-        check caller->redirect(res, http:REDIRECT_TEMPORARY_REDIRECT_307, ["http://localhost:9102/redirect2"]);
+        check caller->redirect(res, http:REDIRECT_TEMPORARY_REDIRECT_307, [string `http://localhost:${redirectTestPort1}/redirect2`]);
     }
 
     resource function get round1(http:Caller caller, http:Request req) returns error? {
@@ -437,7 +437,7 @@ service /redirect1 on serviceEndpoint3 {
 
     resource function get round5(http:Caller caller, http:Request req) returns error? {
         http:Response res = new;
-        check caller->redirect(res, http:REDIRECT_FOUND_302, ["http://localhost:9102/redirect2"]);
+        check caller->redirect(res, http:REDIRECT_FOUND_302, [string `http://localhost:${redirectTestPort1}/redirect2`]);
     }
 
     resource function get qpWithRelativePath(http:Caller caller, http:Request req) returns error? {
@@ -450,7 +450,7 @@ service /redirect1 on serviceEndpoint3 {
     resource function get qpWithAbsolutePath(http:Caller caller, http:Request req) returns error? {
         http:Response res = new;
         check caller->redirect(res, http:REDIRECT_TEMPORARY_REDIRECT_307, [
-            "http://localhost:9103/redirect1/processQP?key=value&lang=ballerina"
+            string `http://localhost:${redirectTestPort2}/redirect1/processQP?key=value&lang=ballerina`
         ]);
     }
 
@@ -465,21 +465,21 @@ service /redirect1 on serviceEndpoint3 {
     resource function head handleHead(http:Caller caller, http:Request req) returns error? {
         http:Response res = new;
         check caller->redirect(res, http:REDIRECT_TEMPORARY_REDIRECT_307, [
-            "http://localhost:9102/redirect2/echo"
+            string `http://localhost:${redirectTestPort1}/redirect2/echo`
         ]);
     }
 
     resource function options handleOptions(http:Caller caller, http:Request req) returns error? {
         http:Response res = new;
         check caller->redirect(res, http:REDIRECT_TEMPORARY_REDIRECT_307, [
-            "http://localhost:9102/redirect2/echo"
+            string `http://localhost:${redirectTestPort1}/redirect2/echo`
         ]);
     }
 
     resource function 'default handlePost(http:Caller caller, http:Request req) returns error? {
         http:Response res = new;
         check caller->redirect(res, http:REDIRECT_TEMPORARY_REDIRECT_307, [
-            "http://localhost:9102/redirect2/echo"
+            string `http://localhost:${redirectTestPort1}/redirect2/echo`
         ]);
     }
 }
@@ -555,8 +555,113 @@ service /redirect3 on httpsEP {
     resource function put handlePost(http:Caller caller, http:Request req) returns error? {
         http:Response res = new;
         check caller->redirect(res, http:REDIRECT_PERMANENT_REDIRECT_308, [
-            "http://localhost:9103/redirect1/handlePost"
+            string `http://localhost:${redirectTestPort2}/redirect1/handlePost`
         ]);
+    }
+}
+
+listener http:Listener httpsAuthEP = new (redirectTestPort4, httpsEPConfig);
+
+listener http:Listener externalRedirectedEP = new (redirectTestPort5, httpVersion = http:HTTP_1_1);
+
+@http:ServiceConfig {
+    auth: [
+        {
+            fileUserStoreConfig: {},
+            scopes: ["write", "update"]
+        }
+    ]
+}
+service /api on httpsAuthEP {
+
+    resource function get redirect(boolean 'external = false) returns http:Found {
+        string redirectUrl = 'external ?
+            string `http://localhost:${redirectTestPort5}/api/hello` :
+            string `https://localhost:${redirectTestPort4}/api/hello`;
+        return {
+            headers: {
+                "Location": redirectUrl
+            }
+        };
+    }
+
+    resource function get hello() returns string {
+        return "Hello, World!";
+    }
+}
+
+service /api on externalRedirectedEP {
+
+    resource function get hello(@http:Header string? Authorization) returns string {
+        return Authorization is string ? "Hello, authenticated user!" : "Hello from external service!";
+    }
+}
+
+@test:Config {
+    groups: ["httpRedirect"]
+}
+public function testRedirectWithAllowAuthHeaders() returns error? {
+    http:ClientConfiguration clientConfig = {
+        httpVersion: http:HTTP_1_1,
+        followRedirects: {enabled: true, allowAuthHeaders: true},
+        auth: {
+            username: "alice",
+            password: "xxx"
+        },
+        secureSocket: {
+            cert: {
+                path: common:TRUSTSTORE_PATH,
+                password: "ballerina"
+            }
+        }
+    };
+    http:Client httpClient = check new (string `https://localhost:${redirectTestPort4}/api`, clientConfig);
+    string|error resp = httpClient->/redirect;
+    if resp is string {
+        test:assertEquals(resp, "Hello, World!");
+    } else {
+        test:assertFail(msg = "Found unexpected output: " + resp.message());
+    }
+
+    resp = httpClient->/redirect('external = true);
+    if resp is string {
+        test:assertEquals(resp, "Hello, authenticated user!");
+    } else {
+        test:assertFail(msg = "Found unexpected output: " + resp.message());
+    }
+}
+
+@test:Config {
+    groups: ["httpRedirect"]
+}
+public function testRedirectWithoutAuthHeaders() returns error? {
+    http:ClientConfiguration clientConfig = {
+        httpVersion: http:HTTP_1_1,
+        followRedirects: {enabled: true, allowAuthHeaders: false},
+        auth: {
+            username: "alice",
+            password: "xxx"
+        },
+        secureSocket: {
+            cert: {
+                path: common:TRUSTSTORE_PATH,
+                password: "ballerina"
+            }
+        }
+    };
+    http:Client httpClient = check new (string `https://localhost:${redirectTestPort4}/api`, clientConfig);
+    string|error resp = httpClient->/redirect;
+    if resp is error {
+        test:assertEquals(resp.message(), "Unauthorized");
+    } else {
+        test:assertFail(msg = "Expected an error but found: " + resp);
+    }
+
+    resp = httpClient->/redirect('external = true);
+    if resp is string {
+        test:assertEquals(resp, "Hello from external service!");
+    } else {
+        test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
 }
 
@@ -564,10 +669,10 @@ service /redirect3 on httpsEP {
     groups: ["httpRedirect"]
 }
 public function testHttpRedirects() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/");
     if resp is http:Response {
-        assertRedirectResponse(resp, "http://localhost:9102/redirect2");
+        assertRedirectResponse(resp, string `http://localhost:${redirectTestPort1}/redirect2`);
     } else {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
@@ -577,10 +682,10 @@ public function testHttpRedirects() returns error? {
     groups: ["httpRedirect"]
 }
 public function testMaxRedirect() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/maxRedirect");
     if resp is http:Response {
-        assertRedirectResponse(resp, "/redirect1/round5:http://localhost:9103/redirect1/round4");
+        assertRedirectResponse(resp, string `/redirect1/round5:http://localhost:${redirectTestPort2}/redirect1/round4`);
     } else {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
@@ -590,10 +695,10 @@ public function testMaxRedirect() returns error? {
     groups: ["httpRedirect"]
 }
 public function testCrossDomain() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/noRedirect");
     if resp is http:Response {
-        assertRedirectResponse(resp, "hello world:http://localhost:9102/redirect2");
+        assertRedirectResponse(resp, string `hello world:http://localhost:${redirectTestPort1}/redirect2`);
     } else {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
@@ -603,10 +708,10 @@ public function testCrossDomain() returns error? {
     groups: ["httpRedirect"]
 }
 public function testNoRedirect() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/crossDomain");
     if resp is http:Response {
-        assertRedirectResponse(resp, "hello world:http://localhost:9102/redirect2");
+        assertRedirectResponse(resp, string `hello world:http://localhost:${redirectTestPort1}/redirect2`);
     } else {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
@@ -616,7 +721,7 @@ public function testNoRedirect() returns error? {
     groups: ["httpRedirect"]
 }
 public function testRedirectOff() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/redirectOff");
     if resp is http:Response {
         assertRedirectResponse(resp, "/redirect1/round2:");
@@ -629,10 +734,10 @@ public function testRedirectOff() returns error? {
     groups: ["httpRedirect"]
 }
 public function testQPWithRelativePath() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/qpWithRelativePath");
     if resp is http:Response {
-        assertRedirectResponse(resp, "value:ballerina:http://localhost:9103/redirect1/processQP?key=value&lang=ballerina");
+        assertRedirectResponse(resp, string `value:ballerina:http://localhost:${redirectTestPort2}/redirect1/processQP?key=value&lang=ballerina`);
     } else {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
@@ -642,10 +747,10 @@ public function testQPWithRelativePath() returns error? {
     groups: ["httpRedirect"]
 }
 public function testQPWithAbsolutePath() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/qpWithAbsolutePath");
     if resp is http:Response {
-        assertRedirectResponse(resp, "value:ballerina:http://localhost:9103/redirect1/processQP?key=value&lang=ballerina");
+        assertRedirectResponse(resp, string `value:ballerina:http://localhost:${redirectTestPort2}/redirect1/processQP?key=value&lang=ballerina`);
     } else {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
@@ -655,10 +760,10 @@ public function testQPWithAbsolutePath() returns error? {
     groups: ["httpRedirect"]
 }
 public function testOriginalRequestWithQP() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/originalRequestWithQP");
     if resp is http:Response {
-        assertRedirectResponse(resp, "hello world:http://localhost:9102/redirect2");
+        assertRedirectResponse(resp, string `hello world:http://localhost:${redirectTestPort1}/redirect2`);
     } else {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
@@ -668,10 +773,10 @@ public function testOriginalRequestWithQP() returns error? {
     groups: ["httpRedirect"]
 }
 public function test303Status() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/test303");
     if resp is http:Response {
-        assertRedirectResponse(resp, "hello world:http://localhost:9102/redirect2");
+        assertRedirectResponse(resp, string `hello world:http://localhost:${redirectTestPort1}/redirect2`);
     } else {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
@@ -681,10 +786,10 @@ public function test303Status() returns error? {
     groups: ["httpRedirect"]
 }
 public function testRedirectWithHTTPs() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/httpsRedirect");
     if resp is http:Response {
-        assertRedirectResponse(resp, "HTTPs Result:https://localhost:9104/redirect3/result");
+        assertRedirectResponse(resp, string `HTTPs Result:https://localhost:${redirectTestPort3}/redirect3/result`);
     } else {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
@@ -694,10 +799,10 @@ public function testRedirectWithHTTPs() returns error? {
     groups: ["httpRedirect"]
 }
 public function testRedirectWithPOST() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/doPost");
     if resp is http:Response {
-        assertRedirectResponse(resp, "Received:Payload redirected:Proxy:http://localhost:9102/redirect2/echo");
+        assertRedirectResponse(resp, string `Received:Payload redirected:Proxy:http://localhost:${redirectTestPort1}/redirect2/echo`);
     } else {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
@@ -707,10 +812,10 @@ public function testRedirectWithPOST() returns error? {
     groups: ["httpRedirect"]
 }
 public function testRedirectWithHead() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/doHead");
     if resp is http:Response {
-        assertRedirectResponse(resp, "Received:No Proxy:HTTP_TEMPORARY_REDIRECT:http://localhost:9102/redirect2/echo");
+        assertRedirectResponse(resp, string `Received:No Proxy:HTTP_TEMPORARY_REDIRECT:http://localhost:${redirectTestPort1}/redirect2/echo`);
     } else {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
@@ -720,10 +825,10 @@ public function testRedirectWithHead() returns error? {
     groups: ["httpRedirect"]
 }
 public function testRedirectWithExecute() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/doExecute");
     if resp is http:Response {
-        assertRedirectResponse(resp, "Received:Payload redirected:Proxy:http://localhost:9102/redirect2/echo");
+        assertRedirectResponse(resp, string `Received:Payload redirected:Proxy:http://localhost:${redirectTestPort1}/redirect2/echo`);
     } else {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
@@ -733,10 +838,10 @@ public function testRedirectWithExecute() returns error? {
     groups: ["httpRedirect"]
 }
 public function testRedirectWithPatch() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/doPatch");
     if resp is http:Response {
-        assertRedirectResponse(resp, "Received:Payload redirected:Proxy:http://localhost:9102/redirect2/echo");
+        assertRedirectResponse(resp, string `Received:Payload redirected:Proxy:http://localhost:${redirectTestPort1}/redirect2/echo`);
     } else {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
@@ -746,10 +851,10 @@ public function testRedirectWithPatch() returns error? {
     groups: ["httpRedirect"]
 }
 public function testRedirectWithDelete() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/doDelete");
     if resp is http:Response {
-        assertRedirectResponse(resp, "Received:Payload redirected:Proxy:http://localhost:9102/redirect2/echo");
+        assertRedirectResponse(resp, string `Received:Payload redirected:Proxy:http://localhost:${redirectTestPort1}/redirect2/echo`);
     } else {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
@@ -759,10 +864,10 @@ public function testRedirectWithDelete() returns error? {
     groups: ["httpRedirect"]
 }
 public function testRedirectWithOptions() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/doOptions");
     if resp is http:Response {
-        assertRedirectResponse(resp, "Received:OPTIONS, HEAD:http://localhost:9102/redirect2/echo");
+        assertRedirectResponse(resp, string `Received:OPTIONS, HEAD:http://localhost:${redirectTestPort1}/redirect2/echo`);
     } else {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
@@ -772,10 +877,10 @@ public function testRedirectWithOptions() returns error? {
     groups: ["httpRedirect"]
 }
 public function testWithHTTPs() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/doSecurePut");
     if resp is http:Response {
-        assertRedirectResponse(resp, "Received:Secure payload:No Proxy:http://localhost:9102/redirect2/echo");
+        assertRedirectResponse(resp, string `Received:Secure payload:No Proxy:http://localhost:${redirectTestPort1}/redirect2/echo`);
     } else {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }
@@ -785,10 +890,10 @@ public function testWithHTTPs() returns error? {
     groups: ["httpRedirect"]
 }
 public function testMultipartRedirect() returns error? {
-    http:Client httpClient = check new ("http://localhost:9103", httpVersion = http:HTTP_1_1);
+    http:Client httpClient = check new (string `http://localhost:${redirectTestPort2}`, httpVersion = http:HTTP_1_1);
     http:Response|error resp = httpClient->get("/testRedirectService/testMultipart");
     if resp is http:Response {
-        assertRedirectResponse(resp, "{\"name\":\"wso2\"}:http://localhost:9102/redirect2/echo");
+        assertRedirectResponse(resp, string `{"name":"wso2"}:http://localhost:${redirectTestPort1}/redirect2/echo`);
     } else {
         test:assertFail(msg = "Found unexpected output: " + resp.message());
     }

--- a/ballerina-tests/http-misc-tests/tests/test_service_ports.bal
+++ b/ballerina-tests/http-misc-tests/tests/test_service_ports.bal
@@ -14,73 +14,79 @@
 // specific language governing permissions and limitations
 // under the License.
 
-const int generalPort = 9000;
-const int http2GeneralPort = 9100;
-const int serviceTestPort = 9011;
+const generalPort = 9000;
+const http2GeneralPort = 9100;
+const serviceTestPort = 9011;
 
-const int proxyTestPort1 = 9019;
-const int proxyTestPort2 = 9020;
+const proxyTestPort1 = 9019;
+const proxyTestPort2 = 9020;
 
-const int requestLimitsTestPort1 = 9501;
-const int requestLimitsTestPort2 = 9502;
-const int requestLimitsTestPort3 = 9503;
-const int requestLimitsTestPort4 = 9504;
-const int requestLimitsTestPort5 = 19555;
-const int requestLimitsTestPort6 = 9556;
+const requestLimitsTestPort1 = 9501;
+const requestLimitsTestPort2 = 9502;
+const requestLimitsTestPort3 = 9503;
+const requestLimitsTestPort4 = 9504;
+const requestLimitsTestPort5 = 19555;
+const requestLimitsTestPort6 = 9556;
 
-const int responseLimitsTestPort1 = 9557;
-const int responseLimitsTestPort2 = 9558;
-const int responseLimitsTestPort3 = 9559;
-const int responseLimitsTestPort4 = 9560;
-const int responseLimitsTestPort5 = 9561;
+const responseLimitsTestPort1 = 9557;
+const responseLimitsTestPort2 = 9558;
+const responseLimitsTestPort3 = 9559;
+const responseLimitsTestPort4 = 9560;
+const responseLimitsTestPort5 = 9561;
 
-const int callerActionTestPort = 9545;
-const int callerRespondTestPort = 9625;
+const callerActionTestPort = 9545;
+const callerRespondTestPort = 9625;
 
-const int echoServiceTestPort = 9506;
-const int echoHttpsServiceTestPort = 9507;
+const echoServiceTestPort = 9506;
+const echoHttpsServiceTestPort = 9507;
 
-const int expectContinueTestPort1 = 9529;
-const int expectContinueTestPort2 = 9530;
+const expectContinueTestPort1 = 9529;
+const expectContinueTestPort2 = 9530;
 
-const int httpHeaderTestPort1 = 9515;
-const int httpHeaderTestPort2 = 9516;
+const httpHeaderTestPort1 = 9515;
+const httpHeaderTestPort2 = 9516;
 
-const int multipleClientTestPort1 = 9535;
-const int multipleClientTestPort2 = 9536;
+const multipleClientTestPort1 = 9535;
+const multipleClientTestPort2 = 9536;
 
-const int pipeliningTestPort1 = 9531;
-const int pipeliningTestPort2 = 9532;
-const int pipeliningTestPort3 = 9533;
+const pipeliningTestPort1 = 9531;
+const pipeliningTestPort2 = 9532;
+const pipeliningTestPort3 = 9533;
 
-const int httpUrlTestPort1 = 9521;
-const int httpUrlTestPort2 = 9522;
+const httpUrlTestPort1 = 9521;
+const httpUrlTestPort2 = 9522;
 
-const int httpPayloadTestPort1 = 9518;
-const int httpPayloadTestPort2 = 9519;
+const httpPayloadTestPort1 = 9518;
+const httpPayloadTestPort2 = 9519;
 
-const int outRequestTypeTestPort = 9563;
-const int outRequestOptionsTestPort = 9564;
+const outRequestTypeTestPort = 9563;
+const outRequestOptionsTestPort = 9564;
 
-const int introResTestPort = 9023;
-const int acceptEncodingHeaderTestPort = 9500;
-const int dirtyResponseTestPort = 9546;
-const int ecommerceTestPort = 9508;
-const int httpEnumMethodsTestPort = 9575;
-const int idleTimeoutTestPort = 9514;
-const int keepAliveClientTestPort = 9534;
-const int httpOptionsTestPort = 9517;
-const int payloadAccessAfterRespondingTestPort = 9576;
-const int httpVerbTestPort = 9523;
-const int serviceChainingTestPort = 9525;
-const int httpRoutingTestPort = 9524;
-const int socketConfigListenerPort = 9635;
-const int requestPayloadRetrievalTestPort = 9637;
-const int resourceFunctionTestPort = 9537;
-const int httpReturnNilTestPort = 9566;
-const int reuseRequestTestPort = 9528;
-const int serializeXmlTestPort = 9540;
-const int httpServerFieldTestPort1 = 9513;
-const int httpStatusCodeTestPort = 9520;
-const int readonlyQueryTestPort = 9607;
-const int resourceReturnTestPort = 9554;
+const redirectTestPort1 = 9102;
+const redirectTestPort2 = 9103;
+const redirectTestPort3 = 9104;
+const redirectTestPort4 = 9105;
+const redirectTestPort5 = 9106;
+
+const introResTestPort = 9023;
+const acceptEncodingHeaderTestPort = 9500;
+const dirtyResponseTestPort = 9546;
+const ecommerceTestPort = 9508;
+const httpEnumMethodsTestPort = 9575;
+const idleTimeoutTestPort = 9514;
+const keepAliveClientTestPort = 9534;
+const httpOptionsTestPort = 9517;
+const payloadAccessAfterRespondingTestPort = 9576;
+const httpVerbTestPort = 9523;
+const serviceChainingTestPort = 9525;
+const httpRoutingTestPort = 9524;
+const socketConfigListenerPort = 9635;
+const requestPayloadRetrievalTestPort = 9637;
+const resourceFunctionTestPort = 9537;
+const httpReturnNilTestPort = 9566;
+const reuseRequestTestPort = 9528;
+const serializeXmlTestPort = 9540;
+const httpServerFieldTestPort1 = 9513;
+const httpStatusCodeTestPort = 9520;
+const readonlyQueryTestPort = 9607;
+const resourceReturnTestPort = 9554;

--- a/ballerina/http_request.bal
+++ b/ballerina/http_request.bal
@@ -45,11 +45,13 @@ public class Request {
 
     private mime:Entity? entity = ();
     private boolean dirtyRequest;
+    private boolean redirected;
     boolean noEntityBody;
 
     public isolated function init() {
         self.dirtyRequest = false;
         self.noEntityBody = false;
+        self.redirected = false;
         self.entity = self.createNewEntity();
     }
 
@@ -437,10 +439,10 @@ public class Request {
     # + contentType - The content type of the payload. This is an optional parameter.
     #                 The `application/json` is the default value
     isolated function setAnydataAsJsonPayload(anydata payload, string? contentType = ()) {
-     mime:Entity entity = self.getEntityWithoutBodyAndHeaders();
-     setJson(entity, jsondata:toJson(payload), self.getContentType(), contentType);
-     self.setEntityAndUpdateContentTypeHeader(entity);
-}
+        mime:Entity entity = self.getEntityWithoutBodyAndHeaders();
+        setJson(entity, jsondata:toJson(payload), self.getContentType(), contentType);
+        self.setEntityAndUpdateContentTypeHeader(entity);
+    }
 
     # Sets an `xml` as the payload. If the content-type header is not set then this method set content-type
     # headers with the default content-type, which is `application/xml`. Any existing content-type can be
@@ -659,6 +661,14 @@ public class Request {
             cookiesInRequest = parseCookieHeader(cookieValue);
         }
         return cookiesInRequest;
+    }
+
+    isolated function isRedirected() returns boolean {
+        return self.redirected;
+    }
+
+    isolated function markAsRedirected() {
+        self.redirected = true;
     }
 }
 

--- a/ballerina/redirect_http_client.bal
+++ b/ballerina/redirect_http_client.bal
@@ -472,6 +472,7 @@ isolated function getRedirectMethod(HttpOperation httpVerb, Response response) r
 }
 
 isolated function createRedirectRequest(Request request, boolean allowAuthHeaders) returns Request {
+    request.markAsRedirected();
     if allowAuthHeaders {
         return request;
     }

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - [Address `CVE-2025-55163` Netty vulnerability](https://github.com/ballerina-platform/ballerina-library/issues/8174)
+- [Prevent auth headers in redirected requests when disallowed](https://github.com/ballerina-platform/ballerina-library/issues/8216)
 
 ## [2.14.3] - 2025-08-04
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,13 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - [Address `CVE-2025-58056` and `CVE-2025-58057` security vulnerabilities in Netty](https://github.com/ballerina-platform/ballerina-library/issues/8214)
+- [Prevent auth headers in redirected requests when disallowed](https://github.com/ballerina-platform/ballerina-library/issues/8216)
 
 ## [2.14.4] - 2025-08-21
 
 ### Fixed
 
 - [Address `CVE-2025-55163` Netty vulnerability](https://github.com/ballerina-platform/ballerina-library/issues/8174)
-- [Prevent auth headers in redirected requests when disallowed](https://github.com/ballerina-platform/ballerina-library/issues/8216)
 
 ## [2.14.3] - 2025-08-04
 


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8216

## Examples

N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
- [x] Checked native-image compatibility
- [ ] ~Checked the impact on OpenAPI generation~
