### PR TITLE
Fix scope validation to require all expected scopes instead of partial match

### DIFF
--- a/ballerina-tests/http-security-tests/tests/auth_listener_auth_handler_test.bal
+++ b/ballerina-tests/http-security-tests/tests/auth_listener_auth_handler_test.bal
@@ -720,3 +720,101 @@ function testListenerOAuth2HandlerAuthnFailure() {
         test:assertEquals(auth2?.body, "Authorization header not available.");
     }
 }
+
+@test:Config {}
+isolated function testListenerFileUserStoreBasicAuthHandlerAllScopesMatchSuccess() {
+    http:ListenerFileUserStoreBasicAuthHandler handler = new;
+    string basicAuthToken = "YWxpY2U6eHh4";
+    string headerValue = http:AUTH_SCHEME_BASIC + " " + basicAuthToken;
+    auth:UserDetails|http:Unauthorized authn = handler.authenticate(headerValue);
+    if authn is auth:UserDetails {
+        test:assertEquals(authn?.scopes, ["write", "update"]);
+    } else {
+        test:assertFail("Test Failed!");
+    }
+
+    http:Forbidden? authz = handler.authorize(<auth:UserDetails>authn, ["write", "update"]);
+    if authz is http:Forbidden {
+        test:assertFail("Test Failed! All required scopes are present but authorization failed.");
+    }
+}
+
+@test:Config {}
+isolated function testListenerFileUserStoreBasicAuthHandlerPartialScopeMatchFailure() {
+    http:ListenerFileUserStoreBasicAuthHandler handler = new;
+    string basicAuthToken = "YWxpY2U6eHh4";
+    string headerValue = http:AUTH_SCHEME_BASIC + " " + basicAuthToken;
+    auth:UserDetails|http:Unauthorized authn = handler.authenticate(headerValue);
+    if authn is auth:UserDetails {
+        test:assertEquals(authn?.scopes, ["write", "update"]);
+    } else {
+        test:assertFail("Test Failed!");
+    }
+
+    http:Forbidden? authz = handler.authorize(<auth:UserDetails>authn, ["write", "admin"]);
+    if authz is () {
+        test:assertFail("Test Failed! Expected authorization failure when a required scope is missing.");
+    }
+}
+
+@test:Config {}
+isolated function testListenerJwtAuthHandlerMultipleScopesSubsetSuccess() {
+    http:JwtValidatorConfig config = {
+        issuer: "wso2",
+        audience: "ballerina",
+        signatureConfig: {
+            trustStoreConfig: {
+                trustStore: {
+                    path: TRUSTSTORE_PATH,
+                    password: "ballerina"
+                },
+                certAlias: "ballerina"
+            }
+        },
+        scopeKey: "scp"
+    };
+    http:ListenerJwtAuthHandler handler = new(config);
+    string headerValue = http:AUTH_SCHEME_BEARER + " " + JWT1_1;
+    jwt:Payload|http:Unauthorized authn = handler.authenticate(headerValue);
+    if authn is jwt:Payload {
+        test:assertEquals(authn["scp"], "read write update");
+    } else {
+        test:assertFail("Test Failed!");
+    }
+
+    http:Forbidden? authz = handler.authorize(<jwt:Payload>authn, ["write", "update"]);
+    if authz is http:Forbidden {
+        test:assertFail("Test Failed! All required scopes are present but authorization failed.");
+    }
+}
+
+@test:Config {}
+isolated function testListenerJwtAuthHandlerSingleActualScopeMultipleExpectedFailure() {
+    http:JwtValidatorConfig config = {
+        issuer: "wso2",
+        audience: "ballerina",
+        signatureConfig: {
+            trustStoreConfig: {
+                trustStore: {
+                    path: TRUSTSTORE_PATH,
+                    password: "ballerina"
+                },
+                certAlias: "ballerina"
+            }
+        },
+        scopeKey: "scp"
+    };
+    http:ListenerJwtAuthHandler handler = new(config);
+    string headerValue = http:AUTH_SCHEME_BEARER + " " + JWT1;
+    jwt:Payload|http:Unauthorized authn = handler.authenticate(headerValue);
+    if authn is jwt:Payload {
+        test:assertEquals(authn["scp"], "write");
+    } else {
+        test:assertFail("Test Failed!");
+    }
+
+    http:Forbidden? authz = handler.authorize(<jwt:Payload>authn, ["write", "update"]);
+    if authz is () {
+        test:assertFail("Test Failed! Expected authorization failure when a required scope is missing.");
+    }
+}

--- a/ballerina/auth_utils.bal
+++ b/ballerina/auth_utils.bal
@@ -95,7 +95,7 @@ isolated function extractAuthorizationHeader(Request|Headers|string data) return
     }
 }
 
-// Match the expectedScopes with actualScopes and return if there is a match.
+// Match the expectedScopes with actualScopes and return if expectedScopes is a subset of actualScopes.
 isolated function matchScopes(string|string[] actualScopes, string|string[] expectedScopes) returns boolean {
     if expectedScopes is string {
         if actualScopes is string {
@@ -110,18 +110,29 @@ isolated function matchScopes(string|string[] actualScopes, string|string[] expe
     } else {
         if actualScopes is string {
             foreach string expectedScope in expectedScopes {
-                if actualScopes == expectedScope {
-                    return true;
+                if actualScopes != expectedScope {
+                    log:printDebug("Failed to match the scopes. Expected '" + expectedScopes.toString() +
+                                   "', but found '" + actualScopes.toString() + "'");
+                    return false;
                 }
             }
+            return true;
         } else {
-            foreach string actualScope in actualScopes {
-                foreach string expectedScope in expectedScopes {
+            foreach string expectedScope in expectedScopes {
+                boolean found = false;
+                foreach string actualScope in actualScopes {
                     if actualScope == expectedScope {
-                        return true;
+                        found = true;
+                        break;
                     }
                 }
+                if !found {
+                    log:printDebug("Failed to match the scopes. Expected '" + expectedScopes.toString() +
+                                   "', but found '" + actualScopes.toString() + "'");
+                    return false;
+                }
             }
+            return true;
         }
     }
     log:printDebug("Failed to match the scopes. Expected '" + expectedScopes.toString() + "', but found '" +


### PR DESCRIPTION
## Purpose

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
- [ ] Checked the impact on OpenAPI generation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request fixes the scope validation logic to enforce stricter authorization requirements by ensuring all expected scopes are validated instead of allowing partial matches.

## Changes

### Core Logic Updates
Modified the `matchScopes` function in `auth_utils.bal` to require all expected scopes to be present in the actual scopes. The function now:
- Iterates through each expected scope and returns false if any expected scope is missing from the actual scopes
- Adds debug logging to track scope mismatches
- Applies this stricter validation consistently for both string and array scope comparisons

### Test Coverage
Added four new test cases in `auth_listener_auth_handler_test.bal` to validate the updated scope matching behavior:
- Tests for `http:ListenerFileUserStoreBasicAuthHandler` covering exact scope match success and failure when required scopes are unavailable
- Tests for `http:ListenerJwtAuthHandler` covering subset matching success and failure scenarios with different scope configurations

## Impact
This change improves authorization enforcement by ensuring that all required scopes are validated, making scope-based access control more reliable and predictable. The implementation requires a complete match of expected scopes against actual scopes rather than accepting partial matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->