### PR TITLE
Fix OpenAPI spec generation compiler plugin tests

### DIFF
--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/OpenAPISpecGenerationTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/OpenAPISpecGenerationTest.java
@@ -19,6 +19,7 @@
 package io.ballerina.stdlib.http.compiler;
 
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -37,7 +38,17 @@ public class OpenAPISpecGenerationTest {
             .toAbsolutePath();
     private static final Path DISTRIBUTION_PATH = Paths.get("../", "target", "ballerina-runtime")
             .toAbsolutePath();
+    private static final String[] OPENAPI_SAMPLE_PACKAGES = {
+            "sample_package_20", "sample_package_42", "sample_package_43", "sample_package_44",
+            "sample_package_45", "sample_package_46", "sample_package_47", "sample_package_48", "sample_package_49"
+    };
 
+    @AfterMethod(alwaysRun = true)
+    public void cleanOpenApiSampleTargets() throws IOException {
+        for (String pkg : OPENAPI_SAMPLE_PACKAGES) {
+            deleteDirectories(RESOURCE_DIRECTORY.resolve(pkg));
+        }
+    }
 
     @Test
     public void testSpecGenerationWithSimpleService() throws Exception {
@@ -46,7 +57,6 @@ public class OpenAPISpecGenerationTest {
         Path actualFile = projectDirPath.resolve("target/openapi").resolve("service_openapi.yaml");
         Path expectedFile = RESOURCE_DIRECTORY.resolve("../yaml_files").resolve("service_openapi_3.yaml");
         verifySpecContent(actualFile, expectedFile);
-        deleteDirectories(projectDirPath);
     }
 
     @Test
@@ -55,7 +65,6 @@ public class OpenAPISpecGenerationTest {
         executeBallerinaCommand(projectDirPath, true);
         Path openApiDir = projectDirPath.resolve("target/openapi");
         Assert.assertTrue(Files.notExists(openApiDir));
-        deleteDirectories(projectDirPath);
     }
 
     @Test
@@ -67,7 +76,6 @@ public class OpenAPISpecGenerationTest {
         Path actualFile = projectDirPath.resolve("target/openapi").resolve("service_352312370_openapi.yaml");
         Path expectedFile = RESOURCE_DIRECTORY.resolve("../yaml_files").resolve("service_openapi_2.yaml");
         verifySpecContent(actualFile, expectedFile);
-        deleteDirectories(projectDirPath);
     }
 
     @Test
@@ -77,7 +85,6 @@ public class OpenAPISpecGenerationTest {
         Path actualFile = projectDirPath.resolve("target/openapi").resolve("userservice_openapi.yaml");
         Path expectedFile = RESOURCE_DIRECTORY.resolve("../yaml_files").resolve("service_openapi_4.yaml");
         verifySpecContent(actualFile, expectedFile);
-        deleteDirectories(projectDirPath);
     }
 
     @Test
@@ -85,8 +92,7 @@ public class OpenAPISpecGenerationTest {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("sample_package_49");
         executeBallerinaCommand(projectDirPath, true);
         Path openApiDir = projectDirPath.resolve("target/openapi");
-        Assert.assertTrue(Files.notExists(openApiDir), "OpenAPI directory should exist");
-        deleteDirectories(projectDirPath);
+        Assert.assertTrue(Files.notExists(openApiDir), "OpenAPI directory should not exist");
     }
 
     @Test
@@ -96,7 +102,6 @@ public class OpenAPISpecGenerationTest {
         Path actualFile = projectDirPath.resolve("target/openapi").resolve("service_openapi.yaml");
         Path expectedFile = RESOURCE_DIRECTORY.resolve("../yaml_files").resolve("service_openapi_1.yaml");
         verifySpecContent(actualFile, expectedFile);
-        deleteDirectories(projectDirPath);
     }
 
     @Test
@@ -107,7 +112,6 @@ public class OpenAPISpecGenerationTest {
                 .resolve("api_v1_openapi.yaml");
         Path expectedFile = RESOURCE_DIRECTORY.resolve("../yaml_files").resolve("complex_openapi.yaml");
         verifySpecContent(actualFile, expectedFile);
-        deleteDirectories(projectDirPath);
     }
 
     @Test
@@ -116,7 +120,6 @@ public class OpenAPISpecGenerationTest {
         executeBallerinaCommand(projectDirPath, false);
         Path yamlFile = projectDirPath.resolve("target/openapi").resolve("service_openapi.yaml");
         Assert.assertTrue(Files.notExists(yamlFile), "OpenAPI spec file should not be generated: " + yamlFile);
-        deleteDirectories(projectDirPath);
     }
 
     @Test
@@ -125,7 +128,6 @@ public class OpenAPISpecGenerationTest {
         executeBallerinaCommand(projectDirPath, false);
         Path yamlFile = projectDirPath.resolve("target/openapi").resolve("service_openapi.yaml");
         Assert.assertTrue(Files.notExists(yamlFile), "OpenAPI spec file should not be generated: " + yamlFile);
-        deleteDirectories(projectDirPath);
     }
 
     @Test
@@ -141,7 +143,6 @@ public class OpenAPISpecGenerationTest {
                     .collect(Collectors.toList());
         }
         Assert.assertEquals(yamlFiles.size(), 5);
-        deleteDirectories(projectDirPath);
     }
 
     public void addJavaAgents(Map<String, String> envProperties) {

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_42/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_42/service.bal
@@ -53,10 +53,6 @@ type SuccessResponse record {|
     json data?;
 |};
 
-type Caller record {|
-    int id;
-|};
-
 map<User> userStore = {};
 
 service /api/v1 on new http:Listener(9090) {
@@ -313,19 +309,7 @@ service /api/v1 on new http:Listener(9090) {
         return "done";
     }
 
-    resource function get callerInf(@http:CallerInfo Caller abc) returns string {
-        return "Caller ID: " + abc.id.toString();
-    }
-
-    resource function get callerErr1(@http:CallerInfo string abc) returns string {
-        return "Invalid caller info type";
-    }
-
-    resource function post callerErr2(@http:CallerInfo @http:Payload Caller abc) returns string {
-        return "Invalid annotation combination";
-    }
-
-    resource function get callerErr3(@http:CallerInfo Caller abc) returns string {
-        return "Caller test: " + abc.id.toString();
+    resource function get callerInf(@http:CallerInfo http:Caller abc) returns error? {
+        return;
     }
 }

--- a/compiler-plugin-tests/src/test/resources/yaml_files/complex_openapi.yaml
+++ b/compiler-plugin-tests/src/test/resources/yaml_files/complex_openapi.yaml
@@ -3,34 +3,34 @@ info:
   title: Api V1
   version: 0.1.0
 servers:
-  - url: "{server}:{port}/api/v1"
-    variables:
-      server:
-        default: http://localhost
-      port:
-        default: "9090"
+- url: "{server}:{port}/api/v1"
+  variables:
+    server:
+      default: http://localhost
+    port:
+      default: "9090"
 paths:
   /users:
     get:
       operationId: getUsers
       parameters:
-        - name: department
-          in: query
-          schema:
-            type: string
-            nullable: true
-        - name: minAge
-          in: query
-          schema:
-            type: integer
-            format: int64
-            nullable: true
-        - name: maxAge
-          in: query
-          schema:
-            type: integer
-            format: int64
-            nullable: true
+      - name: department
+        in: query
+        schema:
+          type: string
+          nullable: true
+      - name: minAge
+        in: query
+        schema:
+          type: integer
+          format: int64
+          nullable: true
+      - name: maxAge
+        in: query
+        schema:
+          type: integer
+          format: int64
+          nullable: true
       responses:
         "200":
           description: Ok
@@ -38,10 +38,10 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - type: array
-                    items:
-                      $ref: '#/components/schemas/User'
-                  - $ref: '#/components/schemas/ErrorResponse'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/User'
+                - $ref: '#/components/schemas/ErrorResponse'
         "400":
           description: BadRequest
           content:
@@ -63,8 +63,8 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/User'
-                  - $ref: '#/components/schemas/ErrorResponse'
+                - $ref: '#/components/schemas/User'
+                - $ref: '#/components/schemas/ErrorResponse'
         "400":
           description: BadRequest
           content:
@@ -74,11 +74,11 @@ paths:
     delete:
       operationId: deleteUsers
       parameters:
-        - name: confirm
-          in: query
-          schema:
-            type: string
-            nullable: true
+      - name: confirm
+        in: query
+        schema:
+          type: string
+          nullable: true
       responses:
         "200":
           description: Ok
@@ -86,8 +86,8 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/SuccessResponse'
-                  - $ref: '#/components/schemas/ErrorResponse'
+                - $ref: '#/components/schemas/SuccessResponse'
+                - $ref: '#/components/schemas/ErrorResponse'
         "400":
           description: BadRequest
           content:
@@ -98,11 +98,11 @@ paths:
     get:
       operationId: getUsersId
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           description: Ok
@@ -110,8 +110,8 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/User'
-                  - $ref: '#/components/schemas/ErrorResponse'
+                - $ref: '#/components/schemas/User'
+                - $ref: '#/components/schemas/ErrorResponse'
         "400":
           description: BadRequest
           content:
@@ -121,11 +121,11 @@ paths:
     delete:
       operationId: deleteUsersId
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           description: Ok
@@ -133,8 +133,8 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/SuccessResponse'
-                  - $ref: '#/components/schemas/ErrorResponse'
+                - $ref: '#/components/schemas/SuccessResponse'
+                - $ref: '#/components/schemas/ErrorResponse'
         "400":
           description: BadRequest
           content:
@@ -144,11 +144,11 @@ paths:
     patch:
       operationId: patchUsersId
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -162,8 +162,8 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/User'
-                  - $ref: '#/components/schemas/ErrorResponse'
+                - $ref: '#/components/schemas/User'
+                - $ref: '#/components/schemas/ErrorResponse'
         "400":
           description: BadRequest
           content:
@@ -208,10 +208,10 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - type: array
-                    items:
-                      $ref: '#/components/schemas/User'
-                  - $ref: '#/components/schemas/ErrorResponse'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/User'
+                - $ref: '#/components/schemas/ErrorResponse'
         "400":
           description: BadRequest
           content:
@@ -222,16 +222,16 @@ paths:
     patch:
       operationId: patchUsersDepartmentOlddeptNewdept
       parameters:
-        - name: oldDept
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: newDept
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: oldDept
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: newDept
+        in: path
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           description: Ok
@@ -239,8 +239,8 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/SuccessResponse'
-                  - $ref: '#/components/schemas/ErrorResponse'
+                - $ref: '#/components/schemas/SuccessResponse'
+                - $ref: '#/components/schemas/ErrorResponse'
         "400":
           description: BadRequest
           content:
@@ -250,114 +250,25 @@ paths:
   /callerInf:
     get:
       operationId: getCallerinf
-      parameters:
-        - name: abc
-          in: query
-          required: true
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Caller'
       responses:
-        "200":
-          description: Ok
-          content:
-            text/plain:
-              schema:
-                type: string
-        "400":
-          description: BadRequest
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorPayload'
-  /callerErr1:
-    get:
-      operationId: getCallererr1
-      parameters:
-        - name: abc
-          in: query
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Ok
-          content:
-            text/plain:
-              schema:
-                type: string
-        "400":
-          description: BadRequest
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorPayload'
-  /callerErr2:
-    post:
-      operationId: postCallererr2
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Caller'
-        required: true
-      responses:
-        "201":
-          description: Created
-          content:
-            text/plain:
-              schema:
-                type: string
-        "400":
-          description: BadRequest
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorPayload'
-  /callerErr3:
-    get:
-      operationId: getCallererr3
-      parameters:
-        - name: abc
-          in: query
-          required: true
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Caller'
-      responses:
-        "200":
-          description: Ok
-          content:
-            text/plain:
-              schema:
-                type: string
-        "400":
-          description: BadRequest
+        "202":
+          description: Accepted
+        "500":
+          description: InternalServerError
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorPayload'
 components:
   schemas:
-    Caller:
-      required:
-        - id
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int64
-      additionalProperties: false
     ErrorPayload:
       required:
-        - message
-        - method
-        - path
-        - reason
-        - status
-        - timestamp
+      - message
+      - method
+      - path
+      - reason
+      - status
+      - timestamp
       type: object
       properties:
         timestamp:
@@ -375,9 +286,9 @@ components:
           type: string
     ErrorResponse:
       required:
-        - code
-        - message
-        - timestamp
+      - code
+      - message
+      - timestamp
       type: object
       properties:
         message:
@@ -389,7 +300,7 @@ components:
       additionalProperties: false
     SuccessResponse:
       required:
-        - message
+      - message
       type: object
       properties:
         message:
@@ -399,12 +310,12 @@ components:
       additionalProperties: false
     User:
       required:
-        - age
-        - createdAt
-        - email
-        - id
-        - name
-        - updatedAt
+      - age
+      - createdAt
+      - email
+      - id
+      - name
+      - updatedAt
       type: object
       properties:
         id:
@@ -425,9 +336,9 @@ components:
       additionalProperties: false
     UserInput:
       required:
-        - age
-        - email
-        - name
+      - age
+      - email
+      - name
       type: object
       properties:
         name:


### PR DESCRIPTION
## Summary
Fixes flaky and failing \OpenAPISpecGenerationTest\ cases seen in CI (stdlib level builds).

## Changes
- **Test cleanup:** \@AfterMethod(alwaysRun = true)\ removes \	arget/\ (and generated \Dependencies.toml\) for all OpenAPI sample packages after every test, so a failed \erifySpecContent\ no longer leaves \	arget/openapi\ and breaks \	estSpecGenerationWithoutFlag\.
- **sample_package_42:** Align with current \http:Caller\ / \@http:CallerInfo\ rules (valid \callerInf\ resource, remove invalid \callerErr*\ resources and the conflicting local \Caller\ record type).
- **complex_openapi.yaml:** Regenerated golden to match OpenAPI output from Ballerina 2201.13.0 with current HTTP module behavior.

## Notes
- Invalid \CallerInfo\ combinations remain covered in other compiler-plugin test packages (e.g. sample_package_43, sample_package_6).


Made with [Cursor](https://cursor.com)