### PR TITLE
Update ballerinaToOpenApi latest patch version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ lz4Version=1.11.1
 marshallingVersion=2.0.5.Final
 protobufVersion=3.25.5
 jacocoVersion=0.8.10
-ballerinaToOpenApiVersion=2.4.0
+ballerinaToOpenApiVersion=2.4.1
 swaggerCoreVersion=2.2.22
 jacksonDatabindVersion=2.17.2
 


### PR DESCRIPTION
## Purpose

Update ballerinaToOpenApiVersion from 2.4.0 to 2.4.1

## Examples

N/A

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
- [ ] Checked the impact on OpenAPI generation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates `ballerinaToOpenApiVersion` from `2.4.0` to `2.4.1` in the Ballerina HTTP module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->