### PR TITLE
[Master] Fix h2c connection eviction returning upgraded channel to pool

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- [Fix h2c connection eviction returning upgraded channel to pool](https://github.com/ballerina-platform/ballerina-library/issues/8780)
+
+## [2.16.2] - 2026-04-29
+
+### Fixed
+
 - [Fix Virtual Thread Pinning Due to Synchronized Block](https://github.com/ballerina-platform/ballerina-library/issues/8772)
 - [Address `CVE-2026-5588` Vulnerability](https://github.com/ballerina-platform/ballerina-library/issues/8774)
 

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/channel/pool/PoolableTargetChannelFactoryPerSrcHndlr.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/channel/pool/PoolableTargetChannelFactoryPerSrcHndlr.java
@@ -16,6 +16,7 @@
 package io.ballerina.stdlib.http.transport.contractimpl.sender.channel.pool;
 
 
+import io.ballerina.stdlib.http.transport.contract.Constants;
 import io.ballerina.stdlib.http.transport.contractimpl.sender.channel.TargetChannel;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
@@ -61,13 +62,16 @@ public class PoolableTargetChannelFactoryPerSrcHndlr implements PoolableObjectFa
     public void destroyObject(Object o) throws Exception {
         TargetChannel targetChannel = (TargetChannel) o;
         Channel nettyChannel = targetChannel.getChannel();
-        if (nettyChannel != null && nettyChannel.isActive()) {
+        if (nettyChannel != null && nettyChannel.isActive()
+                && nettyChannel.pipeline().get(Constants.HTTP_CLIENT_CODEC) != null) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Original Channel {} is returned to the pool. ", nettyChannel.id());
             }
             this.genericObjectPool.returnObject(o);
         } else {
-            // HTTP/2 channels go here when the channel is destroyed
+            // HTTP/2 channels (H2/TLS and h2c upgrade) go here when the channel is destroyed.
+            // For h2c, the pipeline's HttpClientCodec is removed after upgrade, so the channel
+            // cannot be reused for a new upgrade handshake and must be invalidated.
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Original Channel is destroyed. ");
             }


### PR DESCRIPTION
## Summary

Fixes #<!-- not applicable --> (ballerina-library issue: https://github.com/ballerina-platform/ballerina-library/issues/8780)

- After an h2c (cleartext HTTP/2) connection is evicted by `Http2ConnectionManager`, `PoolableTargetChannelFactoryPerSrcHndlr.destroyObject()` was calling `genericObjectPool.returnObject()` because the underlying TCP channel was still active.
- This put the post-upgrade channel — whose pipeline had `HttpClientCodec` removed by `DefaultHttpClientUpgradeHandler` — back into the global pool as if it were a fresh, reusable connection.
- The next request that borrowed it tried to perform a new h2c upgrade by writing a `DefaultHttpRequest`, which landed directly in `Http2ConnectionHandler`, causing Netty to throw `"unsupported message type: DefaultHttpRequest (expected: ByteBuf, FileRegion)"` and returning a 500 to callers.

**Fix:** Add `&& nettyChannel.pipeline().get(Constants.HTTP_CLIENT_CODEC) != null` to the return-to-pool condition. An upgraded h2c channel has no `HttpClientCodec` and is always invalidated (destroyed). HTTP/1.1 channels keep their codec and continue to be returned to the pool as before. H2/TLS channels are unaffected (`targetChannel.getChannel()` is null for them).

## Affected file

`native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/channel/pool/PoolableTargetChannelFactoryPerSrcHndlr.java`

## Test plan

- [ ] Existing test `testConnectionEvictionInH2PassthroughToH2CBackend` in `ballerina-tests/http2-tests/tests/http2_passthrough_client_connection_eviction.bal` should now pass (it was the failing test that exposed this bug)
- [ ] All other `http2ClientConnectionEvictionInPassthrough` group tests continue to pass
- [ ] Full HTTP test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request fixes connection-pooling behavior for HTTP/2 over cleartext (h2c) upgrades to improve stability when connections are evicted.

### Background
Upgraded h2c connections had their HTTP client codec removed from the Netty pipeline. The pool-return logic could still return such channels to the global pool after eviction, which allowed subsequent requests to reuse pipelines that no longer supported HTTP/1.1 request handling and caused runtime errors and 500 responses.

### Changes
- Update PoolableTargetChannelFactoryPerSrcHndlr.destroyObject() to only return a channel to the pool when the Netty channel is active and its pipeline contains the HTTP client codec (Constants.HTTP_CLIENT_CODEC).
- Channels that lack the HTTP client codec (including h2c-upgraded channels) are invalidated and destroyed instead of being returned to the pool.
- Adjusted imports, debug logging, and comments to reflect the new validation.

### Impact
- Prevents reuse of upgraded h2c channels, improving request stability and correctness.
- Preserves pooling behavior for normal HTTP/1.1 connections and leaves TLS-based HTTP/2 channels unaffected.
- Intended to restore passing of testConnectionEvictionInH2PassthroughToH2CBackend and keep related connection-eviction and HTTP test suites green.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->