### PR TITLE
Fix scope validation to require all expected scopes instead of partial match

### DIFF
--- a/ballerina-tests/http-advanced-tests/Ballerina.toml
+++ b/ballerina-tests/http-advanced-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_advanced_tests"
-version = "2.16.0"
+version = "2.16.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.0"
+version = "2.16.1"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-advanced-tests/Dependencies.toml
+++ b/ballerina-tests/http-advanced-tests/Dependencies.toml
@@ -82,7 +82,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.15.4"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -116,7 +116,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_advanced_tests"
-version = "2.16.0"
+version = "2.16.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},
@@ -136,7 +136,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.16.0"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "http"},
@@ -289,7 +289,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.13.0"
+version = "2.17.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -330,7 +330,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.1"
+version = "1.7.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina-tests/http-client-tests/Ballerina.toml
+++ b/ballerina-tests/http-client-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_client_tests"
-version = "2.16.0"
+version = "2.16.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.0"
+version = "2.16.1"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-client-tests/Dependencies.toml
+++ b/ballerina-tests/http-client-tests/Dependencies.toml
@@ -82,7 +82,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.15.4"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -116,7 +116,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_client_tests"
-version = "2.16.0"
+version = "2.16.1"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -136,7 +136,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.16.0"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "http"},
@@ -289,7 +289,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.13.0"
+version = "2.17.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -330,7 +330,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.1"
+version = "1.7.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina-tests/http-dispatching-tests/Ballerina.toml
+++ b/ballerina-tests/http-dispatching-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_dispatching_tests"
-version = "2.16.0"
+version = "2.16.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.0"
+version = "2.16.1"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-dispatching-tests/Dependencies.toml
+++ b/ballerina-tests/http-dispatching-tests/Dependencies.toml
@@ -79,7 +79,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.15.4"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -113,7 +113,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_dispatching_tests"
-version = "2.16.0"
+version = "2.16.1"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
@@ -135,7 +135,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.16.0"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "http"},
@@ -324,7 +324,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.13.0"
+version = "2.17.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -365,7 +365,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.1"
+version = "1.7.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina-tests/http-interceptor-tests/Ballerina.toml
+++ b/ballerina-tests/http-interceptor-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_interceptor_tests"
-version = "2.16.0"
+version = "2.16.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.0"
+version = "2.16.1"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-interceptor-tests/Dependencies.toml
+++ b/ballerina-tests/http-interceptor-tests/Dependencies.toml
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.15.4"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -110,7 +110,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_interceptor_tests"
-version = "2.16.0"
+version = "2.16.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -126,7 +126,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.16.0"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "http"},
@@ -279,7 +279,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.13.0"
+version = "2.17.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -317,7 +317,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.1"
+version = "1.7.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina-tests/http-misc-tests/Ballerina.toml
+++ b/ballerina-tests/http-misc-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_misc_tests"
-version = "2.16.0"
+version = "2.16.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.0"
+version = "2.16.1"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-misc-tests/Dependencies.toml
+++ b/ballerina-tests/http-misc-tests/Dependencies.toml
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.15.4"
+version = "2.16.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -103,7 +103,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_misc_tests"
-version = "2.16.0"
+version = "2.16.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -122,7 +122,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.16.0"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "http"},
@@ -265,7 +265,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.13.0"
+version = "2.17.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -303,7 +303,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.1"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina-tests/http-resiliency-tests/Ballerina.toml
+++ b/ballerina-tests/http-resiliency-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_resiliency_tests"
-version = "2.16.0"
+version = "2.16.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.0"
+version = "2.16.1"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-resiliency-tests/Dependencies.toml
+++ b/ballerina-tests/http-resiliency-tests/Dependencies.toml
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.15.4"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -110,7 +110,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_resiliency_tests"
-version = "2.16.0"
+version = "2.16.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "http_test_common"},
@@ -127,7 +127,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.16.0"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "http"},
@@ -280,7 +280,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.13.0"
+version = "2.17.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.1"
+version = "1.7.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina-tests/http-security-tests/Ballerina.toml
+++ b/ballerina-tests/http-security-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.16.0"
+version = "2.16.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.0"
+version = "2.16.1"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-security-tests/Dependencies.toml
+++ b/ballerina-tests/http-security-tests/Dependencies.toml
@@ -79,7 +79,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.15.4"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -113,7 +113,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.16.0"
+version = "2.16.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "http"},
@@ -131,7 +131,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.16.0"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "http"},
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.13.0"
+version = "2.17.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -322,7 +322,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.1"
+version = "1.7.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina-tests/http-security-tests/tests/auth_client_declarative_design_test.bal
+++ b/ballerina-tests/http-security-tests/tests/auth_client_declarative_design_test.bal
@@ -42,7 +42,7 @@ final http:Client declarativeClientEP = check new("https://localhost:" + secured
         audience: ["ballerina"],
         jwtId: "100078234ba23",
         keyId: "NTAxZmMxNDMyZDg3MTU1ZGM0MzEzODJhZWI4NDNlZDU1OGFkNjFiMQ",
-        customClaims: { "scp": "write" },
+        customClaims: { "scp": "write update" },
         signatureConfig: {
             config: {
                 keyStore: {

--- a/ballerina-tests/http-security-tests/tests/auth_client_imperative_design_test.bal
+++ b/ballerina-tests/http-security-tests/tests/auth_client_imperative_design_test.bal
@@ -46,7 +46,7 @@ final http:Client imperativeClientEP = check new("https://localhost:" + securedL
 @test:Config {}
 function testImperativeEnrichRequest() returns error? {
     http:BearerTokenConfig config = {
-        token: JWT1
+        token: JWT1_1
     };
     http:ClientBearerTokenAuthHandler handler = new(config);
     http:Request request = createDummyRequest();
@@ -58,7 +58,7 @@ function testImperativeEnrichRequest() returns error? {
 @test:Config {}
 function testImperativeEnrichHeaders() returns error? {
     http:BearerTokenConfig config = {
-        token: JWT1
+        token: JWT1_1
     };
     http:ClientBearerTokenAuthHandler handler = new(config);
     map<string|string[]> headers = {};
@@ -72,7 +72,7 @@ function testImperativeEnrichHeaders() returns error? {
 @test:Config {}
 function testImperativeGetSecurityHeaders() returns error? {
     http:BearerTokenConfig config = {
-        token: JWT1
+        token: JWT1_1
     };
     http:ClientBearerTokenAuthHandler handler = new(config);
     map<string|string[]> result = check handler.getSecurityHeaders();

--- a/ballerina-tests/http-security-tests/tests/auth_listener_auth_handler_test.bal
+++ b/ballerina-tests/http-security-tests/tests/auth_listener_auth_handler_test.bal
@@ -720,3 +720,101 @@ function testListenerOAuth2HandlerAuthnFailure() {
         test:assertEquals(auth2?.body, "Authorization header not available.");
     }
 }
+
+@test:Config {}
+isolated function testListenerFileUserStoreBasicAuthHandlerAllScopesMatchSuccess() {
+    http:ListenerFileUserStoreBasicAuthHandler handler = new;
+    string basicAuthToken = "YWxpY2U6eHh4";
+    string headerValue = http:AUTH_SCHEME_BASIC + " " + basicAuthToken;
+    auth:UserDetails|http:Unauthorized authn = handler.authenticate(headerValue);
+    if authn is auth:UserDetails {
+        test:assertEquals(authn?.scopes, ["write", "update"]);
+    } else {
+        test:assertFail("Test Failed!");
+    }
+
+    http:Forbidden? authz = handler.authorize(<auth:UserDetails>authn, ["write", "update"]);
+    if authz is http:Forbidden {
+        test:assertFail("Test Failed! All required scopes are present but authorization failed.");
+    }
+}
+
+@test:Config {}
+isolated function testListenerFileUserStoreBasicAuthHandlerPartialScopeMatchFailure() {
+    http:ListenerFileUserStoreBasicAuthHandler handler = new;
+    string basicAuthToken = "YWxpY2U6eHh4";
+    string headerValue = http:AUTH_SCHEME_BASIC + " " + basicAuthToken;
+    auth:UserDetails|http:Unauthorized authn = handler.authenticate(headerValue);
+    if authn is auth:UserDetails {
+        test:assertEquals(authn?.scopes, ["write", "update"]);
+    } else {
+        test:assertFail("Test Failed!");
+    }
+
+    http:Forbidden? authz = handler.authorize(<auth:UserDetails>authn, ["write", "admin"]);
+    if authz is () {
+        test:assertFail("Test Failed! Expected authorization failure when a required scope is missing.");
+    }
+}
+
+@test:Config {}
+isolated function testListenerJwtAuthHandlerMultipleScopesSubsetSuccess() {
+    http:JwtValidatorConfig config = {
+        issuer: "wso2",
+        audience: "ballerina",
+        signatureConfig: {
+            trustStoreConfig: {
+                trustStore: {
+                    path: TRUSTSTORE_PATH,
+                    password: "ballerina"
+                },
+                certAlias: "ballerina"
+            }
+        },
+        scopeKey: "scp"
+    };
+    http:ListenerJwtAuthHandler handler = new(config);
+    string headerValue = http:AUTH_SCHEME_BEARER + " " + JWT1_1;
+    jwt:Payload|http:Unauthorized authn = handler.authenticate(headerValue);
+    if authn is jwt:Payload {
+        test:assertEquals(authn["scp"], "read write update");
+    } else {
+        test:assertFail("Test Failed!");
+    }
+
+    http:Forbidden? authz = handler.authorize(<jwt:Payload>authn, ["write", "update"]);
+    if authz is http:Forbidden {
+        test:assertFail("Test Failed! All required scopes are present but authorization failed.");
+    }
+}
+
+@test:Config {}
+isolated function testListenerJwtAuthHandlerSingleActualScopeMultipleExpectedFailure() {
+    http:JwtValidatorConfig config = {
+        issuer: "wso2",
+        audience: "ballerina",
+        signatureConfig: {
+            trustStoreConfig: {
+                trustStore: {
+                    path: TRUSTSTORE_PATH,
+                    password: "ballerina"
+                },
+                certAlias: "ballerina"
+            }
+        },
+        scopeKey: "scp"
+    };
+    http:ListenerJwtAuthHandler handler = new(config);
+    string headerValue = http:AUTH_SCHEME_BEARER + " " + JWT1;
+    jwt:Payload|http:Unauthorized authn = handler.authenticate(headerValue);
+    if authn is jwt:Payload {
+        test:assertEquals(authn["scp"], "write");
+    } else {
+        test:assertFail("Test Failed!");
+    }
+
+    http:Forbidden? authz = handler.authorize(<jwt:Payload>authn, ["write", "update"]);
+    if authz is () {
+        test:assertFail("Test Failed! Expected authorization failure when a required scope is missing.");
+    }
+}

--- a/ballerina-tests/http-security-tests/tests/auth_listener_declarative_design_test.bal
+++ b/ballerina-tests/http-security-tests/tests/auth_listener_declarative_design_test.bal
@@ -197,7 +197,6 @@ service /jwtAuth on authListener {
 
 @test:Config {}
 function testJwtAuthServiceAuthSuccess() {
-    assertSuccess(sendBearerTokenRequest("/jwtAuth", JWT1));
     assertSuccess(sendBearerTokenRequest("/jwtAuth", JWT1_1));
     assertSuccess(sendBearerTokenRequest("/jwtAuth", JWT1_2));
     assertSuccess(sendJwtRequest("/jwtAuth"));
@@ -205,6 +204,7 @@ function testJwtAuthServiceAuthSuccess() {
 
 @test:Config {}
 function testJwtAuthServiceAuthzFailure() {
+    assertForbidden(sendBearerTokenRequest("/jwtAuth", JWT1));
     assertForbidden(sendBearerTokenRequest("/jwtAuth", JWT2));
     assertForbidden(sendBearerTokenRequest("/jwtAuth", JWT2_1));
     assertForbidden(sendBearerTokenRequest("/jwtAuth", JWT2_2));
@@ -345,7 +345,6 @@ function testBasicAuthResourceAuthnFailure() {
 
 @test:Config {}
 function testJwtAuthResourceAuthSuccess() {
-    assertSuccess(sendBearerTokenRequest("/foo/jwtAuth", JWT1));
     assertSuccess(sendBearerTokenRequest("/foo/jwtAuth", JWT1_1));
     assertSuccess(sendBearerTokenRequest("/foo/jwtAuth", JWT1_2));
     assertSuccess(sendJwtRequest("/foo/jwtAuth"));
@@ -353,6 +352,7 @@ function testJwtAuthResourceAuthSuccess() {
 
 @test:Config {}
 function testJwtAuthResourceAuthzFailure() {
+    assertForbidden(sendBearerTokenRequest("/foo/jwtAuth", JWT1));
     assertForbidden(sendBearerTokenRequest("/foo/jwtAuth", JWT2));
     assertForbidden(sendBearerTokenRequest("/foo/jwtAuth", JWT2_1));
     assertForbidden(sendBearerTokenRequest("/foo/jwtAuth", JWT2_2));
@@ -434,7 +434,6 @@ service /ignoreOAuth2 on authListener {
 
 @test:Config {}
 function testServiceResourceAuthSuccess() {
-    assertSuccess(sendBearerTokenRequest("/ignoreOAuth2/jwtAuth", JWT1));
     assertSuccess(sendBearerTokenRequest("/ignoreOAuth2/jwtAuth", JWT1_1));
     assertSuccess(sendBearerTokenRequest("/ignoreOAuth2/jwtAuth", JWT1_2));
     assertSuccess(sendJwtRequest("/ignoreOAuth2/jwtAuth"));
@@ -442,6 +441,7 @@ function testServiceResourceAuthSuccess() {
 
 @test:Config {}
 function testServiceResourceAuthzFailure() {
+    assertForbidden(sendBearerTokenRequest("/ignoreOAuth2/jwtAuth", JWT1));
     assertForbidden(sendBearerTokenRequest("/ignoreOAuth2/jwtAuth", JWT2));
     assertForbidden(sendBearerTokenRequest("/ignoreOAuth2/jwtAuth", JWT2_1));
     assertForbidden(sendBearerTokenRequest("/ignoreOAuth2/jwtAuth", JWT2_2));
@@ -491,7 +491,6 @@ service /ignoreScopes on authListener {
 
 @test:Config {}
 function testScopesOverwrittenResourceAuthSuccess() {
-    assertSuccess(sendBearerTokenRequest("/ignoreScopes/jwtAuth", JWT1));
     assertSuccess(sendBearerTokenRequest("/ignoreScopes/jwtAuth", JWT1_1));
     assertSuccess(sendBearerTokenRequest("/ignoreScopes/jwtAuth", JWT1_2));
     assertSuccess(sendJwtRequest("/ignoreScopes/jwtAuth"));
@@ -499,6 +498,7 @@ function testScopesOverwrittenResourceAuthSuccess() {
 
 @test:Config {}
 function testScopesOverwrittenResourceAuthzFailure() {
+    assertForbidden(sendBearerTokenRequest("/ignoreScopes/jwtAuth", JWT1));
     assertForbidden(sendBearerTokenRequest("/ignoreScopes/jwtAuth", JWT2));
     assertForbidden(sendBearerTokenRequest("/ignoreScopes/jwtAuth", JWT2_1));
     assertForbidden(sendBearerTokenRequest("/ignoreScopes/jwtAuth", JWT2_2));
@@ -547,7 +547,6 @@ service /appendScopes on authListener {
 
 @test:Config {}
 function testScopesAppendingResourceAuthSuccess() {
-    assertSuccess(sendBearerTokenRequest("/appendScopes/jwtAuth", JWT1));
     assertSuccess(sendBearerTokenRequest("/appendScopes/jwtAuth", JWT1_1));
     assertSuccess(sendBearerTokenRequest("/appendScopes/jwtAuth", JWT1_2));
     assertSuccess(sendJwtRequest("/appendScopes/jwtAuth"));
@@ -555,6 +554,7 @@ function testScopesAppendingResourceAuthSuccess() {
 
 @test:Config {}
 function testScopesAppendingResourceAuthzFailure() {
+    assertForbidden(sendBearerTokenRequest("/appendScopes/jwtAuth", JWT1));
     assertForbidden(sendBearerTokenRequest("/appendScopes/jwtAuth", JWT2));
     assertForbidden(sendBearerTokenRequest("/appendScopes/jwtAuth", JWT2_1));
     assertForbidden(sendBearerTokenRequest("/appendScopes/jwtAuth", JWT2_2));
@@ -618,7 +618,6 @@ service /multipleAuth on authListener {
 
 @test:Config {}
 function testMultipleAuthServiceAuthSuccess() {
-    assertSuccess(sendBearerTokenRequest("/multipleAuth", JWT1));
     assertSuccess(sendBearerTokenRequest("/multipleAuth", JWT1_1));
     assertSuccess(sendBearerTokenRequest("/multipleAuth", JWT1_2));
     assertSuccess(sendJwtRequest("/multipleAuth"));
@@ -626,6 +625,7 @@ function testMultipleAuthServiceAuthSuccess() {
 
 @test:Config {}
 function testMultipleAuthServiceAuthzFailure() {
+    assertForbidden(sendBearerTokenRequest("/multipleAuth", JWT1));
     assertForbidden(sendBearerTokenRequest("/multipleAuth", JWT2));
     assertForbidden(sendBearerTokenRequest("/multipleAuth", JWT2_1));
     assertForbidden(sendBearerTokenRequest("/multipleAuth", JWT2_2));
@@ -690,7 +690,6 @@ service /bar on authListener {
 
 @test:Config {}
 function testMultipleAuthResourceAuthSuccess() {
-    assertSuccess(sendBearerTokenRequest("/bar/multipleAuth", JWT1));
     assertSuccess(sendBearerTokenRequest("/bar/multipleAuth", JWT1_1));
     assertSuccess(sendBearerTokenRequest("/bar/multipleAuth", JWT1_2));
     assertSuccess(sendJwtRequest("/bar/multipleAuth"));
@@ -698,6 +697,7 @@ function testMultipleAuthResourceAuthSuccess() {
 
 @test:Config {}
 function testMultipleAuthResourceAuthzFailure() {
+    assertForbidden(sendBearerTokenRequest("/bar/multipleAuth", JWT1));
     assertForbidden(sendBearerTokenRequest("/bar/multipleAuth", JWT2));
     assertForbidden(sendBearerTokenRequest("/bar/multipleAuth", JWT2_1));
     assertForbidden(sendBearerTokenRequest("/bar/multipleAuth", JWT2_2));
@@ -810,7 +810,6 @@ service /resourcepath on authListener {
 
 @test:Config {}
 function testResourceWithNoPathAuthSuccess() {
-    assertSuccess(sendBearerTokenRequest("/resourcepath", JWT1));
     assertSuccess(sendBearerTokenRequest("/resourcepath", JWT1_1));
     assertSuccess(sendBearerTokenRequest("/resourcepath", JWT1_2));
     assertSuccess(sendJwtRequest("/resourcepath"));
@@ -818,6 +817,7 @@ function testResourceWithNoPathAuthSuccess() {
 
 @test:Config {}
 function testResourceWithNoPathAuthzFailure() {
+    assertForbidden(sendBearerTokenRequest("/resourcepath", JWT1));
     assertForbidden(sendBearerTokenRequest("/resourcepath", JWT2));
     assertForbidden(sendBearerTokenRequest("/resourcepath", JWT2_1));
     assertForbidden(sendBearerTokenRequest("/resourcepath", JWT2_2));
@@ -831,7 +831,6 @@ function testResourceWithNoPathAuthnFailure() {
 
 @test:Config {}
 function testResourceWithSpecialPathAuthSuccess() {
-    assertSuccess(sendBearerTokenRequest("/resourcepath/foo%24bar%40", JWT1));
     assertSuccess(sendBearerTokenRequest("/resourcepath/foo%24bar%40", JWT1_1));
     assertSuccess(sendBearerTokenRequest("/resourcepath/foo%24bar%40", JWT1_2));
     assertSuccess(sendJwtRequest("/resourcepath/foo%24bar%40"));
@@ -839,6 +838,7 @@ function testResourceWithSpecialPathAuthSuccess() {
 
 @test:Config {}
 function testResourceWithSpecialPathAuthzFailure() {
+    assertForbidden(sendBearerTokenRequest("/resourcepath/foo%24bar%40", JWT1));
     assertForbidden(sendBearerTokenRequest("/resourcepath/foo%24bar%40", JWT2));
     assertForbidden(sendBearerTokenRequest("/resourcepath/foo%24bar%40", JWT2_1));
     assertForbidden(sendBearerTokenRequest("/resourcepath/foo%24bar%40", JWT2_2));

--- a/ballerina-tests/http-security-tests/tests/auth_listener_imperative_design_test.bal
+++ b/ballerina-tests/http-security-tests/tests/auth_listener_imperative_design_test.bal
@@ -75,9 +75,6 @@ service /imperative on authListener {
 
 @test:Config {}
 function testImperativeAuthSuccess() {
-    assertSuccess(sendBearerTokenRequest("/imperative/foo", JWT1));
-    assertSuccess(sendBearerTokenRequest("/imperative/bar", JWT1));
-    assertSuccess(sendBearerTokenRequest("/imperative/baz", JWT1));
     assertSuccess(sendBearerTokenRequest("/imperative/foo", JWT1_1));
     assertSuccess(sendBearerTokenRequest("/imperative/bar", JWT1_1));
     assertSuccess(sendBearerTokenRequest("/imperative/baz", JWT1_1));
@@ -88,6 +85,9 @@ function testImperativeAuthSuccess() {
 
 @test:Config {}
 function testImperativeAuthzFailure() {
+    assertForbidden(sendBearerTokenRequest("/imperative/foo", JWT1));
+    assertForbidden(sendBearerTokenRequest("/imperative/bar", JWT1));
+    assertForbidden(sendBearerTokenRequest("/imperative/baz", JWT1));
     assertForbidden(sendBearerTokenRequest("/imperative/foo", JWT2));
     assertForbidden(sendBearerTokenRequest("/imperative/bar", JWT2));
     assertForbidden(sendBearerTokenRequest("/imperative/baz", JWT2));

--- a/ballerina-tests/http-security-tests/tests/test_commons.bal
+++ b/ballerina-tests/http-security-tests/tests/test_commons.bal
@@ -277,7 +277,7 @@ isolated function sendJwtRequest(string path) returns http:Response|http:ClientE
         audience: ["ballerina"],
         jwtId: "100078234ba23",
         keyId: "NTAxZmMxNDMyZDg3MTU1ZGM0MzEzODJhZWI4NDNlZDU1OGFkNjFiMQ",
-        customClaims: {"scp": "write"},
+        customClaims: {"scp": "write update"},
         signatureConfig: {
             config: {
                 keyStore: {

--- a/ballerina-tests/http-service-tests/Ballerina.toml
+++ b/ballerina-tests/http-service-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_service_tests"
-version = "2.16.0"
+version = "2.16.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.0"
+version = "2.16.1"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.1-SNAPSHOT.jar"

--- a/ballerina-tests/http-service-tests/Dependencies.toml
+++ b/ballerina-tests/http-service-tests/Dependencies.toml
@@ -79,7 +79,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.15.4"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -113,7 +113,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_service_tests"
-version = "2.16.0"
+version = "2.16.1"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
@@ -132,7 +132,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.16.0"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "http"},
@@ -285,7 +285,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.13.0"
+version = "2.17.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -326,7 +326,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.1"
+version = "1.7.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina-tests/http-test-common/Ballerina.toml
+++ b/ballerina-tests/http-test-common/Ballerina.toml
@@ -1,4 +1,4 @@
 [package]
 org = "ballerina"
 name = "http_test_common"
-version = "2.16.0"
+version = "2.16.1"

--- a/ballerina-tests/http-test-common/Dependencies.toml
+++ b/ballerina-tests/http-test-common/Dependencies.toml
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.15.4"
+version = "2.16.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -103,7 +103,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.16.0"
+version = "2.16.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},
@@ -236,7 +236,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.13.0"
+version = "2.17.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -277,7 +277,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.1"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina-tests/http2-tests/Ballerina.toml
+++ b/ballerina-tests/http2-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http2_tests"
-version = "2.16.0"
+version = "2.16.1"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.0"
+version = "2.16.1"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.0.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.1-SNAPSHOT.jar"

--- a/ballerina-tests/http2-tests/Dependencies.toml
+++ b/ballerina-tests/http2-tests/Dependencies.toml
@@ -79,7 +79,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.15.4"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -113,7 +113,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http2_tests"
-version = "2.16.0"
+version = "2.16.1"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
@@ -132,7 +132,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.16.0"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "http"},
@@ -285,7 +285,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.13.0"
+version = "2.17.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -326,7 +326,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.1"
+version = "1.7.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.16.0"
+version = "2.16.1"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -20,8 +20,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.16.0"
-path = "../native/build/libs/http-native-2.16.0.jar"
+version = "2.16.1"
+path = "../native/build/libs/http-native-2.16.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.16.0.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.16.1-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.4.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -88,7 +88,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.16.0"
+version = "2.16.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -298,7 +298,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/auth_utils.bal
+++ b/ballerina/auth_utils.bal
@@ -95,7 +95,7 @@ isolated function extractAuthorizationHeader(Request|Headers|string data) return
     }
 }
 
-// Match the expectedScopes with actualScopes and return if there is a match.
+// Match the expectedScopes with actualScopes and return if expectedScopes is a subset of actualScopes.
 isolated function matchScopes(string|string[] actualScopes, string|string[] expectedScopes) returns boolean {
     if expectedScopes is string {
         if actualScopes is string {
@@ -110,18 +110,29 @@ isolated function matchScopes(string|string[] actualScopes, string|string[] expe
     } else {
         if actualScopes is string {
             foreach string expectedScope in expectedScopes {
-                if actualScopes == expectedScope {
-                    return true;
+                if actualScopes != expectedScope {
+                    log:printDebug("Failed to match the scopes. Expected '" + expectedScopes.toString() +
+                                   "', but found '" + actualScopes.toString() + "'");
+                    return false;
                 }
             }
+            return true;
         } else {
-            foreach string actualScope in actualScopes {
-                foreach string expectedScope in expectedScopes {
+            foreach string expectedScope in expectedScopes {
+                boolean found = false;
+                foreach string actualScope in actualScopes {
                     if actualScope == expectedScope {
-                        return true;
+                        found = true;
+                        break;
                     }
                 }
+                if !found {
+                    log:printDebug("Failed to match the scopes. Expected '" + expectedScopes.toString() +
+                                   "', but found '" + actualScopes.toString() + "'");
+                    return false;
+                }
             }
+            return true;
         }
     }
     log:printDebug("Failed to match the scopes. Expected '" + expectedScopes.toString() + "', but found '" +

--- a/integration-tests/Ballerina.toml
+++ b/integration-tests/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 org = "ballerina"
 name = "integration_tests"
-version = "2.16.0"
+version = "2.16.1"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-test-utils"
 scope = "testOnly"
-path = "../test-utils/build/libs/http-test-utils-2.16.0-SNAPSHOT.jar"
+path = "../test-utils/build/libs/http-test-utils-2.16.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/integration-tests/Dependencies.toml
+++ b/integration-tests/Dependencies.toml
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.16.0"
+version = "2.16.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -110,7 +110,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "integration_tests"
-version = "2.16.0"
+version = "2.16.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},


### PR DESCRIPTION
## Purpose

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
- [ ] Checked the impact on OpenAPI generation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This pull request tightens scope validation so that all expected scopes must be present in the actual scopes (no partial matches). The change makes authorization checks stricter by requiring complete scope compliance.

Key changes
- Core logic
  - Modified matchScopes in ballerina/auth_utils.bal to require that every expected scope is present in the actual scopes. The function now returns false immediately if any expected scope is missing and emits debug logging on failures; existing behavior for expectedScopes as a single string is preserved.

- Tests
  - Added four isolated tests in ballerina-tests/http-security-tests/tests/auth_listener_auth_handler_test.bal to verify authorization succeeds when all required scopes are present and fails when any expected scope is missing. Tests cover both file-based BasicAuth and JWT auth handlers.
  - Adjusted several existing security tests and test utilities: some test assertions and JWT test inputs were updated to align with the stricter scope semantics (e.g., JWT tokens and client custom claims updated).

- Version and dependency updates
  - Bumped package/test module versions from 2.16.0 → 2.16.1 across multiple test modules and updated native/test artifact paths to corresponding 2.16.1-SNAPSHOT jars.
  - Updated generated Dependencies.toml files to newer test/transitive dependency versions (including log and observe).
  - Two automated commits updated native JAR references.

Notes
- PR template fields for Purpose and Examples are empty. Checklist items for linked issue, changelog update, tests added, spec update, native-image compatibility check, and OpenAPI impact check are present but remain unchecked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->