### PR TITLE
Pin transitive Ballerina dependency versions across bal pack runs

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -42,6 +42,7 @@ def ballerinaTomlFilePlaceHolder = new File("${project.rootDir}/build-config/res
 def compilerPluginTomlFilePlaceHolder = new File("${project.rootDir}/build-config/resources/CompilerPlugin.toml")
 def ballerinaTomlFile = new File("$project.projectDir/Ballerina.toml")
 def compilerPluginTomlFile = new File("$project.projectDir/CompilerPlugin.toml")
+def dependenciesTomlFile = new File("$project.projectDir/Dependencies.toml")
 
 def stripBallerinaExtensionVersion(String extVersion) {
     if (extVersion.matches(project.ext.timestampedVersionRegex)) {
@@ -149,6 +150,41 @@ dependencies {
     }
 }
 
+// bal pack resolves these transitive Ballerina packages non-deterministically across
+// environments (see https://github.com/ballerina-platform/ballerina-lang/issues/44423) and has
+// twice rewritten Dependencies.toml to versions that are unresolvable on other CI runners.
+// captureLockedDependencyVersions/restoreLockedDependencyVersions pin them back to whatever
+// was already committed, regardless of what bal pack re-resolves them to.
+def pinnedTransitiveDependencies = ["io", "mime", "observe", "os", "task", "time", "url"]
+
+task captureLockedDependencyVersions {
+    doLast {
+        project.ext.lockedDependencyVersions = [:]
+        if (dependenciesTomlFile.exists()) {
+            def text = dependenciesTomlFile.text
+            pinnedTransitiveDependencies.each { pkg ->
+                def matcher = text =~ /(?m)name = "${pkg}"\nversion = "([^"]+)"/
+                if (matcher.find()) {
+                    project.ext.lockedDependencyVersions[pkg] = matcher.group(1)
+                }
+            }
+        }
+    }
+}
+
+task restoreLockedDependencyVersions {
+    doLast {
+        def locked = project.ext.has('lockedDependencyVersions') ? project.ext.lockedDependencyVersions : [:]
+        if (dependenciesTomlFile.exists() && !locked.isEmpty()) {
+            def text = dependenciesTomlFile.text
+            locked.each { pkg, version ->
+                text = text.replaceAll(/(?m)(name = "${pkg}"\nversion = ")[^"]+(")/, "\$1${version}\$2")
+            }
+            dependenciesTomlFile.text = text
+        }
+    }
+}
+
 task updateTomlFiles {
     doLast {
         def stdlibDependentMimeNativeVersion = project.stdlibMimeVersion
@@ -228,6 +264,9 @@ task deleteDependencyTomlFiles {
 }
 
 updateTomlFiles.dependsOn copyStdlibs
+updateTomlFiles.dependsOn captureLockedDependencyVersions
+captureLockedDependencyVersions.mustRunAfter copyStdlibs
+commitTomlFiles.dependsOn restoreLockedDependencyVersions
 
 build.dependsOn "generatePomFileForMavenPublication"
 build.dependsOn ":${packageName}-native:build"


### PR DESCRIPTION
## Summary

`bal pack` non-deterministically re-resolves transitive Ballerina stdlib packages (`io`, `mime`, `observe`, `os`, `task`, `time`, `url`) depending on what's bundled in the local Ballerina distribution at build time. The `commitTomlFiles` task in `ballerina/build.gradle` then auto-commits whatever `Dependencies.toml` ends up with, under the label `[Automated] Update the native jar versions`.

This has broken the build twice now by bumping `Dependencies.toml` to versions that are unresolvable on other CI runners (`cannot resolve module 'ballerina/mime'`):
- Once on `fix/http2-max-concurrent-streams-2.16.x`, manually fixed in `4cd59905e`.
- Again via commit `975dbf861` on `release-2.16.4`, which broke PR #2638 (both Windows and Ubuntu jobs), fixed manually in `4129f3ccc`.

Root cause is an upstream Ballerina resolution-engine bug (`ballerina-lang#44423`, `#39925`, `#44645`) — `bal pack --offline` (hardcoded by `io.ballerina.plugin`, no `sticky` option exposed) can still resolve to a version present in one environment's local cache but absent in another's.

## Fix

Since there's no lever to fix this via the compiler or the Gradle plugin, this pins `Dependencies.toml` at the build.gradle level: capture the versions of the known-drifting packages from `Dependencies.toml` *before* `bal pack` runs, then force-restore those exact values *after* `bal pack` regenerates the file, before `commitTomlFiles` commits it. No hardcoded version numbers — it's self-referential, so it always locks to whatever was already deliberately committed.

## Test plan

- [ ] CI passes on this PR (validates the new tasks don't break normal builds where `Dependencies.toml` doesn't drift)
- [ ] Consider backporting to `2.16.x` given the recurrence there

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated `ballerina/build.gradle` to keep `Dependencies.toml` stable across `bal pack` runs by preserving the previously committed transitive stdlib versions and restoring them after regeneration. The build now captures the existing versions for the affected packages, reapplies them before TOML files are committed, and wires the new tasks into the existing update flow so dependency versions remain consistent across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->