### PR TITLE
Fix virtual thread pinning by replacing synchronized block with ReentrantLock

### DIFF
--- a/ballerina-tests/http-advanced-tests/Ballerina.toml
+++ b/ballerina-tests/http-advanced-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_advanced_tests"
-version = "2.16.1"
+version = "2.16.2"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.1"
+version = "2.16.2"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.1.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.2-SNAPSHOT.jar"

--- a/ballerina-tests/http-client-tests/Ballerina.toml
+++ b/ballerina-tests/http-client-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_client_tests"
-version = "2.16.1"
+version = "2.16.2"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.1"
+version = "2.16.2"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.1.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.2-SNAPSHOT.jar"

--- a/ballerina-tests/http-dispatching-tests/Ballerina.toml
+++ b/ballerina-tests/http-dispatching-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_dispatching_tests"
-version = "2.16.1"
+version = "2.16.2"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.1"
+version = "2.16.2"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.1.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.2-SNAPSHOT.jar"

--- a/ballerina-tests/http-interceptor-tests/Ballerina.toml
+++ b/ballerina-tests/http-interceptor-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_interceptor_tests"
-version = "2.16.1"
+version = "2.16.2"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.1"
+version = "2.16.2"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.1.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.2-SNAPSHOT.jar"

--- a/ballerina-tests/http-misc-tests/Ballerina.toml
+++ b/ballerina-tests/http-misc-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_misc_tests"
-version = "2.16.1"
+version = "2.16.2"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.1"
+version = "2.16.2"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.1.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.2-SNAPSHOT.jar"

--- a/ballerina-tests/http-resiliency-tests/Ballerina.toml
+++ b/ballerina-tests/http-resiliency-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_resiliency_tests"
-version = "2.16.1"
+version = "2.16.2"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.1"
+version = "2.16.2"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.1.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.2-SNAPSHOT.jar"

--- a/ballerina-tests/http-security-tests/Ballerina.toml
+++ b/ballerina-tests/http-security-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_security_tests"
-version = "2.16.1"
+version = "2.16.2"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.1"
+version = "2.16.2"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.1.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.2-SNAPSHOT.jar"

--- a/ballerina-tests/http-service-tests/Ballerina.toml
+++ b/ballerina-tests/http-service-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http_service_tests"
-version = "2.16.1"
+version = "2.16.2"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.1"
+version = "2.16.2"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.1.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.2-SNAPSHOT.jar"

--- a/ballerina-tests/http-test-common/Ballerina.toml
+++ b/ballerina-tests/http-test-common/Ballerina.toml
@@ -1,4 +1,4 @@
 [package]
 org = "ballerina"
 name = "http_test_common"
-version = "2.16.1"
+version = "2.16.2"

--- a/ballerina-tests/http-test-common/Dependencies.toml
+++ b/ballerina-tests/http-test-common/Dependencies.toml
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.16.1"
+version = "2.16.2"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -103,7 +103,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.16.1"
+version = "2.16.2"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/http2-tests/Ballerina.toml
+++ b/ballerina-tests/http2-tests/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerina"
 name = "http2_tests"
-version = "2.16.1"
+version = "2.16.2"
 
 [[dependency]]
 org = "ballerina"
 name = "http_test_common"
 repository = "local"
-version = "2.16.1"
+version = "2.16.2"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 scope = "testOnly"
-path = "../../test-utils/build/libs/http-test-utils-2.16.1.jar"
+path = "../../test-utils/build/libs/http-test-utils-2.16.2-SNAPSHOT.jar"

--- a/ballerina-tests/http2-tests/Dependencies.toml
+++ b/ballerina-tests/http2-tests/Dependencies.toml
@@ -79,7 +79,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.16.1"
+version = "2.16.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -113,7 +113,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http2_tests"
-version = "2.16.1"
+version = "2.16.2"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
@@ -132,7 +132,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http_test_common"
-version = "2.16.1"
+version = "2.16.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "http"},

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.16.1"
+version = "2.17.0"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -20,8 +20,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.16.1"
-path = "../native/build/libs/http-native-2.16.1.jar"
+version = "2.17.0"
+path = "../native/build/libs/http-native-2.17.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.17.0"
+version = "2.16.2"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -20,8 +20,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.17.0"
-path = "../native/build/libs/http-native-2.17.0-SNAPSHOT.jar"
+version = "2.16.2"
+path = "../native/build/libs/http-native-2.16.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.16.1.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.17.0-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.4.0.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.17.0-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.16.2-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.4.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -88,7 +88,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.16.1"
+version = "2.17.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -88,7 +88,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.17.0"
+version = "2.16.2"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ This file contains all the notable changes done to the Ballerina HTTP package th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [Fix Virtual Thread Pinning Due to Synchronized Block](https://github.com/ballerina-platform/ballerina-library/issues/8772)
+
 ## [2.16.1] - 2026-04-07
 
 ### Fixed

--- a/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/pipelining/PipeliningHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/pipelining/PipeliningHandler.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Queue;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static io.ballerina.stdlib.http.api.HttpUtil.sendOutboundResponse;
 
@@ -79,7 +80,9 @@ public class PipeliningHandler {
                                                             PipelinedResponse pipelinedResponse) {
         HttpResponseFuture responseFuture = null;
 
-        synchronized (sourceContext.channel().attr(Constants.RESPONSE_QUEUE).get()) {
+        ReentrantLock pipelineLock = sourceContext.channel().attr(Constants.PIPELINE_LOCK).get();
+        pipelineLock.lock();
+        try {
             Queue<PipelinedResponse> responseQueue = sourceContext.channel().attr(Constants.RESPONSE_QUEUE).get();
             if (thresholdReached(sourceContext, responseQueue)) {
                 return null;
@@ -112,6 +115,8 @@ public class PipeliningHandler {
                 }
             }
             return responseFuture;
+        } finally {
+            pipelineLock.unlock();
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contract/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contract/Constants.java
@@ -22,6 +22,7 @@ import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.EventExecutorGroup;
 
 import java.util.Queue;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Common Constants used by gate way.
@@ -283,6 +284,7 @@ public final class Constants {
             .valueOf("MAX_RESPONSES_ALLOWED_TO_BE_QUEUED");
     public static final AttributeKey<Queue> RESPONSE_QUEUE = AttributeKey.valueOf("RESPONSE_QUEUE");
     public static final AttributeKey<Long> NEXT_SEQUENCE_NUMBER = AttributeKey.valueOf("NEXT_SEQUENCE_NUMBER");
+    public static final AttributeKey<ReentrantLock> PIPELINE_LOCK = AttributeKey.valueOf("PIPELINE_LOCK");
     public static final AttributeKey<EventExecutorGroup> PIPELINING_EXECUTOR = AttributeKey
             .valueOf("PIPELINING_EXECUTOR");
 

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/SourceHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/SourceHandler.java
@@ -52,6 +52,7 @@ import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static io.ballerina.stdlib.http.transport.contract.Constants.EXPECTED_SEQUENCE_NUMBER;
 import static io.ballerina.stdlib.http.transport.contract.Constants.IDLE_TIMEOUT_TRIGGERED_BEFORE_INITIATING_INBOUND_REQUEST;
@@ -290,6 +291,9 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
 
         if (ctx.channel().attr(Constants.PIPELINING_EXECUTOR).get() == null) {
             ctx.channel().attr(Constants.PIPELINING_EXECUTOR).set(pipeliningGroup);
+        }
+        if (ctx.channel().attr(Constants.PIPELINE_LOCK).get() == null) {
+            ctx.channel().attr(Constants.PIPELINE_LOCK).set(new ReentrantLock());
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/states/SendingEntityBody.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/states/SendingEntityBody.java
@@ -47,6 +47,7 @@ import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static io.ballerina.stdlib.http.transport.contract.Constants.HTTP_HEAD_METHOD;
 import static io.ballerina.stdlib.http.transport.contract.Constants.IDLE_TIMEOUT_TRIGGERED_WHILE_WRITING_OUTBOUND_RESPONSE_BODY;
@@ -245,7 +246,9 @@ public class SendingEntityBody implements ListenerState {
         if (outboundResponseMsg.isPipeliningEnabled() && Constants.HTTP_1_1_VERSION.equalsIgnoreCase
                 (httpVersion)) {
             Queue responseQueue;
-            synchronized (sourceContext.channel().attr(Constants.RESPONSE_QUEUE).get()) {
+            ReentrantLock pipelineLock = sourceContext.channel().attr(Constants.PIPELINE_LOCK).get();
+            pipelineLock.lock();
+            try {
                 responseQueue = sourceContext.channel().attr(Constants.RESPONSE_QUEUE).get();
                 Long nextSequenceNumber = sourceContext.channel().attr(Constants.NEXT_SEQUENCE_NUMBER).get();
                 //IMPORTANT:Next sequence number should never be incremented for interim 100 continue response
@@ -257,6 +260,8 @@ public class SendingEntityBody implements ListenerState {
                     LOG.debug("Current sequence id of the response : {}", outboundResponseMsg.getSequenceId());
                     LOG.debug("Updated next sequence id to : {}", nextSequenceNumber);
                 }
+            } finally {
+                pipelineLock.unlock();
             }
             if (!responseQueue.isEmpty()) {
                 if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
## Purpose
$subject
Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8772

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [x] Checked native-image compatibility
- [x] Checked the impact on OpenAPI generation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request improves virtual thread compatibility in the HTTP transport module by replacing monitor-based synchronization with explicit mutual exclusion using `ReentrantLock`.

## Changes

**Overview**: Four files are modified to introduce a new `ReentrantLock`-based locking mechanism for pipelining operations:

1. **Constants.java** - Adds a new `PIPELINE_LOCK` channel attribute key (type: `ReentrantLock`)

2. **SourceHandler.java** - Initializes the `PIPELINE_LOCK` in the `setPipeliningProperties()` method alongside other pipelining configuration, ensuring each connection has its own lock instance

3. **PipeliningHandler.java** - Refactors `executePipeliningLogic` to acquire and release the lock using explicit lock/finally patterns instead of synchronized blocks, maintaining the same critical section protection

4. **SendingEntityBody.java** - Updates `triggerPipeliningLogic` to use the new `PIPELINE_LOCK` for synchronizing response queue and sequence number operations

**Impact**: The refactoring maintains the same mutual exclusion semantics while enabling better performance characteristics with virtual threads by avoiding thread pinning that occurs with synchronized blocks on shared objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->