### PR TITLE
[2201.12.x] Fix h2c connection eviction returning upgraded channel to pool

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "http"
-version = "2.14.10"
+version = "2.14.11"
 authors = ["Ballerina"]
 keywords = ["http", "network", "service", "listener", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-http"
@@ -20,8 +20,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.14.10"
-path = "../native/build/libs/http-native-2.14.10.jar"
+version = "2.14.11"
+path = "../native/build/libs/http-native-2.14.11-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "http-compiler-plugin"
 class = "io.ballerina.stdlib.http.compiler.HttpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/http-compiler-plugin-2.14.10.jar"
+path = "../compiler-plugin/build/libs/http-compiler-plugin-2.14.11-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -88,7 +88,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.10"
+version = "2.14.11"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ This file contains all the notable changes done to the Ballerina HTTP package th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [Fix h2c connection eviction returning upgraded channel to pool](https://github.com/ballerina-platform/ballerina-library/issues/8780)
+
 ## [2.14.9] - 2026-01-09
 
 ### Fixed

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/channel/pool/PoolableTargetChannelFactoryPerSrcHndlr.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/channel/pool/PoolableTargetChannelFactoryPerSrcHndlr.java
@@ -16,6 +16,7 @@
 package io.ballerina.stdlib.http.transport.contractimpl.sender.channel.pool;
 
 
+import io.ballerina.stdlib.http.transport.contract.Constants;
 import io.ballerina.stdlib.http.transport.contractimpl.sender.channel.TargetChannel;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
@@ -61,13 +62,16 @@ public class PoolableTargetChannelFactoryPerSrcHndlr implements PoolableObjectFa
     public void destroyObject(Object o) throws Exception {
         TargetChannel targetChannel = (TargetChannel) o;
         Channel nettyChannel = targetChannel.getChannel();
-        if (nettyChannel != null && nettyChannel.isActive()) {
+        if (nettyChannel != null && nettyChannel.isActive()
+                && nettyChannel.pipeline().get(Constants.HTTP_CLIENT_CODEC) != null) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Original Channel {} is returned to the pool. ", nettyChannel.id());
             }
             this.genericObjectPool.returnObject(o);
         } else {
-            // HTTP/2 channels go here when the channel is destroyed
+            // HTTP/2 channels (H2/TLS and h2c upgrade) go here when the channel is destroyed.
+            // For h2c, the pipeline's HttpClientCodec is removed after upgrade, so the channel
+            // cannot be reused for a new upgrade handshake and must be invalidated.
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Original Channel is destroyed. ");
             }


### PR DESCRIPTION
## Summary

Fixes #<!-- not applicable --> (ballerina-library issue: https://github.com/ballerina-platform/ballerina-library/issues/8780)

- After an h2c (cleartext HTTP/2) connection is evicted by `Http2ConnectionManager`, `PoolableTargetChannelFactoryPerSrcHndlr.destroyObject()` was calling `genericObjectPool.returnObject()` because the underlying TCP channel was still active.
- This put the post-upgrade channel — whose pipeline had `HttpClientCodec` removed by `DefaultHttpClientUpgradeHandler` — back into the global pool as if it were a fresh, reusable connection.
- The next request that borrowed it tried to perform a new h2c upgrade by writing a `DefaultHttpRequest`, which landed directly in `Http2ConnectionHandler`, causing Netty to throw `"unsupported message type: DefaultHttpRequest (expected: ByteBuf, FileRegion)"` and returning a 500 to callers.

**Fix:** Add `&& nettyChannel.pipeline().get(Constants.HTTP_CLIENT_CODEC) != null` to the return-to-pool condition. An upgraded h2c channel has no `HttpClientCodec` and is always invalidated (destroyed). HTTP/1.1 channels keep their codec and continue to be returned to the pool as before. H2/TLS channels are unaffected (`targetChannel.getChannel()` is null for them).

## Affected file

`native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/channel/pool/PoolableTargetChannelFactoryPerSrcHndlr.java`

## Test plan

- [ ] Existing test `testConnectionEvictionInH2PassthroughToH2CBackend` in `ballerina-tests/http2-tests/tests/http2_passthrough_client_connection_eviction.bal` should now pass (it was the failing test that exposed this bug)
- [ ] All other `http2ClientConnectionEvictionInPassthrough` group tests continue to pass
- [ ] Full HTTP test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)