### PR TITLE
[Master] Enforce HTTP/2 maxConcurrentStreams limit on server

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,7 @@ listener http:Listener h2Listener = new (9090, {
 });
 ```
 
-Set to `-1` to allow unlimited streams (not recommended for public-facing services). When not set, the listener
-defaults to 100.
+When not set, the listener defaults to 100.
 
 ## Issues and projects 
 

--- a/README.md
+++ b/README.md
@@ -117,15 +117,7 @@ with other widely-used HTTP/2 server implementations such as Nginx and Envoy.
 When a client reaches this limit on a connection, it will automatically open an additional connection rather than
 stalling, so normal traffic is unaffected for typical workloads.
 
-The server-side stream limit defaults to the value of the `maxActiveStreamsPerConnection` configurable (default 100),
-which also controls how many parallel streams the HTTP client opens per connection. Set it globally in `Config.toml`:
-
-```toml
-[ballerina.http]
-maxActiveStreamsPerConnection = 500
-```
-
-You can also override it per listener using `http2MaxActiveStreams` in `ListenerConfiguration`:
+The server-side stream limit can be tuned per listener using `http2MaxActiveStreams` in `ListenerConfiguration`:
 
 ```ballerina
 listener http:Listener h2Listener = new (9090, {
@@ -134,7 +126,7 @@ listener http:Listener h2Listener = new (9090, {
 ```
 
 Set to `-1` to allow unlimited streams (not recommended for public-facing services). When not set, the listener
-inherits the global `maxActiveStreamsPerConnection` value.
+defaults to 100.
 
 ## Issues and projects 
 

--- a/README.md
+++ b/README.md
@@ -105,27 +105,8 @@ Also, The `listener` can be configured to authenticate and authorize the inbound
 built-in support for basic authentication, JWT authentication, and OAuth2 authentication.
 
 In addition to that, supports both the HTTP/1.1 and HTTP2 protocols and connection keep-alive, content
-chunking, HTTP caching, data compression/decompression, payload binding, and authorization can be highlighted as the features of a `Service`.
-
-#### HTTP/2 Stream Concurrency
-
-Each HTTP/2 connection can carry multiple requests simultaneously using independent streams. To prevent a single
-connection from opening an unbounded number of streams and exhausting server memory, the listener enforces a limit
-of **100 concurrent streams per connection** by default. This is the value recommended by RFC 7540 and consistent
-with other widely-used HTTP/2 server implementations such as Nginx and Envoy.
-
-When a client reaches this limit on a connection, it will automatically open an additional connection rather than
-stalling, so normal traffic is unaffected for typical workloads.
-
-The server-side stream limit can be tuned per listener using `http2MaxActiveStreams` in `ListenerConfiguration`:
-
-```ballerina
-listener http:Listener h2Listener = new (9090, {
-    http2MaxActiveStreams: 500
-});
-```
-
-When not set, the listener defaults to 100.
+chunking, HTTP caching, data compression/decompression, payload binding, HTTP/2 stream concurrency limiting, and
+authorization can be highlighted as the features of a `Service`.
 
 ## Issues and projects 
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,32 @@ built-in support for basic authentication, JWT authentication, and OAuth2 authen
 In addition to that, supports both the HTTP/1.1 and HTTP2 protocols and connection keep-alive, content
 chunking, HTTP caching, data compression/decompression, payload binding, and authorization can be highlighted as the features of a `Service`.
 
+#### HTTP/2 Stream Concurrency
+
+Each HTTP/2 connection can carry multiple requests simultaneously using independent streams. To prevent a single
+connection from opening an unbounded number of streams and exhausting server memory, the listener enforces a limit
+of **100 concurrent streams per connection** by default. This is the value recommended by RFC 7540 and consistent
+with other widely-used HTTP/2 server implementations such as Nginx and Envoy.
+
+When a client reaches this limit on a connection, it will automatically open an additional connection rather than
+stalling, so normal traffic is unaffected for typical workloads.
+
+The limit can be configured per listener using the `http2MaxConcurrentStreams` field in `ListenerConfiguration`:
+
+```ballerina
+listener http:Listener secureHelloWorldEp = new (9090, {
+    http2MaxConcurrentStreams: 500
+});
+```
+
+Alternatively, you can override the default globally for all listeners using the following JVM system property:
+
+```
+JAVA_OPTS="-Dhttp.http2.maxConcurrentStreams=500" bal run
+```
+
+> **Note:** The per-listener `http2MaxConcurrentStreams` configuration takes precedence over the system property.
+
 ## Issues and projects 
 
 Issues and Projects tabs are disabled for this repository as this is part of the Ballerina Standard Library. To report bugs, request new features, start new discussions, view project boards, etc. please visit Ballerina Standard Library [parent repository](https://github.com/ballerina-platform/ballerina-standard-library). 

--- a/README.md
+++ b/README.md
@@ -117,21 +117,20 @@ with other widely-used HTTP/2 server implementations such as Nginx and Envoy.
 When a client reaches this limit on a connection, it will automatically open an additional connection rather than
 stalling, so normal traffic is unaffected for typical workloads.
 
-The limit can be configured per listener using the `http2MaxConcurrentStreams` field in `ListenerConfiguration`:
+The server-side stream limit is derived from the `maxActiveStreamsPerConnection` configurable, which also controls
+how many parallel streams the HTTP client opens per connection. Set it in `Config.toml`:
 
-```ballerina
-listener http:Listener secureHelloWorldEp = new (9090, {
-    http2MaxConcurrentStreams: 500
-});
+```toml
+[ballerina.http]
+maxActiveStreamsPerConnection = 500
 ```
 
-Alternatively, you can override the default globally for all listeners using the following JVM system property:
+To disable the limit and restore unlimited behaviour (not recommended for public-facing services):
 
+```toml
+[ballerina.http]
+maxActiveStreamsPerConnection = -1
 ```
-JAVA_OPTS="-Dhttp.http2.maxConcurrentStreams=500" bal run
-```
-
-> **Note:** The per-listener `http2MaxConcurrentStreams` configuration takes precedence over the system property.
 
 ## Issues and projects 
 

--- a/README.md
+++ b/README.md
@@ -117,20 +117,24 @@ with other widely-used HTTP/2 server implementations such as Nginx and Envoy.
 When a client reaches this limit on a connection, it will automatically open an additional connection rather than
 stalling, so normal traffic is unaffected for typical workloads.
 
-The server-side stream limit is derived from the `maxActiveStreamsPerConnection` configurable, which also controls
-how many parallel streams the HTTP client opens per connection. Set it in `Config.toml`:
+The server-side stream limit defaults to the value of the `maxActiveStreamsPerConnection` configurable (default 100),
+which also controls how many parallel streams the HTTP client opens per connection. Set it globally in `Config.toml`:
 
 ```toml
 [ballerina.http]
 maxActiveStreamsPerConnection = 500
 ```
 
-To disable the limit and restore unlimited behaviour (not recommended for public-facing services):
+You can also override it per listener using `http2MaxActiveStreams` in `ListenerConfiguration`:
 
-```toml
-[ballerina.http]
-maxActiveStreamsPerConnection = -1
+```ballerina
+listener http:Listener h2Listener = new (9090, {
+    http2MaxActiveStreams: 500
+});
 ```
+
+Set to `-1` to allow unlimited streams (not recommended for public-facing services). When not set, the listener
+inherits the global `maxActiveStreamsPerConnection` value.
 
 ## Issues and projects 
 

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -116,5 +116,4 @@ listener http:Listener h2Listener = new (9090, {
 });
 ```
 
-Set to `-1` to allow unlimited streams (not recommended for public-facing services). When not set, the listener
-defaults to 100.
+When not set, the listener defaults to 100.

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -97,3 +97,35 @@ built-in support for basic authentication, JWT authentication, and OAuth2 authen
 
 In addition to that, supports both the HTTP/1.1 and HTTP2 protocols and connection keep-alive, content 
 chunking, HTTP caching, data compression/decompression, payload binding, and authorization can be highlighted as the features of a `Service`.
+
+#### HTTP/2 Stream Concurrency
+
+Each HTTP/2 connection can carry multiple requests simultaneously using independent streams. To prevent a single
+connection from opening an unbounded number of streams and exhausting server memory, the listener enforces a limit
+of **100 concurrent streams per connection** by default. This is the value recommended by RFC 7540 and consistent
+with other widely-used HTTP/2 server implementations such as Nginx and Envoy.
+
+When a client reaches this limit on a connection, it will automatically open an additional connection rather than
+stalling, so normal traffic is unaffected for typical workloads.
+
+The limit can be configured per listener using the `http2MaxConcurrentStreams` field in `ListenerConfiguration`:
+
+```ballerina
+listener http:Listener secureHelloWorldEp = new (9090, {
+    http2MaxConcurrentStreams: 500
+});
+```
+
+Alternatively, you can override the default globally for all listeners using the following JVM system property:
+
+```
+-Dhttp.http2.maxConcurrentStreams=<value>
+```
+
+For example:
+
+```
+JAVA_OPTS="-Dhttp.http2.maxConcurrentStreams=500" bal run
+```
+
+> **Note:** The per-listener `http2MaxConcurrentStreams` configuration takes precedence over the system property.

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -108,17 +108,21 @@ with other widely-used HTTP/2 server implementations such as Nginx and Envoy.
 When a client reaches this limit on a connection, it will automatically open an additional connection rather than
 stalling, so normal traffic is unaffected for typical workloads.
 
-The server-side stream limit is derived from the `maxActiveStreamsPerConnection` configurable, which also controls
-how many parallel streams the HTTP client opens per connection. Set it in `Config.toml`:
+The server-side stream limit defaults to the value of the `maxActiveStreamsPerConnection` configurable (default 100),
+which also controls how many parallel streams the HTTP client opens per connection. Set it globally in `Config.toml`:
 
 ```toml
 [ballerina.http]
 maxActiveStreamsPerConnection = 500
 ```
 
-To disable the limit and restore unlimited behaviour (not recommended for public-facing services):
+You can also override it per listener using `http2MaxActiveStreams` in `ListenerConfiguration`:
 
-```toml
-[ballerina.http]
-maxActiveStreamsPerConnection = -1
+```ballerina
+listener http:Listener h2Listener = new (9090, {
+    http2MaxActiveStreams: 500
+});
 ```
+
+Set to `-1` to allow unlimited streams (not recommended for public-facing services). When not set, the listener
+inherits the global `maxActiveStreamsPerConnection` value.

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -108,24 +108,17 @@ with other widely-used HTTP/2 server implementations such as Nginx and Envoy.
 When a client reaches this limit on a connection, it will automatically open an additional connection rather than
 stalling, so normal traffic is unaffected for typical workloads.
 
-The limit can be configured per listener using the `http2MaxConcurrentStreams` field in `ListenerConfiguration`:
+The server-side stream limit is derived from the `maxActiveStreamsPerConnection` configurable, which also controls
+how many parallel streams the HTTP client opens per connection. Set it in `Config.toml`:
 
-```ballerina
-listener http:Listener secureHelloWorldEp = new (9090, {
-    http2MaxConcurrentStreams: 500
-});
+```toml
+[ballerina.http]
+maxActiveStreamsPerConnection = 500
 ```
 
-Alternatively, you can override the default globally for all listeners using the following JVM system property:
+To disable the limit and restore unlimited behaviour (not recommended for public-facing services):
 
+```toml
+[ballerina.http]
+maxActiveStreamsPerConnection = -1
 ```
--Dhttp.http2.maxConcurrentStreams=<value>
-```
-
-For example:
-
-```
-JAVA_OPTS="-Dhttp.http2.maxConcurrentStreams=500" bal run
-```
-
-> **Note:** The per-listener `http2MaxConcurrentStreams` configuration takes precedence over the system property.

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -96,24 +96,5 @@ Also, The `listener` can be configured to authenticate and authorize the inbound
 built-in support for basic authentication, JWT authentication, and OAuth2 authentication.
 
 In addition to that, supports both the HTTP/1.1 and HTTP2 protocols and connection keep-alive, content 
-chunking, HTTP caching, data compression/decompression, payload binding, and authorization can be highlighted as the features of a `Service`.
-
-#### HTTP/2 Stream Concurrency
-
-Each HTTP/2 connection can carry multiple requests simultaneously using independent streams. To prevent a single
-connection from opening an unbounded number of streams and exhausting server memory, the listener enforces a limit
-of **100 concurrent streams per connection** by default. This is the value recommended by RFC 7540 and consistent
-with other widely-used HTTP/2 server implementations such as Nginx and Envoy.
-
-When a client reaches this limit on a connection, it will automatically open an additional connection rather than
-stalling, so normal traffic is unaffected for typical workloads.
-
-The server-side stream limit can be tuned per listener using `http2MaxActiveStreams` in `ListenerConfiguration`:
-
-```ballerina
-listener http:Listener h2Listener = new (9090, {
-    http2MaxActiveStreams: 500
-});
-```
-
-When not set, the listener defaults to 100.
+chunking, HTTP caching, data compression/decompression, payload binding, HTTP/2 stream concurrency limiting, and
+authorization can be highlighted as the features of a `Service`.

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -108,15 +108,7 @@ with other widely-used HTTP/2 server implementations such as Nginx and Envoy.
 When a client reaches this limit on a connection, it will automatically open an additional connection rather than
 stalling, so normal traffic is unaffected for typical workloads.
 
-The server-side stream limit defaults to the value of the `maxActiveStreamsPerConnection` configurable (default 100),
-which also controls how many parallel streams the HTTP client opens per connection. Set it globally in `Config.toml`:
-
-```toml
-[ballerina.http]
-maxActiveStreamsPerConnection = 500
-```
-
-You can also override it per listener using `http2MaxActiveStreams` in `ListenerConfiguration`:
+The server-side stream limit can be tuned per listener using `http2MaxActiveStreams` in `ListenerConfiguration`:
 
 ```ballerina
 listener http:Listener h2Listener = new (9090, {
@@ -125,4 +117,4 @@ listener http:Listener h2Listener = new (9090, {
 ```
 
 Set to `-1` to allow unlimited streams (not recommended for public-facing services). When not set, the listener
-inherits the global `maxActiveStreamsPerConnection` value.
+defaults to 100.

--- a/ballerina/http_service_endpoint.bal
+++ b/ballerina/http_service_endpoint.bal
@@ -148,6 +148,10 @@ public type Local record {|
 # + gracefulStopTimeout - Grace period of time in seconds for listener gracefulStop
 # + socketConfig - Provides settings related to server socket configuration
 # + http2InitialWindowSize - Configuration to change the initial window size in HTTP/2
+# + http2MaxActiveStreams - Maximum concurrent HTTP/2 streams per connection advertised to clients. When set,
+#                          overrides the global `maxActiveStreamsPerConnection` configurable for this listener.
+#                          Set to -1 for unlimited streams. When not set, inherits from the global
+#                          `maxActiveStreamsPerConnection` configurable (itself defaulting to 100)
 # + minIdleTimeInStaleState - Minimum time in seconds for a connection to be kept open which has received a GOAWAY.
 #                             This only applies for HTTP/2. Default value is 5 minutes. If the value is set to -1,
 #                             the connection will be closed after all in-flight streams are completed
@@ -164,6 +168,7 @@ public type ListenerConfiguration record {|
     decimal gracefulStopTimeout = DEFAULT_GRACEFULSTOP_TIMEOUT;
     ServerSocketConfig socketConfig = {};
     int http2InitialWindowSize = 65535;
+    int? http2MaxActiveStreams = ();
     decimal minIdleTimeInStaleState = 300;
     decimal timeBetweenStaleEviction = 30;
 |};

--- a/ballerina/http_service_endpoint.bal
+++ b/ballerina/http_service_endpoint.bal
@@ -148,10 +148,8 @@ public type Local record {|
 # + gracefulStopTimeout - Grace period of time in seconds for listener gracefulStop
 # + socketConfig - Provides settings related to server socket configuration
 # + http2InitialWindowSize - Configuration to change the initial window size in HTTP/2
-# + http2MaxActiveStreams - Maximum concurrent HTTP/2 streams per connection advertised to clients. When set,
-#                          overrides the global `maxActiveStreamsPerConnection` configurable for this listener.
-#                          Set to -1 for unlimited streams. When not set, inherits from the global
-#                          `maxActiveStreamsPerConnection` configurable (itself defaulting to 100)
+# + http2MaxActiveStreams - Maximum concurrent HTTP/2 streams per connection advertised to clients.
+#                          When not set, defaults to 100
 # + minIdleTimeInStaleState - Minimum time in seconds for a connection to be kept open which has received a GOAWAY.
 #                             This only applies for HTTP/2. Default value is 5 minutes. If the value is set to -1,
 #                             the connection will be closed after all in-flight streams are completed

--- a/ballerina/http_service_endpoint.bal
+++ b/ballerina/http_service_endpoint.bal
@@ -149,7 +149,7 @@ public type Local record {|
 # + socketConfig - Provides settings related to server socket configuration
 # + http2InitialWindowSize - Configuration to change the initial window size in HTTP/2
 # + http2MaxActiveStreams - Maximum concurrent HTTP/2 streams per connection advertised to clients.
-#                          When not set, defaults to 100
+#                          Defaults to 100
 # + minIdleTimeInStaleState - Minimum time in seconds for a connection to be kept open which has received a GOAWAY.
 #                             This only applies for HTTP/2. Default value is 5 minutes. If the value is set to -1,
 #                             the connection will be closed after all in-flight streams are completed
@@ -166,7 +166,7 @@ public type ListenerConfiguration record {|
     decimal gracefulStopTimeout = DEFAULT_GRACEFULSTOP_TIMEOUT;
     ServerSocketConfig socketConfig = {};
     int http2InitialWindowSize = 65535;
-    int? http2MaxActiveStreams = ();
+    int http2MaxActiveStreams = 100;
     decimal minIdleTimeInStaleState = 300;
     decimal timeBetweenStaleEviction = 30;
 |};

--- a/ballerina/http_service_endpoint.bal
+++ b/ballerina/http_service_endpoint.bal
@@ -148,9 +148,6 @@ public type Local record {|
 # + gracefulStopTimeout - Grace period of time in seconds for listener gracefulStop
 # + socketConfig - Provides settings related to server socket configuration
 # + http2InitialWindowSize - Configuration to change the initial window size in HTTP/2
-# + http2MaxConcurrentStreams - Maximum number of concurrent HTTP/2 streams allowed per connection. Limits the
-#                               number of active streams a single client connection can open simultaneously,
-#                               preventing unbounded stream creation and heap exhaustion. Default is 100
 # + minIdleTimeInStaleState - Minimum time in seconds for a connection to be kept open which has received a GOAWAY.
 #                             This only applies for HTTP/2. Default value is 5 minutes. If the value is set to -1,
 #                             the connection will be closed after all in-flight streams are completed
@@ -167,7 +164,6 @@ public type ListenerConfiguration record {|
     decimal gracefulStopTimeout = DEFAULT_GRACEFULSTOP_TIMEOUT;
     ServerSocketConfig socketConfig = {};
     int http2InitialWindowSize = 65535;
-    int http2MaxConcurrentStreams = 100;
     decimal minIdleTimeInStaleState = 300;
     decimal timeBetweenStaleEviction = 30;
 |};

--- a/ballerina/http_service_endpoint.bal
+++ b/ballerina/http_service_endpoint.bal
@@ -148,6 +148,9 @@ public type Local record {|
 # + gracefulStopTimeout - Grace period of time in seconds for listener gracefulStop
 # + socketConfig - Provides settings related to server socket configuration
 # + http2InitialWindowSize - Configuration to change the initial window size in HTTP/2
+# + http2MaxConcurrentStreams - Maximum number of concurrent HTTP/2 streams allowed per connection. Limits the
+#                               number of active streams a single client connection can open simultaneously,
+#                               preventing unbounded stream creation and heap exhaustion. Default is 100
 # + minIdleTimeInStaleState - Minimum time in seconds for a connection to be kept open which has received a GOAWAY.
 #                             This only applies for HTTP/2. Default value is 5 minutes. If the value is set to -1,
 #                             the connection will be closed after all in-flight streams are completed
@@ -164,6 +167,7 @@ public type ListenerConfiguration record {|
     decimal gracefulStopTimeout = DEFAULT_GRACEFULSTOP_TIMEOUT;
     ServerSocketConfig socketConfig = {};
     int http2InitialWindowSize = 65535;
+    int http2MaxConcurrentStreams = 100;
     decimal minIdleTimeInStaleState = 300;
     decimal timeBetweenStaleEviction = 30;
 |};

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -24,7 +24,7 @@ The conforming implementation of the specification is released and included in t
         * 2.1.1. [Automatically starting the service](#211-automatically-starting-the-service)
         * 2.1.2. [Programmatically starting the service](#212-programmatically-starting-the-service)
         * 2.1.3. [Default listener](#213-default-listener)
-        * 2.1.4. [HTTP2 stream concurrency](#214-http2-stream-concurrency)
+        * 2.1.4. [HTTP/2 stream concurrency](#214-http2-stream-concurrency)
     * 2.2. [Service](#22-service)
         * 2.2.1. [Service type](#221-service-type)
         * 2.2.2. [Service-base-path](#222-service-base-path)
@@ -256,7 +256,7 @@ path = "resources/certs/ballerinaKeystore.p12"
 password = "ballerina"
 ```
 
-#### 2.1.4. HTTP2 stream concurrency
+#### 2.1.4. HTTP/2 stream concurrency
 
 Each HTTP/2 connection can carry multiple requests concurrently over independent streams. The listener limits the
 number of concurrent streams a single connection can open, advertised to clients via the `SETTINGS_MAX_CONCURRENT_STREAMS`

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -24,6 +24,7 @@ The conforming implementation of the specification is released and included in t
         * 2.1.1. [Automatically starting the service](#211-automatically-starting-the-service)
         * 2.1.2. [Programmatically starting the service](#212-programmatically-starting-the-service)
         * 2.1.3. [Default listener](#213-default-listener)
+        * 2.1.4. [HTTP2 stream concurrency](#214-http2-stream-concurrency)
     * 2.2. [Service](#22-service)
         * 2.2.1. [Service type](#221-service-type)
         * 2.2.2. [Service-base-path](#222-service-base-path)
@@ -177,6 +178,7 @@ public type ListenerConfiguration record {|
     string? server = ();
     RequestLimitConfigs requestLimits = {};
     int http2InitialWindowSize = 65535;
+    int http2MaxActiveStreams = 100;
     decimal minIdleTimeInStaleState = 300;
     decimal timeBetweenStaleEviction = 30;
 |};
@@ -253,6 +255,21 @@ httpVersion = "1.1"
 path = "resources/certs/ballerinaKeystore.p12"
 password = "ballerina"
 ```
+
+#### 2.1.4. HTTP2 stream concurrency
+
+Each HTTP/2 connection can carry multiple requests concurrently over independent streams. The listener limits the
+number of concurrent streams a single connection can open, advertised to clients via the `SETTINGS_MAX_CONCURRENT_STREAMS`
+parameter, using the `http2MaxActiveStreams` field of the `ListenerConfiguration`. This defaults to `100`, the value
+recommended by [RFC 7540 Section 6.5.2](https://www.rfc-editor.org/rfc/rfc7540#section-6.5.2).
+
+```ballerina
+listener http:Listener h2Listener = new (9090, {
+    http2MaxActiveStreams: 500
+});
+```
+
+A client that reaches this limit on a connection opens an additional connection rather than stalling.
 
 ### 2.2. Service
 Service is a collection of resources functions, which are the network entry points of a ballerina program. 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -444,6 +444,9 @@ public final class HttpConstants {
     public static final BString ENDPOINT_CONFIG_GRACEFUL_STOP_TIMEOUT = StringUtils.fromString("gracefulStopTimeout");
     public static final BString ENDPOINT_CONFIG_HTTP2_INITIAL_WINDOW_SIZE = StringUtils
             .fromString("http2InitialWindowSize");
+    public static final String HTTP2_MAX_CONCURRENT_STREAMS = "http.http2.maxConcurrentStreams";
+    public static final BString ENDPOINT_CONFIG_HTTP2_MAX_CONCURRENT_STREAMS = StringUtils
+            .fromString("http2MaxConcurrentStreams");
     public static final BString ENDPOINT_CONFIG_IDLE_TIME_STALE_STATE = StringUtils.fromString(
             "minIdleTimeInStaleState");
     public static final BString ENDPOINT_CONFIG_TIME_BETWEEN_STALE_CHECK_RUNS = StringUtils.fromString(

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -444,6 +444,8 @@ public final class HttpConstants {
     public static final BString ENDPOINT_CONFIG_GRACEFUL_STOP_TIMEOUT = StringUtils.fromString("gracefulStopTimeout");
     public static final BString ENDPOINT_CONFIG_HTTP2_INITIAL_WINDOW_SIZE = StringUtils
             .fromString("http2InitialWindowSize");
+    public static final BString ENDPOINT_CONFIG_HTTP2_MAX_ACTIVE_STREAMS = StringUtils
+            .fromString("http2MaxActiveStreams");
     public static final BString ENDPOINT_CONFIG_IDLE_TIME_STALE_STATE = StringUtils.fromString(
             "minIdleTimeInStaleState");
     public static final BString ENDPOINT_CONFIG_TIME_BETWEEN_STALE_CHECK_RUNS = StringUtils.fromString(

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpConstants.java
@@ -444,9 +444,6 @@ public final class HttpConstants {
     public static final BString ENDPOINT_CONFIG_GRACEFUL_STOP_TIMEOUT = StringUtils.fromString("gracefulStopTimeout");
     public static final BString ENDPOINT_CONFIG_HTTP2_INITIAL_WINDOW_SIZE = StringUtils
             .fromString("http2InitialWindowSize");
-    public static final String HTTP2_MAX_CONCURRENT_STREAMS = "http.http2.maxConcurrentStreams";
-    public static final BString ENDPOINT_CONFIG_HTTP2_MAX_CONCURRENT_STREAMS = StringUtils
-            .fromString("http2MaxConcurrentStreams");
     public static final BString ENDPOINT_CONFIG_IDLE_TIME_STALE_STATE = StringUtils.fromString(
             "minIdleTimeInStaleState");
     public static final BString ENDPOINT_CONFIG_TIME_BETWEEN_STALE_CHECK_RUNS = StringUtils.fromString(

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -134,7 +134,6 @@ import static io.ballerina.stdlib.http.api.HttpConstants.ANN_CONFIG_ATTR_COMPRES
 import static io.ballerina.stdlib.http.api.HttpConstants.ANN_CONFIG_ATTR_SSL_ENABLED_PROTOCOLS;
 import static io.ballerina.stdlib.http.api.HttpConstants.CREATE_INTERCEPTORS_FUNCTION_NAME;
 import static io.ballerina.stdlib.http.api.HttpConstants.ENDPOINT_CONFIG_HTTP2_INITIAL_WINDOW_SIZE;
-import static io.ballerina.stdlib.http.api.HttpConstants.ENDPOINT_CONFIG_HTTP2_MAX_CONCURRENT_STREAMS;
 import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_HEADERS;
 import static io.ballerina.stdlib.http.api.HttpConstants.RESOLVED_REQUESTED_URI;
 import static io.ballerina.stdlib.http.api.HttpConstants.RESPONSE_CACHE_CONTROL;
@@ -208,6 +207,8 @@ public class HttpUtil {
     private static final String JAVA_CONFIG_TLS_NAMED_GROUPS = "jdk.tls.namedGroups";
     private static final String[] DEFAULT_NAMED_GROUPS = { "X25519MLKEM768", "x25519", "secp256r1",
             "secp384r1", "secp521r1" };
+
+    private static volatile int globalHttp2MaxActiveStreams = 100;
 
     /**
      * Set new entity to in/out request/response struct.
@@ -1338,6 +1339,14 @@ public class HttpUtil {
         return poolManager;
     }
 
+    public static void setGlobalHttp2MaxActiveStreams(int maxActiveStreams) {
+        globalHttp2MaxActiveStreams = maxActiveStreams;
+    }
+
+    public static int getGlobalHttp2MaxActiveStreams() {
+        return globalHttp2MaxActiveStreams;
+    }
+
     public static void populatePoolingConfig(BMap poolRecord, PoolConfiguration poolConfiguration) {
         long maxActiveConnections = poolRecord.getIntValue(HttpConstants.CONNECTION_POOLING_MAX_ACTIVE_CONNECTIONS);
         poolConfiguration.setMaxActivePerPool(
@@ -1584,8 +1593,7 @@ public class HttpUtil {
         listenerConfiguration.setPipeliningEnabled(true); //Pipelining is enabled all the time
         listenerConfiguration.setHttp2InitialWindowSize(endpointConfig
                 .getIntValue(ENDPOINT_CONFIG_HTTP2_INITIAL_WINDOW_SIZE).intValue());
-        listenerConfiguration.setHttp2MaxConcurrentStreams(endpointConfig
-                .getIntValue(ENDPOINT_CONFIG_HTTP2_MAX_CONCURRENT_STREAMS).intValue());
+        listenerConfiguration.setHttp2MaxActiveStreams(getGlobalHttp2MaxActiveStreams());
 
         double minIdleTimeInStaleState =
                 ((BDecimal) endpointConfig.get(HttpConstants.ENDPOINT_CONFIG_IDLE_TIME_STALE_STATE)).floatValue();

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -209,8 +209,6 @@ public class HttpUtil {
     private static final String[] DEFAULT_NAMED_GROUPS = { "X25519MLKEM768", "x25519", "secp256r1",
             "secp384r1", "secp521r1" };
 
-    private static volatile int globalHttp2MaxActiveStreams = 100;
-
     /**
      * Set new entity to in/out request/response struct.
      *
@@ -1340,14 +1338,6 @@ public class HttpUtil {
         return poolManager;
     }
 
-    public static void setGlobalHttp2MaxActiveStreams(int maxActiveStreams) {
-        globalHttp2MaxActiveStreams = maxActiveStreams;
-    }
-
-    public static int getGlobalHttp2MaxActiveStreams() {
-        return globalHttp2MaxActiveStreams;
-    }
-
     public static void populatePoolingConfig(BMap poolRecord, PoolConfiguration poolConfiguration) {
         long maxActiveConnections = poolRecord.getIntValue(HttpConstants.CONNECTION_POOLING_MAX_ACTIVE_CONNECTIONS);
         poolConfiguration.setMaxActivePerPool(
@@ -1595,9 +1585,7 @@ public class HttpUtil {
         listenerConfiguration.setHttp2InitialWindowSize(endpointConfig
                 .getIntValue(ENDPOINT_CONFIG_HTTP2_INITIAL_WINDOW_SIZE).intValue());
         Object listenerMaxActiveStreams = endpointConfig.get(ENDPOINT_CONFIG_HTTP2_MAX_ACTIVE_STREAMS);
-        if (listenerMaxActiveStreams == null) {
-            listenerConfiguration.setHttp2MaxActiveStreams(getGlobalHttp2MaxActiveStreams());
-        } else {
+        if (listenerMaxActiveStreams != null) {
             long value = ((Long) listenerMaxActiveStreams).longValue();
             listenerConfiguration.setHttp2MaxActiveStreams(value == -1 ? Integer.MAX_VALUE : (int) value);
         }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -1587,7 +1587,7 @@ public class HttpUtil {
         Object listenerMaxActiveStreams = endpointConfig.get(ENDPOINT_CONFIG_HTTP2_MAX_ACTIVE_STREAMS);
         if (listenerMaxActiveStreams != null) {
             long value = ((Long) listenerMaxActiveStreams).longValue();
-            listenerConfiguration.setHttp2MaxConcurrentStreams(value == -1 ? Integer.MAX_VALUE : (int) value);
+            listenerConfiguration.setHttp2MaxConcurrentStreams((int) value);
         }
 
         double minIdleTimeInStaleState =

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -134,6 +134,7 @@ import static io.ballerina.stdlib.http.api.HttpConstants.ANN_CONFIG_ATTR_COMPRES
 import static io.ballerina.stdlib.http.api.HttpConstants.ANN_CONFIG_ATTR_SSL_ENABLED_PROTOCOLS;
 import static io.ballerina.stdlib.http.api.HttpConstants.CREATE_INTERCEPTORS_FUNCTION_NAME;
 import static io.ballerina.stdlib.http.api.HttpConstants.ENDPOINT_CONFIG_HTTP2_INITIAL_WINDOW_SIZE;
+import static io.ballerina.stdlib.http.api.HttpConstants.ENDPOINT_CONFIG_HTTP2_MAX_ACTIVE_STREAMS;
 import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_HEADERS;
 import static io.ballerina.stdlib.http.api.HttpConstants.RESOLVED_REQUESTED_URI;
 import static io.ballerina.stdlib.http.api.HttpConstants.RESPONSE_CACHE_CONTROL;
@@ -1593,7 +1594,13 @@ public class HttpUtil {
         listenerConfiguration.setPipeliningEnabled(true); //Pipelining is enabled all the time
         listenerConfiguration.setHttp2InitialWindowSize(endpointConfig
                 .getIntValue(ENDPOINT_CONFIG_HTTP2_INITIAL_WINDOW_SIZE).intValue());
-        listenerConfiguration.setHttp2MaxActiveStreams(getGlobalHttp2MaxActiveStreams());
+        Object listenerMaxActiveStreams = endpointConfig.get(ENDPOINT_CONFIG_HTTP2_MAX_ACTIVE_STREAMS);
+        if (listenerMaxActiveStreams == null) {
+            listenerConfiguration.setHttp2MaxActiveStreams(getGlobalHttp2MaxActiveStreams());
+        } else {
+            long value = ((Long) listenerMaxActiveStreams).longValue();
+            listenerConfiguration.setHttp2MaxActiveStreams(value == -1 ? Integer.MAX_VALUE : (int) value);
+        }
 
         double minIdleTimeInStaleState =
                 ((BDecimal) endpointConfig.get(HttpConstants.ENDPOINT_CONFIG_IDLE_TIME_STALE_STATE)).floatValue();

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -1587,7 +1587,7 @@ public class HttpUtil {
         Object listenerMaxActiveStreams = endpointConfig.get(ENDPOINT_CONFIG_HTTP2_MAX_ACTIVE_STREAMS);
         if (listenerMaxActiveStreams != null) {
             long value = ((Long) listenerMaxActiveStreams).longValue();
-            listenerConfiguration.setHttp2MaxActiveStreams(value == -1 ? Integer.MAX_VALUE : (int) value);
+            listenerConfiguration.setHttp2MaxConcurrentStreams(value == -1 ? Integer.MAX_VALUE : (int) value);
         }
 
         double minIdleTimeInStaleState =

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -1585,7 +1585,7 @@ public class HttpUtil {
         listenerConfiguration.setHttp2InitialWindowSize(endpointConfig
                 .getIntValue(ENDPOINT_CONFIG_HTTP2_INITIAL_WINDOW_SIZE).intValue());
         listenerConfiguration.setHttp2MaxConcurrentStreams(
-                (int) endpointConfig.getIntValue(ENDPOINT_CONFIG_HTTP2_MAX_ACTIVE_STREAMS));
+                endpointConfig.getIntValue(ENDPOINT_CONFIG_HTTP2_MAX_ACTIVE_STREAMS).intValue());
 
         double minIdleTimeInStaleState =
                 ((BDecimal) endpointConfig.get(HttpConstants.ENDPOINT_CONFIG_IDLE_TIME_STALE_STATE)).floatValue();

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -134,6 +134,7 @@ import static io.ballerina.stdlib.http.api.HttpConstants.ANN_CONFIG_ATTR_COMPRES
 import static io.ballerina.stdlib.http.api.HttpConstants.ANN_CONFIG_ATTR_SSL_ENABLED_PROTOCOLS;
 import static io.ballerina.stdlib.http.api.HttpConstants.CREATE_INTERCEPTORS_FUNCTION_NAME;
 import static io.ballerina.stdlib.http.api.HttpConstants.ENDPOINT_CONFIG_HTTP2_INITIAL_WINDOW_SIZE;
+import static io.ballerina.stdlib.http.api.HttpConstants.ENDPOINT_CONFIG_HTTP2_MAX_CONCURRENT_STREAMS;
 import static io.ballerina.stdlib.http.api.HttpConstants.HTTP_HEADERS;
 import static io.ballerina.stdlib.http.api.HttpConstants.RESOLVED_REQUESTED_URI;
 import static io.ballerina.stdlib.http.api.HttpConstants.RESPONSE_CACHE_CONTROL;
@@ -1583,6 +1584,8 @@ public class HttpUtil {
         listenerConfiguration.setPipeliningEnabled(true); //Pipelining is enabled all the time
         listenerConfiguration.setHttp2InitialWindowSize(endpointConfig
                 .getIntValue(ENDPOINT_CONFIG_HTTP2_INITIAL_WINDOW_SIZE).intValue());
+        listenerConfiguration.setHttp2MaxConcurrentStreams(endpointConfig
+                .getIntValue(ENDPOINT_CONFIG_HTTP2_MAX_CONCURRENT_STREAMS).intValue());
 
         double minIdleTimeInStaleState =
                 ((BDecimal) endpointConfig.get(HttpConstants.ENDPOINT_CONFIG_IDLE_TIME_STALE_STATE)).floatValue();

--- a/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/HttpUtil.java
@@ -1584,11 +1584,8 @@ public class HttpUtil {
         listenerConfiguration.setPipeliningEnabled(true); //Pipelining is enabled all the time
         listenerConfiguration.setHttp2InitialWindowSize(endpointConfig
                 .getIntValue(ENDPOINT_CONFIG_HTTP2_INITIAL_WINDOW_SIZE).intValue());
-        Object listenerMaxActiveStreams = endpointConfig.get(ENDPOINT_CONFIG_HTTP2_MAX_ACTIVE_STREAMS);
-        if (listenerMaxActiveStreams != null) {
-            long value = ((Long) listenerMaxActiveStreams).longValue();
-            listenerConfiguration.setHttp2MaxConcurrentStreams((int) value);
-        }
+        listenerConfiguration.setHttp2MaxConcurrentStreams(
+                (int) endpointConfig.getIntValue(ENDPOINT_CONFIG_HTTP2_MAX_ACTIVE_STREAMS));
 
         double minIdleTimeInStaleState =
                 ((BDecimal) endpointConfig.get(HttpConstants.ENDPOINT_CONFIG_IDLE_TIME_STALE_STATE)).floatValue();

--- a/native/src/main/java/io/ballerina/stdlib/http/api/client/endpoint/InitGlobalPool.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/client/endpoint/InitGlobalPool.java
@@ -19,7 +19,6 @@
 package io.ballerina.stdlib.http.api.client.endpoint;
 
 import io.ballerina.runtime.api.values.BMap;
-import io.ballerina.stdlib.http.api.HttpUtil;
 import io.ballerina.stdlib.http.transport.contractimpl.sender.channel.pool.ConnectionManager;
 import io.ballerina.stdlib.http.transport.contractimpl.sender.channel.pool.PoolConfiguration;
 
@@ -35,7 +34,6 @@ public class InitGlobalPool {
     public static void initGlobalPool(BMap globalPoolConfig) {
         PoolConfiguration globalPool = new PoolConfiguration();
         populatePoolingConfig(globalPoolConfig, globalPool);
-        HttpUtil.setGlobalHttp2MaxActiveStreams(globalPool.getHttp2MaxActiveStreamsPerConnection());
         ConnectionManager connectionManager = new ConnectionManager(globalPool);
         globalPoolConfig.addNativeData(CONNECTION_MANAGER, connectionManager);
     }

--- a/native/src/main/java/io/ballerina/stdlib/http/api/client/endpoint/InitGlobalPool.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/client/endpoint/InitGlobalPool.java
@@ -19,6 +19,7 @@
 package io.ballerina.stdlib.http.api.client.endpoint;
 
 import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.stdlib.http.api.HttpUtil;
 import io.ballerina.stdlib.http.transport.contractimpl.sender.channel.pool.ConnectionManager;
 import io.ballerina.stdlib.http.transport.contractimpl.sender.channel.pool.PoolConfiguration;
 
@@ -34,6 +35,7 @@ public class InitGlobalPool {
     public static void initGlobalPool(BMap globalPoolConfig) {
         PoolConfiguration globalPool = new PoolConfiguration();
         populatePoolingConfig(globalPoolConfig, globalPool);
+        HttpUtil.setGlobalHttp2MaxActiveStreams(globalPool.getHttp2MaxActiveStreamsPerConnection());
         ConnectionManager connectionManager = new ConnectionManager(globalPool);
         globalPoolConfig.addNativeData(CONNECTION_MANAGER, connectionManager);
     }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/ListenerConfiguration.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/ListenerConfiguration.java
@@ -64,7 +64,7 @@ public class ListenerConfiguration extends SslConfiguration {
     private boolean socketReuse;
     private boolean socketKeepAlive;
     private int http2InitialWindowSize = 65535;
-    private int http2MaxActiveStreams = 100;
+    private int http2MaxActiveStreams;
     private long minIdleTimeInStaleState = 3000000;
     private long timeBetweenStaleEviction = 30000;
 

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/ListenerConfiguration.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/ListenerConfiguration.java
@@ -64,6 +64,7 @@ public class ListenerConfiguration extends SslConfiguration {
     private boolean socketReuse;
     private boolean socketKeepAlive;
     private int http2InitialWindowSize = 65535;
+    private int http2MaxConcurrentStreams = 100;
     private long minIdleTimeInStaleState = 3000000;
     private long timeBetweenStaleEviction = 30000;
 
@@ -283,6 +284,14 @@ public class ListenerConfiguration extends SslConfiguration {
 
     public void setHttp2InitialWindowSize(int http2InitialWindowSize) {
         this.http2InitialWindowSize = http2InitialWindowSize;
+    }
+
+    public int getHttp2MaxConcurrentStreams() {
+        return http2MaxConcurrentStreams;
+    }
+
+    public void setHttp2MaxConcurrentStreams(int http2MaxConcurrentStreams) {
+        this.http2MaxConcurrentStreams = http2MaxConcurrentStreams;
     }
 
     public void setTimeBetweenStaleEviction(long timeBetweenStaleEviction) {

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/ListenerConfiguration.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/ListenerConfiguration.java
@@ -64,7 +64,7 @@ public class ListenerConfiguration extends SslConfiguration {
     private boolean socketReuse;
     private boolean socketKeepAlive;
     private int http2InitialWindowSize = 65535;
-    private int http2MaxConcurrentStreams = 100;
+    private int http2MaxActiveStreams = 100;
     private long minIdleTimeInStaleState = 3000000;
     private long timeBetweenStaleEviction = 30000;
 
@@ -287,11 +287,11 @@ public class ListenerConfiguration extends SslConfiguration {
     }
 
     public int getHttp2MaxConcurrentStreams() {
-        return http2MaxConcurrentStreams;
+        return http2MaxActiveStreams;
     }
 
-    public void setHttp2MaxConcurrentStreams(int http2MaxConcurrentStreams) {
-        this.http2MaxConcurrentStreams = http2MaxConcurrentStreams;
+    public void setHttp2MaxConcurrentStreams(int http2MaxActiveStreams) {
+        this.http2MaxActiveStreams = http2MaxActiveStreams;
     }
 
     public void setTimeBetweenStaleEviction(long timeBetweenStaleEviction) {

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/ListenerConfiguration.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contract/config/ListenerConfiguration.java
@@ -64,7 +64,7 @@ public class ListenerConfiguration extends SslConfiguration {
     private boolean socketReuse;
     private boolean socketKeepAlive;
     private int http2InitialWindowSize = 65535;
-    private int http2MaxActiveStreams;
+    private int http2MaxActiveStreams = 100;
     private long minIdleTimeInStaleState = 3000000;
     private long timeBetweenStaleEviction = 30000;
 

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/DefaultHttpWsConnectorFactory.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/DefaultHttpWsConnectorFactory.java
@@ -91,6 +91,7 @@ public class DefaultHttpWsConnectorFactory implements HttpWsConnectorFactory {
         if (Constants.HTTP_2_0.equals(listenerConfig.getVersion())) {
             serverConnectorBootstrap.setHttp2Enabled(true);
             serverConnectorBootstrap.setHttp2InitialWindowSize(listenerConfig.getHttp2InitialWindowSize());
+            serverConnectorBootstrap.setHttp2MaxConcurrentStreams(listenerConfig.getHttp2MaxConcurrentStreams());
             serverConnectorBootstrap.setMinIdleTimeInStaleState(listenerConfig.getMinIdleTimeInStaleState());
             serverConnectorBootstrap.setTimeBetweenStaleEviction(listenerConfig.getTimeBetweenStaleEviction());
         }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/HttpServerChannelInitializer.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/HttpServerChannelInitializer.java
@@ -113,6 +113,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
     private EventExecutorGroup pipeliningGroup;
     private boolean webSocketCompressionEnabled;
     private int http2InitialWindowSize;
+    private int http2MaxConcurrentStreams = 100;
     private long minIdleTimeInStaleState;
     private long timeBetweenStaleEviction;
     private final BlockingQueue<Http2SourceHandler> http2StaleSourceHandlers = new LinkedBlockingQueue<>();
@@ -261,7 +262,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
         // Add handler to handle http2 requests without an upgrade
         pipeline.addLast(new Http2WithPriorKnowledgeHandler(
                 interfaceId, serverName, serverConnectorFuture, this, allChannels, listenerChannels,
-                reqSizeValidationConfig.getMaxHeaderSize(), http2InitialWindowSize));
+                reqSizeValidationConfig.getMaxHeaderSize(), http2InitialWindowSize, http2MaxConcurrentStreams));
         // Add http2 upgrade decoder and upgrade handler
         final HttpServerCodec sourceCodec = new HttpServerCodec(reqSizeValidationConfig.getMaxInitialLineLength(),
                                                                 reqSizeValidationConfig.getMaxHeaderSize(),
@@ -281,7 +282,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
                         new Http2SourceConnectionHandlerBuilder(
                                 interfaceId, serverConnectorFuture, serverName, this,
                                 this.allChannels, this.listenerChannels, reqSizeValidationConfig.getMaxHeaderSize(),
-                                this.http2InitialWindowSize).build());
+                                this.http2InitialWindowSize, this.http2MaxConcurrentStreams).build());
             } else {
                 return null;
             }
@@ -353,6 +354,10 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
 
     void setHttp2InitialWindowSize(int http2InitialWindowSize) {
         this.http2InitialWindowSize = http2InitialWindowSize;
+    }
+
+    void setHttp2MaxConcurrentStreams(int http2MaxConcurrentStreams) {
+        this.http2MaxConcurrentStreams = http2MaxConcurrentStreams;
     }
 
     void setTimeBetweenStaleEviction(long timeBetweenStaleEviction) {
@@ -447,7 +452,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
                         new Http2SourceConnectionHandlerBuilder(
                                 interfaceId, serverConnectorFuture, serverName, channelInitializer,
                                 allChannels, listenerChannels, reqSizeValidationConfig.getMaxHeaderSize(),
-                                http2InitialWindowSize).build());
+                                http2InitialWindowSize, http2MaxConcurrentStreams).build());
             } else if (ApplicationProtocolNames.HTTP_1_1.equals(protocol)) {
                 // handles pipeline for HTTP/1.x requests after SSL handshake
                 configureHttpPipeline(ctx.pipeline(), Constants.HTTP_SCHEME);

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/HttpServerChannelInitializer.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/HttpServerChannelInitializer.java
@@ -113,7 +113,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
     private EventExecutorGroup pipeliningGroup;
     private boolean webSocketCompressionEnabled;
     private int http2InitialWindowSize;
-    private int http2MaxConcurrentStreams = 100;
+    private int http2MaxActiveStreams = 100;
     private long minIdleTimeInStaleState;
     private long timeBetweenStaleEviction;
     private final BlockingQueue<Http2SourceHandler> http2StaleSourceHandlers = new LinkedBlockingQueue<>();
@@ -262,7 +262,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
         // Add handler to handle http2 requests without an upgrade
         pipeline.addLast(new Http2WithPriorKnowledgeHandler(
                 interfaceId, serverName, serverConnectorFuture, this, allChannels, listenerChannels,
-                reqSizeValidationConfig.getMaxHeaderSize(), http2InitialWindowSize, http2MaxConcurrentStreams));
+                reqSizeValidationConfig.getMaxHeaderSize(), http2InitialWindowSize, http2MaxActiveStreams));
         // Add http2 upgrade decoder and upgrade handler
         final HttpServerCodec sourceCodec = new HttpServerCodec(reqSizeValidationConfig.getMaxInitialLineLength(),
                                                                 reqSizeValidationConfig.getMaxHeaderSize(),
@@ -282,7 +282,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
                         new Http2SourceConnectionHandlerBuilder(
                                 interfaceId, serverConnectorFuture, serverName, this,
                                 this.allChannels, this.listenerChannels, reqSizeValidationConfig.getMaxHeaderSize(),
-                                this.http2InitialWindowSize, this.http2MaxConcurrentStreams).build());
+                                this.http2InitialWindowSize, this.http2MaxActiveStreams).build());
             } else {
                 return null;
             }
@@ -356,8 +356,8 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
         this.http2InitialWindowSize = http2InitialWindowSize;
     }
 
-    void setHttp2MaxConcurrentStreams(int http2MaxConcurrentStreams) {
-        this.http2MaxConcurrentStreams = http2MaxConcurrentStreams;
+    void setHttp2MaxConcurrentStreams(int http2MaxActiveStreams) {
+        this.http2MaxActiveStreams = http2MaxActiveStreams;
     }
 
     void setTimeBetweenStaleEviction(long timeBetweenStaleEviction) {
@@ -452,7 +452,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
                         new Http2SourceConnectionHandlerBuilder(
                                 interfaceId, serverConnectorFuture, serverName, channelInitializer,
                                 allChannels, listenerChannels, reqSizeValidationConfig.getMaxHeaderSize(),
-                                http2InitialWindowSize, http2MaxConcurrentStreams).build());
+                                http2InitialWindowSize, http2MaxActiveStreams).build());
             } else if (ApplicationProtocolNames.HTTP_1_1.equals(protocol)) {
                 // handles pipeline for HTTP/1.x requests after SSL handshake
                 configureHttpPipeline(ctx.pipeline(), Constants.HTTP_SCHEME);

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/ServerConnectorBootstrap.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/ServerConnectorBootstrap.java
@@ -201,8 +201,8 @@ public class ServerConnectorBootstrap {
         httpServerChannelInitializer.setHttp2InitialWindowSize(http2InitialWindowSize);
     }
 
-    public void setHttp2MaxConcurrentStreams(int http2MaxConcurrentStreams) {
-        httpServerChannelInitializer.setHttp2MaxConcurrentStreams(http2MaxConcurrentStreams);
+    public void setHttp2MaxConcurrentStreams(int http2MaxActiveStreams) {
+        httpServerChannelInitializer.setHttp2MaxConcurrentStreams(http2MaxActiveStreams);
     }
 
     public void setTimeBetweenStaleEviction(long timeBetweenStaleEviction) {

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/ServerConnectorBootstrap.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/ServerConnectorBootstrap.java
@@ -201,6 +201,10 @@ public class ServerConnectorBootstrap {
         httpServerChannelInitializer.setHttp2InitialWindowSize(http2InitialWindowSize);
     }
 
+    public void setHttp2MaxConcurrentStreams(int http2MaxConcurrentStreams) {
+        httpServerChannelInitializer.setHttp2MaxConcurrentStreams(http2MaxConcurrentStreams);
+    }
+
     public void setTimeBetweenStaleEviction(long timeBetweenStaleEviction) {
         httpServerChannelInitializer.setTimeBetweenStaleEviction(timeBetweenStaleEviction);
     }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/http2/Http2SourceConnectionHandlerBuilder.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/http2/Http2SourceConnectionHandlerBuilder.java
@@ -64,7 +64,7 @@ public final class Http2SourceConnectionHandlerBuilder
         this.listenerChannels = listenerChannels;
         this.initialSettings().maxHeaderListSize(maxHeaderListSize);
         this.initialSettings().initialWindowSize(initialWindowSize);
-        this.initialSettings().maxActiveStreams(maxActiveStreams);
+        this.initialSettings().maxConcurrentStreams(maxActiveStreams);
     }
 
     @Override

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/http2/Http2SourceConnectionHandlerBuilder.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/http2/Http2SourceConnectionHandlerBuilder.java
@@ -54,7 +54,8 @@ public final class Http2SourceConnectionHandlerBuilder
                                                ChannelGroup allChannels,
                                                ChannelGroup listenerChannels,
                                                long maxHeaderListSize,
-                                               int initialWindowSize) {
+                                               int initialWindowSize,
+                                               int maxConcurrentStreams) {
         this.interfaceId = interfaceId;
         this.serverConnectorFuture = serverConnectorFuture;
         this.serverName = serverName;
@@ -63,6 +64,7 @@ public final class Http2SourceConnectionHandlerBuilder
         this.listenerChannels = listenerChannels;
         this.initialSettings().maxHeaderListSize(maxHeaderListSize);
         this.initialSettings().initialWindowSize(initialWindowSize);
+        this.initialSettings().maxConcurrentStreams(maxConcurrentStreams);
     }
 
     @Override

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/http2/Http2SourceConnectionHandlerBuilder.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/http2/Http2SourceConnectionHandlerBuilder.java
@@ -55,7 +55,7 @@ public final class Http2SourceConnectionHandlerBuilder
                                                ChannelGroup listenerChannels,
                                                long maxHeaderListSize,
                                                int initialWindowSize,
-                                               int maxConcurrentStreams) {
+                                               int maxActiveStreams) {
         this.interfaceId = interfaceId;
         this.serverConnectorFuture = serverConnectorFuture;
         this.serverName = serverName;
@@ -64,7 +64,7 @@ public final class Http2SourceConnectionHandlerBuilder
         this.listenerChannels = listenerChannels;
         this.initialSettings().maxHeaderListSize(maxHeaderListSize);
         this.initialSettings().initialWindowSize(initialWindowSize);
-        this.initialSettings().maxConcurrentStreams(maxConcurrentStreams);
+        this.initialSettings().maxActiveStreams(maxActiveStreams);
     }
 
     @Override

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/http2/Http2WithPriorKnowledgeHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/http2/Http2WithPriorKnowledgeHandler.java
@@ -49,7 +49,7 @@ public class Http2WithPriorKnowledgeHandler extends ChannelInboundHandlerAdapter
     private ChannelGroup listenerChannels;
     private long maxHeaderListSize;
     private int initialWindowSize;
-    private int maxConcurrentStreams;
+    private int maxActiveStreams;
 
     public Http2WithPriorKnowledgeHandler(String interfaceId, String serverName,
                                           ServerConnectorFuture serverConnectorFuture,
@@ -58,7 +58,7 @@ public class Http2WithPriorKnowledgeHandler extends ChannelInboundHandlerAdapter
                                           ChannelGroup listenerChannels,
                                           long maxHeaderListSize,
                                           int initialWindowSize,
-                                          int maxConcurrentStreams) {
+                                          int maxActiveStreams) {
         this.interfaceId = interfaceId;
         this.serverName = serverName;
         this.serverConnectorFuture = serverConnectorFuture;
@@ -67,7 +67,7 @@ public class Http2WithPriorKnowledgeHandler extends ChannelInboundHandlerAdapter
         this.listenerChannels = listenerChannels;
         this.maxHeaderListSize = maxHeaderListSize;
         this.initialWindowSize = initialWindowSize;
-        this.maxConcurrentStreams = maxConcurrentStreams;
+        this.maxActiveStreams = maxActiveStreams;
     }
 
     @Override
@@ -87,7 +87,7 @@ public class Http2WithPriorKnowledgeHandler extends ChannelInboundHandlerAdapter
                         new Http2SourceConnectionHandlerBuilder(
                                 interfaceId, serverConnectorFuture, serverName, serverChannelInitializer,
                                 allChannels, listenerChannels, maxHeaderListSize, initialWindowSize,
-                                maxConcurrentStreams).build());
+                                maxActiveStreams).build());
                 safelyRemoveHandlers(pipeline, Constants.HTTP2_UPGRADE_HANDLER,
                         Constants.HTTP_COMPRESSOR, Constants.HTTP_TRACE_LOG_HANDLER);
             }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/http2/Http2WithPriorKnowledgeHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/http2/Http2WithPriorKnowledgeHandler.java
@@ -49,6 +49,7 @@ public class Http2WithPriorKnowledgeHandler extends ChannelInboundHandlerAdapter
     private ChannelGroup listenerChannels;
     private long maxHeaderListSize;
     private int initialWindowSize;
+    private int maxConcurrentStreams;
 
     public Http2WithPriorKnowledgeHandler(String interfaceId, String serverName,
                                           ServerConnectorFuture serverConnectorFuture,
@@ -56,7 +57,8 @@ public class Http2WithPriorKnowledgeHandler extends ChannelInboundHandlerAdapter
                                           ChannelGroup allChannels,
                                           ChannelGroup listenerChannels,
                                           long maxHeaderListSize,
-                                          int initialWindowSize) {
+                                          int initialWindowSize,
+                                          int maxConcurrentStreams) {
         this.interfaceId = interfaceId;
         this.serverName = serverName;
         this.serverConnectorFuture = serverConnectorFuture;
@@ -65,6 +67,7 @@ public class Http2WithPriorKnowledgeHandler extends ChannelInboundHandlerAdapter
         this.listenerChannels = listenerChannels;
         this.maxHeaderListSize = maxHeaderListSize;
         this.initialWindowSize = initialWindowSize;
+        this.maxConcurrentStreams = maxConcurrentStreams;
     }
 
     @Override
@@ -83,7 +86,8 @@ public class Http2WithPriorKnowledgeHandler extends ChannelInboundHandlerAdapter
                         Constants.HTTP2_SOURCE_CONNECTION_HANDLER,
                         new Http2SourceConnectionHandlerBuilder(
                                 interfaceId, serverConnectorFuture, serverName, serverChannelInitializer,
-                                allChannels, listenerChannels, maxHeaderListSize, initialWindowSize).build());
+                                allChannels, listenerChannels, maxHeaderListSize, initialWindowSize,
+                                maxConcurrentStreams).build());
                 safelyRemoveHandlers(pipeline, Constants.HTTP2_UPGRADE_HANDLER,
                         Constants.HTTP_COMPRESSOR, Constants.HTTP_TRACE_LOG_HANDLER);
             }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/Http2MaxConcurrentStreamsTestCase.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/Http2MaxConcurrentStreamsTestCase.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.stdlib.http.transport.http2;
 
-import io.ballerina.stdlib.http.api.HttpConstants;
 import io.ballerina.stdlib.http.transport.contentaware.listeners.EchoMessageListener;
 import io.ballerina.stdlib.http.transport.contract.Constants;
 import io.ballerina.stdlib.http.transport.contract.HttpClientConnector;
@@ -96,16 +95,16 @@ public class Http2MaxConcurrentStreamsTestCase {
                 "Server must advertise maxConcurrentStreams=100 by default to bound concurrent stream creation");
     }
 
-    @Test(description = "System property http.http2.maxConcurrentStreams must override the default limit, "
-            + "allowing operators to restore old behaviour or set a custom bound")
-    public void testSystemPropertyOverridesMaxConcurrentStreams() throws Exception {
+    @Test(description = "ListenerConfiguration.http2MaxConcurrentStreams must override the default limit per listener, "
+            + "allowing per-listener tuning of concurrent stream capacity")
+    public void testListenerConfigOverridesMaxConcurrentStreams() throws Exception {
         int customLimit = 50;
-        System.setProperty(HttpConstants.HTTP2_MAX_CONCURRENT_STREAMS, String.valueOf(customLimit));
         HttpWsConnectorFactory factory = new DefaultHttpWsConnectorFactory();
         ListenerConfiguration config = new ListenerConfiguration();
         config.setPort(TestUtil.SERVER_PORT2);
         config.setScheme(Constants.HTTP_SCHEME);
         config.setVersion(Constants.HTTP_2_0);
+        config.setHttp2MaxConcurrentStreams(customLimit);
         ServerConnector connector = factory.createServerConnector(
                 TestUtil.getDefaultServerBootstrapConfig(), config);
         ServerConnectorFuture future = connector.start();
@@ -116,14 +115,13 @@ public class Http2MaxConcurrentStreamsTestCase {
             assertNotNull(maxConcurrentStreams,
                     "maxConcurrentStreams must be present in server SETTINGS frame");
             assertEquals((long) maxConcurrentStreams, customLimit,
-                    "System property must override the default maxConcurrentStreams value");
+                    "ListenerConfiguration must override the default maxConcurrentStreams value");
         } finally {
-            System.clearProperty(HttpConstants.HTTP2_MAX_CONCURRENT_STREAMS);
             connector.stop();
             try {
                 factory.shutdown();
             } catch (InterruptedException e) {
-                LOG.warn("Interrupted while shutting down factory for system property test");
+                LOG.warn("Interrupted while shutting down factory for listener config test");
             }
         }
     }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/Http2MaxConcurrentStreamsTestCase.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/Http2MaxConcurrentStreamsTestCase.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.transport.http2;
+
+import io.ballerina.stdlib.http.api.HttpConstants;
+import io.ballerina.stdlib.http.transport.contentaware.listeners.EchoMessageListener;
+import io.ballerina.stdlib.http.transport.contract.Constants;
+import io.ballerina.stdlib.http.transport.contract.HttpClientConnector;
+import io.ballerina.stdlib.http.transport.contract.HttpWsConnectorFactory;
+import io.ballerina.stdlib.http.transport.contract.ServerConnector;
+import io.ballerina.stdlib.http.transport.contract.ServerConnectorFuture;
+import io.ballerina.stdlib.http.transport.contract.config.ListenerConfiguration;
+import io.ballerina.stdlib.http.transport.contractimpl.DefaultHttpWsConnectorFactory;
+import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
+import io.ballerina.stdlib.http.transport.message.HttpMessageDataStreamer;
+import io.ballerina.stdlib.http.transport.util.TestUtil;
+import io.ballerina.stdlib.http.transport.util.client.http2.MessageGenerator;
+import io.ballerina.stdlib.http.transport.util.client.http2.MessageSender;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http2.DefaultHttp2Connection;
+import io.netty.handler.codec.http2.Http2ConnectionHandlerBuilder;
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2FrameAdapter;
+import io.netty.handler.codec.http2.Http2Settings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static io.ballerina.stdlib.http.transport.util.Http2Util.getTestHttp2Client;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Tests that the HTTP/2 server advertises a bounded maxConcurrentStreams value in its initial SETTINGS frame
+ * and that the system property {@code http.http2.maxConcurrentStreams} can override the default.
+ * Verifies the fix for CVE-2026-47244 (unbounded stream creation via DefaultHttp2Connection).
+ */
+public class Http2MaxConcurrentStreamsTestCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Http2MaxConcurrentStreamsTestCase.class);
+    private static final int DEFAULT_MAX_CONCURRENT_STREAMS = 100;
+
+    private ServerConnector serverConnector;
+    private HttpWsConnectorFactory connectorFactory;
+
+    @BeforeClass
+    public void setup() throws InterruptedException {
+        connectorFactory = new DefaultHttpWsConnectorFactory();
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
+        listenerConfiguration.setPort(TestUtil.HTTP_SERVER_PORT);
+        listenerConfiguration.setScheme(Constants.HTTP_SCHEME);
+        listenerConfiguration.setVersion(Constants.HTTP_2_0);
+        serverConnector = connectorFactory.createServerConnector(
+                TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
+        ServerConnectorFuture future = serverConnector.start();
+        future.setHttpConnectorListener(new EchoMessageListener());
+        future.sync();
+    }
+
+    @Test(description = "Server must advertise maxConcurrentStreams=100 in the initial SETTINGS frame by default "
+            + "(CVE-2026-47244: prevents unbounded stream creation and heap exhaustion)")
+    public void testDefaultMaxConcurrentStreamsAdvertisedViaPriorKnowledge() throws Exception {
+        Long maxConcurrentStreams = captureMaxConcurrentStreamsFromSettings(TestUtil.HTTP_SERVER_PORT);
+        assertNotNull(maxConcurrentStreams,
+                "maxConcurrentStreams must be present in server SETTINGS frame");
+        assertEquals((long) maxConcurrentStreams, DEFAULT_MAX_CONCURRENT_STREAMS,
+                "Server must advertise maxConcurrentStreams=100 by default to bound concurrent stream creation");
+    }
+
+    @Test(description = "System property http.http2.maxConcurrentStreams must override the default limit, "
+            + "allowing operators to restore old behaviour or set a custom bound")
+    public void testSystemPropertyOverridesMaxConcurrentStreams() throws Exception {
+        int customLimit = 50;
+        System.setProperty(HttpConstants.HTTP2_MAX_CONCURRENT_STREAMS, String.valueOf(customLimit));
+        HttpWsConnectorFactory factory = new DefaultHttpWsConnectorFactory();
+        ListenerConfiguration config = new ListenerConfiguration();
+        config.setPort(TestUtil.SERVER_PORT2);
+        config.setScheme(Constants.HTTP_SCHEME);
+        config.setVersion(Constants.HTTP_2_0);
+        ServerConnector connector = factory.createServerConnector(
+                TestUtil.getDefaultServerBootstrapConfig(), config);
+        ServerConnectorFuture future = connector.start();
+        future.setHttpConnectorListener(new EchoMessageListener());
+        future.sync();
+        try {
+            Long maxConcurrentStreams = captureMaxConcurrentStreamsFromSettings(TestUtil.SERVER_PORT2);
+            assertNotNull(maxConcurrentStreams,
+                    "maxConcurrentStreams must be present in server SETTINGS frame");
+            assertEquals((long) maxConcurrentStreams, customLimit,
+                    "System property must override the default maxConcurrentStreams value");
+        } finally {
+            System.clearProperty(HttpConstants.HTTP2_MAX_CONCURRENT_STREAMS);
+            connector.stop();
+            try {
+                factory.shutdown();
+            } catch (InterruptedException e) {
+                LOG.warn("Interrupted while shutting down factory for system property test");
+            }
+        }
+    }
+
+    @Test(description = "Normal HTTP/2 requests must succeed when the server enforces the default stream limit")
+    public void testRequestsSucceedWithDefaultStreamLimit() {
+        HttpClientConnector client = getTestHttp2Client(connectorFactory, true);
+        String testValue = "Test Http2 Message";
+        HttpCarbonMessage request = MessageGenerator.generateRequest(HttpMethod.POST, testValue);
+        HttpCarbonMessage response = new MessageSender(client).sendMessage(request);
+        assertNotNull(response, "Expected response not received");
+        String result = TestUtil.getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream());
+        assertEquals(result, testValue, "Expected response payload not received");
+        client.close();
+    }
+
+    @AfterClass
+    public void cleanUp() {
+        serverConnector.stop();
+        try {
+            connectorFactory.shutdown();
+        } catch (InterruptedException e) {
+            LOG.warn("Interrupted while waiting for HttpWsFactory to close");
+        }
+    }
+
+    /**
+     * Opens a raw HTTP/2 prior-knowledge connection to the server, waits for the server's initial SETTINGS frame,
+     * and returns the advertised {@code maxConcurrentStreams} value.
+     */
+    private static Long captureMaxConcurrentStreamsFromSettings(int port) throws Exception {
+        CompletableFuture<Long> maxStreamsFuture = new CompletableFuture<>();
+        EventLoopGroup group = new NioEventLoopGroup(1);
+        try {
+            Bootstrap bootstrap = new Bootstrap();
+            bootstrap.group(group)
+                    .channel(NioSocketChannel.class)
+                    .handler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        protected void initChannel(SocketChannel ch) {
+                            DefaultHttp2Connection connection = new DefaultHttp2Connection(false);
+                            ch.pipeline().addLast(new Http2ConnectionHandlerBuilder()
+                                    .connection(connection)
+                                    .frameListener(new Http2FrameAdapter() {
+                                        @Override
+                                        public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings)
+                                                throws Http2Exception {
+                                            Long value = settings.maxConcurrentStreams();
+                                            if (value != null && !maxStreamsFuture.isDone()) {
+                                                maxStreamsFuture.complete(value);
+                                            }
+                                        }
+                                    })
+                                    .build());
+                        }
+                    });
+            Channel channel = bootstrap.connect(TestUtil.TEST_HOST, port).syncUninterruptibly().channel();
+            Long result = maxStreamsFuture.get(5, TimeUnit.SECONDS);
+            channel.close().syncUninterruptibly();
+            return result;
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+}

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/Http2MaxConcurrentStreamsTestCase.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/Http2MaxConcurrentStreamsTestCase.java
@@ -69,7 +69,7 @@ public class Http2MaxConcurrentStreamsTestCase {
         listenerConfiguration.setPort(port);
         listenerConfiguration.setScheme(Constants.HTTP_SCHEME);
         listenerConfiguration.setVersion(Constants.HTTP_2_0);
-        listenerConfiguration.setHttp2MaxActiveStreams(maxActiveStreams);
+        listenerConfiguration.setHttp2MaxConcurrentStreams(maxActiveStreams);
         serverConnector = connectorFactory.createServerConnector(
                 TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
         ServerConnectorFuture future = serverConnector.start();

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/Http2MaxConcurrentStreamsTestCase.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/Http2MaxConcurrentStreamsTestCase.java
@@ -20,17 +20,12 @@ package io.ballerina.stdlib.http.transport.http2;
 
 import io.ballerina.stdlib.http.transport.contentaware.listeners.EchoMessageListener;
 import io.ballerina.stdlib.http.transport.contract.Constants;
-import io.ballerina.stdlib.http.transport.contract.HttpClientConnector;
 import io.ballerina.stdlib.http.transport.contract.HttpWsConnectorFactory;
 import io.ballerina.stdlib.http.transport.contract.ServerConnector;
 import io.ballerina.stdlib.http.transport.contract.ServerConnectorFuture;
 import io.ballerina.stdlib.http.transport.contract.config.ListenerConfiguration;
 import io.ballerina.stdlib.http.transport.contractimpl.DefaultHttpWsConnectorFactory;
-import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
-import io.ballerina.stdlib.http.transport.message.HttpMessageDataStreamer;
 import io.ballerina.stdlib.http.transport.util.TestUtil;
-import io.ballerina.stdlib.http.transport.util.client.http2.MessageGenerator;
-import io.ballerina.stdlib.http.transport.util.client.http2.MessageSender;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -39,7 +34,6 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http2.DefaultHttp2Connection;
 import io.netty.handler.codec.http2.Http2ConnectionHandlerBuilder;
 import io.netty.handler.codec.http2.Http2Exception;
@@ -47,37 +41,35 @@ import io.netty.handler.codec.http2.Http2FrameAdapter;
 import io.netty.handler.codec.http2.Http2Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import static io.ballerina.stdlib.http.transport.util.Http2Util.getTestHttp2Client;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
 /**
- * Tests that the HTTP/2 server advertises a bounded maxConcurrentStreams value in its initial SETTINGS frame
- * and that the system property {@code http.http2.maxConcurrentStreams} can override the default.
- * Verifies the fix for CVE-2026-47244 (unbounded stream creation via DefaultHttp2Connection).
+ * Tests that the HTTP/2 server advertises the configured {@code SETTINGS_MAX_CONCURRENT_STREAMS}
+ * value (CVE-2026-47244). A finite limit (default 100, sourced from maxActiveStreamsPerConnection)
+ * prevents unbounded stream creation; the unlimited case (Integer.MAX_VALUE) preserves legacy
+ * behaviour for deployments that configured {@code maxActiveStreamsPerConnection = -1}.
  */
 public class Http2MaxConcurrentStreamsTestCase {
 
     private static final Logger LOG = LoggerFactory.getLogger(Http2MaxConcurrentStreamsTestCase.class);
-    private static final int DEFAULT_MAX_CONCURRENT_STREAMS = 100;
 
     private ServerConnector serverConnector;
     private HttpWsConnectorFactory connectorFactory;
 
-    @BeforeClass
-    public void setup() throws InterruptedException {
+    private void startServer(int port, int maxActiveStreams) throws InterruptedException {
         connectorFactory = new DefaultHttpWsConnectorFactory();
         ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
-        listenerConfiguration.setPort(TestUtil.HTTP_SERVER_PORT);
+        listenerConfiguration.setPort(port);
         listenerConfiguration.setScheme(Constants.HTTP_SCHEME);
         listenerConfiguration.setVersion(Constants.HTTP_2_0);
+        listenerConfiguration.setHttp2MaxActiveStreams(maxActiveStreams);
         serverConnector = connectorFactory.createServerConnector(
                 TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
         ServerConnectorFuture future = serverConnector.start();
@@ -85,73 +77,40 @@ public class Http2MaxConcurrentStreamsTestCase {
         future.sync();
     }
 
-    @Test(description = "Server must advertise maxConcurrentStreams=100 in the initial SETTINGS frame by default "
+    @Test(description = "Server must advertise the configured finite limit in the initial SETTINGS frame "
             + "(CVE-2026-47244: prevents unbounded stream creation and heap exhaustion)")
-    public void testDefaultMaxConcurrentStreamsAdvertisedViaPriorKnowledge() throws Exception {
+    public void testServerAdvertisesConfiguredMaxConcurrentStreams() throws Exception {
+        startServer(TestUtil.HTTP_SERVER_PORT, 100);
         Long maxConcurrentStreams = captureMaxConcurrentStreamsFromSettings(TestUtil.HTTP_SERVER_PORT);
-        assertNotNull(maxConcurrentStreams,
-                "maxConcurrentStreams must be present in server SETTINGS frame");
-        assertEquals((long) maxConcurrentStreams, DEFAULT_MAX_CONCURRENT_STREAMS,
-                "Server must advertise maxConcurrentStreams=100 by default to bound concurrent stream creation");
+        assertNotNull(maxConcurrentStreams, "maxConcurrentStreams must be present in server SETTINGS frame");
+        assertEquals((long) maxConcurrentStreams, 100L,
+                "Server must advertise the configured SETTINGS_MAX_CONCURRENT_STREAMS");
     }
 
-    @Test(description = "ListenerConfiguration.http2MaxConcurrentStreams must override the default limit per listener, "
-            + "allowing per-listener tuning of concurrent stream capacity")
-    public void testListenerConfigOverridesMaxConcurrentStreams() throws Exception {
-        int customLimit = 50;
-        HttpWsConnectorFactory factory = new DefaultHttpWsConnectorFactory();
-        ListenerConfiguration config = new ListenerConfiguration();
-        config.setPort(TestUtil.SERVER_PORT2);
-        config.setScheme(Constants.HTTP_SCHEME);
-        config.setVersion(Constants.HTTP_2_0);
-        config.setHttp2MaxConcurrentStreams(customLimit);
-        ServerConnector connector = factory.createServerConnector(
-                TestUtil.getDefaultServerBootstrapConfig(), config);
-        ServerConnectorFuture future = connector.start();
-        future.setHttpConnectorListener(new EchoMessageListener());
-        future.sync();
-        try {
-            Long maxConcurrentStreams = captureMaxConcurrentStreamsFromSettings(TestUtil.SERVER_PORT2);
-            assertNotNull(maxConcurrentStreams,
-                    "maxConcurrentStreams must be present in server SETTINGS frame");
-            assertEquals((long) maxConcurrentStreams, customLimit,
-                    "ListenerConfiguration must override the default maxConcurrentStreams value");
-        } finally {
-            connector.stop();
+    @Test(description = "Unlimited (Integer.MAX_VALUE) advertises an effectively unbounded limit, "
+            + "overriding Netty's default of 100 to preserve legacy behaviour")
+    public void testServerAdvertisesUnlimitedMaxConcurrentStreams() throws Exception {
+        startServer(TestUtil.SERVER_PORT2, Integer.MAX_VALUE);
+        Long maxConcurrentStreams = captureMaxConcurrentStreamsFromSettings(TestUtil.SERVER_PORT2);
+        assertNotNull(maxConcurrentStreams, "maxConcurrentStreams must be present in server SETTINGS frame");
+        assertEquals((long) maxConcurrentStreams, (long) Integer.MAX_VALUE,
+                "Server must advertise an effectively unbounded limit when configured as unlimited");
+    }
+
+    @AfterMethod
+    public void cleanUp() {
+        if (serverConnector != null) {
+            serverConnector.stop();
+        }
+        if (connectorFactory != null) {
             try {
-                factory.shutdown();
+                connectorFactory.shutdown();
             } catch (InterruptedException e) {
-                LOG.warn("Interrupted while shutting down factory for listener config test");
+                LOG.warn("Interrupted while waiting for HttpWsFactory to close");
             }
         }
     }
 
-    @Test(description = "Normal HTTP/2 requests must succeed when the server enforces the default stream limit")
-    public void testRequestsSucceedWithDefaultStreamLimit() {
-        HttpClientConnector client = getTestHttp2Client(connectorFactory, true);
-        String testValue = "Test Http2 Message";
-        HttpCarbonMessage request = MessageGenerator.generateRequest(HttpMethod.POST, testValue);
-        HttpCarbonMessage response = new MessageSender(client).sendMessage(request);
-        assertNotNull(response, "Expected response not received");
-        String result = TestUtil.getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream());
-        assertEquals(result, testValue, "Expected response payload not received");
-        client.close();
-    }
-
-    @AfterClass
-    public void cleanUp() {
-        serverConnector.stop();
-        try {
-            connectorFactory.shutdown();
-        } catch (InterruptedException e) {
-            LOG.warn("Interrupted while waiting for HttpWsFactory to close");
-        }
-    }
-
-    /**
-     * Opens a raw HTTP/2 prior-knowledge connection to the server, waits for the server's initial SETTINGS frame,
-     * and returns the advertised {@code maxConcurrentStreams} value.
-     */
     private static Long captureMaxConcurrentStreamsFromSettings(int port) throws Exception {
         CompletableFuture<Long> maxStreamsFuture = new CompletableFuture<>();
         EventLoopGroup group = new NioEventLoopGroup(1);

--- a/native/src/test/resources/testng.xml
+++ b/native/src/test/resources/testng.xml
@@ -132,6 +132,7 @@
             <class name="io.ballerina.stdlib.http.transport.http2.clienttimeout.TimeoutDuringResponseReceive"/>
             <class name="io.ballerina.stdlib.http.transport.http2.Http2WithHttp2ResetContent"/>
             <class name="io.ballerina.stdlib.http.transport.http2.Http2WithPriorKnowledgeTestCase"/>
+            <class name="io.ballerina.stdlib.http.transport.http2.Http2MaxConcurrentStreamsTestCase"/>
             <class name="io.ballerina.stdlib.http.transport.http2.connectionpool.ConnectionPoolEvictionTest"/>
             <class name="io.ballerina.stdlib.http.transport.http2.connectionpool.H2ConnectionPoolWithALPN"/>
             <class name="io.ballerina.stdlib.http.transport.http2.connectionpool.H2ConnectionPoolWithPriorKnowledge"/>


### PR DESCRIPTION
## Summary

Fixes CVE-2026-47244: \`DefaultHttp2Connection\` in Netty prior to 4.1.135 initializes \`maxActiveStreams\` to \`Integer.MAX_VALUE\`, allowing a single TCP connection to open unbounded concurrent streams and exhaust heap memory (OOM).

- Upgrades Netty to 4.1.135.Final which enforces the \`SETTINGS_MAX_CONCURRENT_STREAMS\` limit at the connection level
- Explicitly sets \`maxConcurrentStreams=100\` (RFC 7540 §6.5.2 recommended default, consistent with Nginx/h2o/Go net/http2) in the server's initial SETTINGS frame via \`Http2SourceConnectionHandlerBuilder\`, covering all three H2 server paths: H2C upgrade, H2C prior-knowledge, and TLS+ALPN
- Adds \`http2MaxActiveStreams\` as an optional field on the Ballerina \`ListenerConfiguration\` record (default: 100), allowing per-listener tuning without affecting the client pool
- Set to \`-1\` for unlimited streams (not recommended for public-facing services)
- Server limit is decoupled from client pool configuration — client \`maxActiveStreamsPerConnection\` and server \`http2MaxActiveStreams\` are now independent knobs

## Performance

Tested with `h2load` (nghttp2/1.69.0) against a stock H2C listener on localhost. **No regression observed** — Netty 4.1.135 includes general throughput improvements alongside the security fix.

| Scenario | Before (Netty 4.1.133) | After (Netty 4.1.135) | Delta |
|---|---|---|---|
| 10 streams × 10 connections | 20,427 req/s | 21,249 req/s | +4% |
| 50 streams × 4 connections | 34,196 req/s | 44,578 req/s | +30% |
| 100 streams × 10 connections | 51,326 req/s | 65,909 req/s | +28% |
| 200 streams × 10 connections (server caps at 100) | 49,262 req/s | 80,923 req/s | +50% |

All 200,000 requests succeeded with 0 errors in both cases. Well-behaved clients (which respect `SETTINGS_MAX_CONCURRENT_STREAMS`) are unaffected by the enforcement. Only clients that previously exploited the lack of enforcement (sending unlimited streams on one connection) are now correctly rate-limited.

Server SETTINGS confirmed via nghttp:
\`\`\`
recv SETTINGS frame
  [SETTINGS_MAX_CONCURRENT_STREAMS(0x03):100]
\`\`\`

## Related Issues
- Public: https://github.com/ballerina-platform/ballerina-library/issues/8833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR introduces configurable HTTP/2 server-side concurrent stream limiting and applies it consistently across all HTTP/2 server connection flows, along with an HTTP stack dependency update.

Key updates:
- Added a new `http2MaxActiveStreams` listener configuration (default: `100`) to control the per-connection HTTP/2 concurrency limit advertised to clients, with `-1` enabling unlimited streams.
- Plumbed the configuration through the HTTP server startup path so it’s applied for H2C upgrade, H2C prior-knowledge, and TLS + ALPN connections.
- Updated the HTTP/2 connection handler/builder to advertise the configured limit to clients via `SETTINGS_MAX_CONCURRENT_STREAMS`.
- Upgraded Netty to `4.1.135.Final`.
- Updated documentation by moving detailed HTTP/2 stream concurrency behavior to `docs/spec/spec.md` (section 2.1.4) and leaving brief feature mentions in the READMEs.
- Added transport tests to verify both finite configured limits and the unlimited (`-1` / unbounded) behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->