### PR TITLE
[2.16.x] Fix large streamed messages being truncated when the application consumes them slowly

### DIFF
--- a/ballerina/http_back_pressure.bal
+++ b/ballerina/http_back_pressure.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/jballerina.java;
+
+// Maximum time (in seconds) a message transfer may sit still solely because of application back-pressure
+// (a slow reader or writer) before `timeout` is allowed to apply after all. Negative excuses it indefinitely;
+// zero excuses none of it.
+configurable decimal maxBackPressureStallTime = 300;
+
+isolated function externSetMaxBackPressureStallTime(decimal maxBackPressureStallTime) = @java:Method {
+    'class: "io.ballerina.stdlib.http.api.nativeimpl.ExternBackPressureConfig",
+    name: "setMaxBackPressureStallTime"
+} external;

--- a/ballerina/init.bal
+++ b/ballerina/init.bal
@@ -21,6 +21,7 @@ import ballerina/io;
 
 function init() returns error? {
     setModule();
+    externSetMaxBackPressureStallTime(maxBackPressureStallTime);
     LogFileConfig? traceFileConfig = traceLogAdvancedConfig.file;
     check validateFileOrPath(traceFileConfig, traceLogAdvancedConfig.path);
     check validateFileOrPath(accessLogConfig.file, accessLogConfig.path);

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - [Update lz4-java to 1.11.1 to fix CVE-2026-59949](https://github.com/ballerina-platform/ballerina-library/issues/8933)
+- [Fix large streamed message being truncated when the application consumes it more slowly than the socket idle timeout](https://github.com/ballerina-platform/ballerina-library/issues/9033)
 
 ## [2.16.5] - 2026-07-24
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -3,7 +3,7 @@
 _Owners_: @shafreenAnfar @TharmiganK @ayeshLK @chamil321  
 _Reviewers_: @shafreenAnfar @bhashinee @TharmiganK @ldclakmal  
 _Created_: 2021/12/23  
-_Updated_: 2024/06/13   
+_Updated_: 2026/08/18   
 _Edition_: Swan Lake
 
 
@@ -88,6 +88,7 @@ The conforming implementation of the specification is released and included in t
     * 5.2. [Query](#52-query)
     * 5.3. [Matrix](#53-matrix)
 6. [Request and Response](#6-request-and-response)
+    * 6.1. [Message body streaming and back-pressure](#61-message-body-streaming-and-back-pressure)
 7. [Header and Payload](#7-header-and-payload)
     * 7.1. [Parse header functions](#71-parse-header-functions)
     * 7.2. [Links support](#72-links-support)
@@ -2065,6 +2066,21 @@ public class Response {
 ```
 
 The header and the payload manipulation can be done using the functions associated to the response.
+
+### 6.1. Message body streaming and back-pressure
+
+Message bodies are moved on demand rather than buffered in full. An inbound body is read from the connection as the application consumes what has already been delivered, and an outbound body is written as the remote endpoint accepts it. An application that consumes or produces a body slowly therefore holds the transfer still, and no data moves on the connection while that lasts.
+
+The `timeout` of a client or a listener measures the responsiveness of the remote endpoint. Inactivity that is caused by the pace of the application itself is not a sign of an unresponsive remote endpoint, and does not make the connection eligible for the timeout. A large body is transferred in full however slowly it is consumed, while a remote endpoint that genuinely stops responding is still timed out after the configured period. For HTTP/2, this exclusion applies to both directions of a stream: consuming a response slowly and writing a request slowly are both distinguished from an unresponsive peer. For HTTP/1.1, only the inbound direction currently participates in it - an application that reads a request or response body slowly is protected the same way, but a peer that reads a response or request body slowly from an HTTP/1.1 connection is not yet distinguished from one that has genuinely stopped responding.
+
+That allowance is bounded, so that a connection can still be reclaimed from an application that has stopped consuming altogether, or from a remote endpoint that has stopped reading. A transfer that makes no progress at all is treated as stalled once the connection's own `timeout` has already elapsed once for it, and continues to be excused for up to `maxBackPressureStallTime` further seconds before the timeout applies as usual. Any progress, however small, restarts that span. A transfer that never makes progress again is therefore reclaimed after `timeout + maxBackPressureStallTime`, not `maxBackPressureStallTime` alone. The default is 300 seconds:
+
+```toml
+[ballerina.http]
+maxBackPressureStallTime = 600
+```
+
+A negative value allows back-pressure to hold a transfer still indefinitely. Zero removes the allowance entirely, so that any inactivity is treated as an idle connection.
 
 ## 7. Header and Payload
 The header and payload are the main components of the request and response. In the world of MIME, that is called 

--- a/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternBackPressureConfig.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/api/nativeimpl/ExternBackPressureConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.api.nativeimpl;
+
+import io.ballerina.runtime.api.values.BDecimal;
+import io.ballerina.stdlib.http.transport.contractimpl.common.Util;
+
+/**
+ * Carries the module level back-pressure configurables down to the transport.
+ */
+public class ExternBackPressureConfig {
+
+    private ExternBackPressureConfig() {
+    }
+
+    // maxBackPressureStallTime in seconds; negative excuses back-pressure indefinitely, zero excuses none.
+    public static void setMaxBackPressureStallTime(BDecimal maxBackPressureStallTime) {
+        Util.setMaxBackPressureStallTime(maxBackPressureStallTime.floatValue());
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/Http2OutboundRespListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/Http2OutboundRespListener.java
@@ -299,7 +299,8 @@ public class Http2OutboundRespListener implements HttpConnectorListener {
                 new Http2PassthroughBackPressureListener((Http2InboundContentListener) inboundListener));
         } else if (inboundListener instanceof DefaultListener) {
             writer.getBackPressureObservable().setListener(
-                new PassthroughBackPressureListener(outboundResponseMsg.getTargetContext()));
+                new PassthroughBackPressureListener(outboundResponseMsg.getTargetContext(),
+                                                     (DefaultListener) inboundListener));
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/BackPressureAwareIdleStateHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/BackPressureAwareIdleStateHandler.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.transport.contractimpl.common;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+
+import static io.ballerina.stdlib.http.transport.contractimpl.common.Util.isWithinBackPressureStallLimit;
+import static io.ballerina.stdlib.http.transport.contractimpl.common.Util.remainingBackPressureStallNanos;
+import static io.ballerina.stdlib.http.transport.contractimpl.common.Util.ticksInNanos;
+
+/**
+ * An {@link IdleStateHandler} which does not treat inbound application back-pressure as an idle connection:
+ * a slow consumer suspending reads looks identical to an unresponsive peer to a plain {@link IdleStateHandler},
+ * which would otherwise tear down the connection mid-transfer. Fires an {@link IdleStateEvent} only once reads
+ * have been suspended, or genuinely idle, for a full period, and only excuses that for up to
+ * {@code maxBackPressureStallTime} before timing out anyway.
+ */
+public class BackPressureAwareIdleStateHandler extends IdleStateHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BackPressureAwareIdleStateHandler.class);
+    private static final long MIN_RECHECK_NANOS = TimeUnit.MILLISECONDS.toNanos(1);
+
+    private static final AttributeKey<InboundReadState> INBOUND_READ_STATE =
+            AttributeKey.valueOf(BackPressureAwareIdleStateHandler.class, "inboundReadState");
+
+    private final long idleTimeoutNanos;
+
+    public BackPressureAwareIdleStateHandler(long idleTimeout, TimeUnit unit) {
+        super(0, 0, idleTimeout, unit);
+        this.idleTimeoutNanos = unit.toNanos(idleTimeout);
+    }
+
+    // readSuspended is polled when a timeout is about to be raised, rather than cached, so it cannot go stale.
+    // owner identifies the caller (e.g. the DefaultListener for the message currently being read) so that a
+    // resumed() call arriving late - after a reused channel has moved on to tracking a different message - can
+    // be told apart from one that still applies and ignored instead of resetting state it no longer owns.
+    public static void trackInboundReads(Channel channel, Object owner, BooleanSupplier readSuspended) {
+        getOrCreateState(channel).track(owner, readSuspended);
+    }
+
+    // Ignored, like inboundReadsResumed, if owner is no longer the one currently being tracked: untracking is
+    // the more destructive of the two, since clearing readSuspended for a message that has since started being
+    // tracked in its place would leave that message's back-pressure invisible to the idle timeout.
+    public static void untrackInboundReads(Channel channel, Object owner) {
+        getOrCreateState(channel).reset(owner);
+    }
+
+    // Restarts the idle countdown and clears any accumulated stall allowance. Ignored if owner is no longer
+    // the one currently being tracked on this channel.
+    public static void inboundReadsResumed(Channel channel, Object owner) {
+        getOrCreateState(channel).resumed(owner);
+    }
+
+    private static InboundReadState getOrCreateState(Channel channel) {
+        Attribute<InboundReadState> attribute = channel.attr(INBOUND_READ_STATE);
+        InboundReadState state = attribute.get();
+        if (state != null) {
+            return state;
+        }
+        InboundReadState newState = new InboundReadState();
+        InboundReadState existingState = attribute.setIfAbsent(newState);
+        state = existingState != null ? existingState : newState;
+        return state;
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        // Runs before the superclass starts its own timers: a pooled channel can carry state from the
+        // previous message, so every message this handler is installed for starts with a clean countdown.
+        getOrCreateState(ctx.channel()).reset();
+        super.handlerAdded(ctx);
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        // Recorded in the same method the superclass uses to update its own idle baseline for this read, so
+        // the two advance together. Deriving this from DefaultListener's later, separate notification instead
+        // would trail Netty's own baseline by however long that read takes to reach it, which could make a
+        // connection that is now genuinely idle still look recently active when the idle check runs.
+        getOrCreateState(ctx.channel()).recordRawRead();
+        super.channelReadComplete(ctx);
+    }
+
+    @Override
+    protected void channelIdle(ChannelHandlerContext ctx, IdleStateEvent evt) throws Exception {
+        InboundReadState state = ctx.channel().attr(INBOUND_READ_STATE).get();
+        if (state != null && isCausedByBackPressure(state)) {
+            long stallStart = state.recordStall();
+            if (isWithinBackPressureStallLimit(stallStart)) {
+                scheduleStallLimitRecheck(ctx, evt, state, stallStart);
+                LOG.debug("Idle timeout not triggered on {}, inbound reads are held up by application "
+                                  + "back-pressure", ctx.channel().id());
+                return;
+            }
+            LOG.debug("Idle timeout triggered on {}, inbound reads have been held up by application "
+                              + "back-pressure past the permitted stall time without any progress",
+                      ctx.channel().id());
+        }
+        super.channelIdle(ctx, evt);
+    }
+
+    // Netty only rechecks once per idleTimeoutNanos, too coarse when maxBackPressureStallTime is shorter, so
+    // this schedules an extra, cancellable recheck timed to the remaining allowance.
+    private void scheduleStallLimitRecheck(ChannelHandlerContext ctx, IdleStateEvent evt, InboundReadState state,
+                                           long stallStart) {
+        state.cancelStallLimitRecheck();
+        long remaining = remainingBackPressureStallNanos(stallStart);
+        if (remaining < 0 || remaining >= idleTimeoutNanos) {
+            return;
+        }
+        long delay = Math.max(remaining, MIN_RECHECK_NANOS);
+        state.setStallLimitRecheckTask(ctx.channel().eventLoop().schedule(() -> {
+            if (ctx.isRemoved()) {
+                return;
+            }
+            try {
+                channelIdle(ctx, evt);
+            } catch (Exception e) {
+                LOG.debug("Error while re-checking the back-pressure stall limit on {}", ctx.channel().id(), e);
+            }
+        }, delay, TimeUnit.NANOSECONDS));
+    }
+
+    private boolean isCausedByBackPressure(InboundReadState state) {
+        if (state.isReadSuspended()) {
+            // Remembered so that the resume which ends this suspension - the one this check has just run into
+            // - is the one allowed to restart the countdown. See resumed().
+            state.noteSuspensionSeen();
+            return true;
+        }
+        // Only while a message is actually being tracked. On a connection no application back-pressure has
+        // been applied to, a channelReadComplete that carried no decoded message - a partial chunk, a partial
+        // TLS record, a read that returned nothing - must not excuse a timeout that is otherwise due.
+        return state.isTracking() && ticksInNanos() - state.getLastProgressTimeNanos() < idleTimeoutNanos;
+    }
+
+    // Per channel view of whether the transport is currently asking the socket for inbound data.
+    private static final class InboundReadState {
+
+        private volatile Object owner;
+        private volatile BooleanSupplier readSuspended;
+        // Updated only from channelReadComplete, in step with the superclass's own idle baseline - see there.
+        private volatile long lastRawReadTimeNanos = ticksInNanos();
+        // When the transport last went back to asking the peer for data after a suspension the idle check had
+        // run into. Kept alongside the raw read time because such a resume leaves that one stale by
+        // definition: the peer has to be given a full period to answer the read only now being reissued to it.
+        private volatile long lastResumeTimeNanos = ticksInNanos();
+        private final AtomicBoolean suspensionSeen = new AtomicBoolean();
+        private final AtomicLong stallStartTimeNanos = new AtomicLong();
+        private final AtomicReference<ScheduledFuture<?>> stallLimitRecheckTask = new AtomicReference<>();
+
+        void track(Object newOwner, BooleanSupplier suspensionCheck) {
+            owner = newOwner;
+            readSuspended = suspensionCheck;
+            // A newly tracked message starts on a clean stall clock. Whatever the previous one left behind on
+            // this channel - it may have ended without ever untracking - is not this message's to answer for.
+            lastResumeTimeNanos = ticksInNanos();
+            suspensionSeen.set(false);
+            clearStall();
+        }
+
+        void noteSuspensionSeen() {
+            suspensionSeen.set(true);
+        }
+
+        boolean isTracking() {
+            return owner != null;
+        }
+
+        void recordRawRead() {
+            lastRawReadTimeNanos = ticksInNanos();
+        }
+
+        // Ignored if callerOwner is not the owner currently being tracked: a message's own progress must not
+        // resurrect stall-clock state that, on a reused channel, already belongs to whatever message has since
+        // started being tracked in its place.
+        void resumed(Object callerOwner) {
+            if (callerOwner != owner) {
+                return;
+            }
+            // Only the resume that ends a suspension the idle check actually ran into restarts the countdown.
+            // Progress reported while reads were never suspended is already covered by the raw read time,
+            // which, being recorded in the same method the superclass records its own baseline in, can never
+            // run ahead of it and hand a connection nothing is holding up an undeserved reprieve.
+            if (suspensionSeen.compareAndSet(true, false)) {
+                lastResumeTimeNanos = ticksInNanos();
+            }
+            clearStall();
+        }
+
+        // Guarded the same way resumed() is - see untrackInboundReads.
+        void reset(Object callerOwner) {
+            if (callerOwner != owner) {
+                return;
+            }
+            reset();
+        }
+
+        void reset() {
+            owner = null;
+            readSuspended = null;
+            // A freshly tracked message starts out counted as recently active, the same way a freshly added
+            // handler does, rather than inheriting a possibly stale timestamp from whatever this channel was
+            // last used for.
+            lastRawReadTimeNanos = ticksInNanos();
+            lastResumeTimeNanos = ticksInNanos();
+            suspensionSeen.set(false);
+            clearStall();
+        }
+
+        private void clearStall() {
+            stallStartTimeNanos.set(0);
+            cancelStallLimitRecheck();
+        }
+
+        void setStallLimitRecheckTask(ScheduledFuture<?> task) {
+            ScheduledFuture<?> previous = stallLimitRecheckTask.getAndSet(task);
+            if (previous != null) {
+                previous.cancel(false);
+            }
+        }
+
+        void cancelStallLimitRecheck() {
+            ScheduledFuture<?> task = stallLimitRecheckTask.getAndSet(null);
+            if (task != null) {
+                task.cancel(false);
+            }
+        }
+
+        boolean isReadSuspended() {
+            BooleanSupplier suspensionCheck = readSuspended;
+            return suspensionCheck != null && suspensionCheck.getAsBoolean();
+        }
+
+        // The later of the two, so that neither a peer that has just sent something nor a read that has just
+        // been reissued to it is mistaken for silence.
+        long getLastProgressTimeNanos() {
+            return Math.max(lastRawReadTimeNanos, lastResumeTimeNanos);
+        }
+
+        // Marks the channel as stalled if it was not already, and returns when the stall began; compareAndSet
+        // keeps the original start time so the allowance covers the whole stall, not just the latest check.
+        long recordStall() {
+            long now = ticksInNanos();
+            return stallStartTimeNanos.compareAndSet(0, now) ? now : stallStartTimeNanos.get();
+        }
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/FlowControlStallTracker.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/FlowControlStallTracker.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.transport.contractimpl.common;
+
+import io.netty.handler.codec.http2.Http2Connection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static io.ballerina.stdlib.http.transport.contractimpl.common.Util.isStreamBlockedByFlowControl;
+import static io.ballerina.stdlib.http.transport.contractimpl.common.Util.isWithinBackPressureStallLimit;
+import static io.ballerina.stdlib.http.transport.contractimpl.common.Util.remainingBackPressureStallNanos;
+import static io.ballerina.stdlib.http.transport.contractimpl.common.Util.ticksInNanos;
+
+/**
+ * Decides, on behalf of both HTTP/2 stream timeout handlers, whether the silence on a stream is down to flow
+ * control rather than an unresponsive peer. Also excuses one extra check after the window has just reopened,
+ * so a timer landing in that race does not fail a stream a slow peer would otherwise still complete, and caps
+ * the whole reprieve at {@code maxBackPressureStallTime} so a peer that never reopens the window cannot pin a
+ * stream forever.
+ */
+public class FlowControlStallTracker {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FlowControlStallTracker.class);
+    private static final long MIN_RECHECK_NANOS = TimeUnit.MILLISECONDS.toNanos(1);
+
+    private final Supplier<Http2Connection> connectionSupplier;
+    // Streams whose recent timeout checks found them held up by flow control, and when that started.
+    private final Map<Integer, Long> stallStartTimes = new ConcurrentHashMap<>();
+
+    public FlowControlStallTracker(Supplier<Http2Connection> connectionSupplier) {
+        this.connectionSupplier = connectionSupplier;
+    }
+
+    // True if the silence on streamId is explained by flow control and the maxBackPressureStallTime cap has
+    // not been reached, i.e. the caller's timeout should be excused rather than failing the stream.
+    public boolean isStalledByFlowControl(int streamId) {
+        Long stallStartTime = stallStartTimes.get(streamId);
+        if (stallStartTime != null && !isWithinBackPressureStallLimit(stallStartTime)) {
+            // Left standing: until something actually moves, every further period should time out too.
+            LOG.debug("Stream {} has been held up by flow control past the permitted stall time without any "
+                              + "progress, letting the idle timeout run", streamId);
+            return false;
+        }
+        if (isStreamBlockedByFlowControl(connectionSupplier.get(), streamId)) {
+            // First time seen stalled: still check against the limit immediately, so a zero (or already
+            // elapsed) allowance is not excused for one free period.
+            long startTime = stallStartTime != null ? stallStartTime
+                    : stallStartTimes.merge(streamId, ticksInNanos(), (existing, fresh) -> existing);
+            return isWithinBackPressureStallLimit(startTime);
+        }
+        if (stallStartTime != null) {
+            // The window has only just reopened; give the peer one full period to act before failing it.
+            stallStartTimes.remove(streamId);
+            return true;
+        }
+        return false;
+    }
+
+    // Delay before rechecking a stream currently excused for flow control: idleTimeNanos, unless
+    // maxBackPressureStallTime is shorter, so a short cap does not have to wait a full idle period.
+    public long nextRecheckDelayNanos(int streamId, long idleTimeNanos) {
+        Long stallStartTime = stallStartTimes.get(streamId);
+        if (stallStartTime == null) {
+            return idleTimeNanos;
+        }
+        long remaining = remainingBackPressureStallNanos(stallStartTime);
+        if (remaining < 0) {
+            return idleTimeNanos;
+        }
+        return Math.min(idleTimeNanos, Math.max(remaining, MIN_RECHECK_NANOS));
+    }
+
+    public void recordProgress(int streamId) {
+        stallStartTimes.remove(streamId);
+    }
+
+    public void remove(int streamId) {
+        stallStartTimes.remove(streamId);
+    }
+
+    public void clear() {
+        stallStartTimes.clear();
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/Util.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/common/Util.java
@@ -66,8 +66,11 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.Http2LocalFlowController;
+import io.netty.handler.codec.http2.Http2Stream;
 import io.netty.handler.codec.http2.HttpConversionUtil;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolNames;
@@ -147,6 +150,13 @@ public class Util {
     private static final Logger LOG = LoggerFactory.getLogger(Util.class);
     public static final String HTTP_1_1 = "http/1.1";
     private static final float EPSILON = 0.00001f;
+
+    // Default for the maxBackPressureStallTime configurable, in seconds; negative excuses back-pressure
+    // indefinitely, zero excuses none of it.
+    public static final double DEFAULT_MAX_BACK_PRESSURE_STALL_TIME = 300;
+
+    private static volatile long maxBackPressureStallTimeNanos =
+            (long) (DEFAULT_MAX_BACK_PRESSURE_STALL_TIME * 1_000_000_000L);
 
     private static String getStringValue(HttpCarbonMessage msg, String key, String defaultValue) {
         String value = (String) msg.getProperty(key);
@@ -1035,7 +1045,8 @@ public class Util {
             backpressureHandler.getBackPressureObservable().setListener(
                 new Http2PassthroughBackPressureListener((Http2InboundContentListener) inboundListener));
         } else if (inboundListener instanceof DefaultListener && ctx != null) {
-            backpressureHandler.getBackPressureObservable().setListener(new PassthroughBackPressureListener(ctx));
+            backpressureHandler.getBackPressureObservable().setListener(
+                new PassthroughBackPressureListener(ctx, (DefaultListener) inboundListener));
         }
     }
 
@@ -1179,5 +1190,63 @@ public class Util {
         String[] protocols = {HTTP_1_1};
         sslParams.setApplicationProtocols(protocols);
         sslEngine.setSSLParameters(sslParams);
+    }
+
+    // True if the stream is quiet because of HTTP/2 flow control - our inbound window closed on an unconsumed
+    // message, or our outbound message queued waiting on the peer's window - rather than an unresponsive peer.
+    public static boolean isStreamBlockedByFlowControl(Http2Connection connection, int streamId) {
+        if (connection == null) {
+            return false;
+        }
+        Http2Stream stream = connection.stream(streamId);
+        if (stream == null) {
+            return false;
+        }
+        try {
+            Http2LocalFlowController localFlowController = connection.local().flowController();
+            // The peer cannot send: we have not consumed what it already delivered.
+            if (localFlowController.windowSize(stream) <= 0) {
+                return true;
+            }
+            // The shared connection window is exhausted by unconsumed content on this or a sibling stream.
+            if (localFlowController.unconsumedBytes(stream) > 0
+                    && localFlowController.windowSize(connection.connectionStream()) <= 0) {
+                return true;
+            }
+            // We cannot send: our message is queued because the peer has not opened its window.
+            return connection.remote().flowController().hasFlowControlled(stream);
+        } catch (RuntimeException e) {
+            LOG.debug("Could not read the flow control state of stream {}", streamId, e);
+            return false;
+        }
+    }
+
+    // Sets the maxBackPressureStallTime allowance, in seconds. Called once during module initialisation.
+    public static void setMaxBackPressureStallTime(double seconds) {
+        maxBackPressureStallTimeNanos = seconds < 0 ? -1L : (long) (seconds * 1_000_000_000L);
+    }
+
+    // True if a back-pressure stall that began at stallStartTimeNanos (from ticksInNanos()) is still within
+    // its maxBackPressureStallTime allowance.
+    public static boolean isWithinBackPressureStallLimit(long stallStartTimeNanos) {
+        long limitNanos = maxBackPressureStallTimeNanos;
+        if (limitNanos < 0) {
+            return true;
+        }
+        if (limitNanos == 0) {
+            return false;
+        }
+        return ticksInNanos() - stallStartTimeNanos < limitNanos;
+    }
+
+    // Remaining maxBackPressureStallTime allowance in nanoseconds for a stall that began at stallStartTimeNanos,
+    // or negative if the allowance is unlimited. Lets a caller reschedule its own recheck for exactly when the
+    // allowance runs out instead of waiting for the next fixed idle period.
+    public static long remainingBackPressureStallNanos(long stallStartTimeNanos) {
+        long limitNanos = maxBackPressureStallTimeNanos;
+        if (limitNanos < 0) {
+            return -1L;
+        }
+        return Math.max(0L, limitNanos - (ticksInNanos() - stallStartTimeNanos));
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/HttpServerChannelInitializer.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/HttpServerChannelInitializer.java
@@ -20,6 +20,7 @@ import io.ballerina.stdlib.http.transport.contract.ServerConnectorFuture;
 import io.ballerina.stdlib.http.transport.contract.config.ChunkConfig;
 import io.ballerina.stdlib.http.transport.contract.config.InboundMsgSizeValidationConfig;
 import io.ballerina.stdlib.http.transport.contract.config.KeepAliveConfig;
+import io.ballerina.stdlib.http.transport.contractimpl.common.BackPressureAwareIdleStateHandler;
 import io.ballerina.stdlib.http.transport.contractimpl.common.BackPressureHandler;
 import io.ballerina.stdlib.http.transport.contractimpl.common.Util;
 import io.ballerina.stdlib.http.transport.contractimpl.common.certificatevalidation.CertificateVerificationException;
@@ -52,7 +53,6 @@ import io.netty.handler.ssl.ReferenceCountedOpenSslEngine;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
-import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.AsciiString;
 import io.netty.util.concurrent.EventExecutorGroup;
 import org.bouncycastle.cert.ocsp.OCSPResp;
@@ -248,7 +248,8 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
                                                  this.pipeliningGroup));
         if (socketIdleTimeout >= 0) {
             serverPipeline.addBefore(Constants.HTTP_SOURCE_HANDLER, Constants.IDLE_STATE_HANDLER,
-                                     new IdleStateHandler(0, 0, socketIdleTimeout, TimeUnit.MILLISECONDS));
+                                     new BackPressureAwareIdleStateHandler(socketIdleTimeout,
+                                                                          TimeUnit.MILLISECONDS));
         }
         serverPipeline.addLast(Constants.HTTP_EXCEPTION_HANDLER, new HttpExceptionHandler());
     }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/http2/Http2ServerTimeoutHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/http2/Http2ServerTimeoutHandler.java
@@ -19,9 +19,11 @@
 package io.ballerina.stdlib.http.transport.contractimpl.listener.http2;
 
 import io.ballerina.stdlib.http.transport.contract.ServerConnectorFuture;
+import io.ballerina.stdlib.http.transport.contractimpl.common.FlowControlStallTracker;
 import io.ballerina.stdlib.http.transport.contractimpl.sender.http2.Http2DataEventListener;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2Error;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Headers;
@@ -47,12 +49,14 @@ public class Http2ServerTimeoutHandler implements Http2DataEventListener {
     private Http2ServerChannel http2ServerChannel;
     private Map<Integer, ScheduledFuture<?>> timerTasks;
     private ServerConnectorFuture serverConnectorFuture;
+    private final FlowControlStallTracker flowControlStallTracker;
 
     Http2ServerTimeoutHandler(long idleTimeMills, Http2ServerChannel serverChannel,
-                              ServerConnectorFuture serverConnectorFuture) {
+                              ServerConnectorFuture serverConnectorFuture, Http2Connection connection) {
         this.idleTimeNanos = Math.max(TimeUnit.MILLISECONDS.toNanos(idleTimeMills), MIN_TIMEOUT_NANOS);
         this.http2ServerChannel = serverChannel;
         this.serverConnectorFuture = serverConnectorFuture;
+        this.flowControlStallTracker = new FlowControlStallTracker(() -> connection);
         timerTasks = new ConcurrentHashMap<>();
     }
 
@@ -104,6 +108,7 @@ public class Http2ServerTimeoutHandler implements Http2DataEventListener {
 
     @Override
     public void onStreamClose(int streamId) {
+        flowControlStallTracker.remove(streamId);
         ScheduledFuture timerTask = timerTasks.get(streamId);
         if (timerTask != null) {
             if (LOG.isDebugEnabled()) {
@@ -118,6 +123,7 @@ public class Http2ServerTimeoutHandler implements Http2DataEventListener {
     public void destroy() {
         timerTasks.forEach((streamId, task) -> task.cancel(false));
         timerTasks.clear();
+        flowControlStallTracker.clear();
     }
 
     private class IdleTimeoutTask implements Runnable {
@@ -139,13 +145,22 @@ public class Http2ServerTimeoutHandler implements Http2DataEventListener {
 
         private void runTimeOutLogic(InboundMessageHolder msgHolder) {
             long nextDelay = getNextDelay(msgHolder);
-            if (nextDelay <= 0) {
-                handleTimeout(msgHolder);
-                closeStream(msgHolder, streamId, ctx);
-            } else {
+            if (nextDelay > 0) {
                 // Read or write occurred before the timeout - set a new timeout with shorter delay.
+                flowControlStallTracker.recordProgress(streamId);
                 timerTasks.put(streamId, schedule(ctx, this, nextDelay));
+                return;
             }
+            if (flowControlStallTracker.isStalledByFlowControl(streamId)) {
+                // lastReadWriteTime is left untouched: bumping it would make the next getNextDelay() see real
+                // progress and call recordProgress(), letting a permanently stalled stream renew its excuse
+                // forever instead of ever hitting maxBackPressureStallTime.
+                long recheckDelay = flowControlStallTracker.nextRecheckDelayNanos(streamId, idleTimeNanos);
+                timerTasks.put(streamId, schedule(ctx, this, recheckDelay));
+                return;
+            }
+            handleTimeout(msgHolder);
+            closeStream(msgHolder, streamId, ctx);
         }
 
         private long getNextDelay(InboundMessageHolder msgHolder) {

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/http2/Http2SourceHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/listener/http2/Http2SourceHandler.java
@@ -113,7 +113,7 @@ public final class Http2SourceHandler extends ChannelInboundHandlerAdapter {
                 serverChannelInitializer.getSocketIdleTimeout();
         http2ServerChannel.addDataEventListener(Constants.IDLE_STATE_HANDLER,
                                                 new Http2ServerTimeoutHandler(serverTimeout, http2ServerChannel,
-                                                                              serverConnectorFuture));
+                                                                              serverConnectorFuture, conn));
     }
 
     private void setRemoteFlowController() {

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/http2/Http2ClientTimeoutHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/http2/Http2ClientTimeoutHandler.java
@@ -20,6 +20,7 @@ package io.ballerina.stdlib.http.transport.contractimpl.sender.http2;
 
 import io.ballerina.stdlib.http.transport.contract.Constants;
 import io.ballerina.stdlib.http.transport.contract.exceptions.EndpointTimeOutException;
+import io.ballerina.stdlib.http.transport.contractimpl.common.FlowControlStallTracker;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderException;
@@ -53,13 +54,19 @@ public class Http2ClientTimeoutHandler implements Http2DataEventListener {
     private static final Logger LOG = LoggerFactory.getLogger(Http2ClientTimeoutHandler.class);
     private static final long MIN_TIMEOUT_NANOS = TimeUnit.MILLISECONDS.toNanos(1);
 
-    private long idleTimeNanos;
+    // Only the budget for streams timed from onStreamInit. A stream that goes through createTimerTask - an
+    // Expect: 100-continue wait, for one - carries its own instead. Each IdleTimeoutTask keeps its own copy so
+    // that one stream's much shorter timeout cannot corrupt the budget every other stream multiplexed on this
+    // connection is judged against.
+    private final long defaultIdleTimeNanos;
     private Http2ClientChannel http2ClientChannel;
     private Map<Integer, ScheduledFuture<?>> timerTasks;
+    private final FlowControlStallTracker flowControlStallTracker;
 
     public Http2ClientTimeoutHandler(long idleTimeMills, Http2ClientChannel http2ClientChannel) {
-        this.idleTimeNanos = Math.max(TimeUnit.MILLISECONDS.toNanos(idleTimeMills), MIN_TIMEOUT_NANOS);
+        this.defaultIdleTimeNanos = Math.max(TimeUnit.MILLISECONDS.toNanos(idleTimeMills), MIN_TIMEOUT_NANOS);
         this.http2ClientChannel = http2ClientChannel;
+        this.flowControlStallTracker = new FlowControlStallTracker(http2ClientChannel::getConnection);
         timerTasks = new ConcurrentHashMap<>();
     }
 
@@ -76,15 +83,19 @@ public class Http2ClientTimeoutHandler implements Http2DataEventListener {
     private void setTimerTask(ChannelHandlerContext ctx, int streamId, OutboundMsgHolder outboundMsgHolder) {
         if (outboundMsgHolder != null) {
             outboundMsgHolder.setLastReadWriteTime(ticksInNanos());
-            timerTasks.put(streamId,
-                           schedule(ctx, new IdleTimeoutTask(ctx, streamId, false), idleTimeNanos));
+            timerTasks.put(streamId, schedule(
+                    ctx, new IdleTimeoutTask(ctx, streamId, false, defaultIdleTimeNanos), defaultIdleTimeNanos));
         }
     }
 
     public void createTimerTask(ChannelHandlerContext ctx, int streamId, long timeOut, boolean expectContinue) {
-        this.idleTimeNanos = timeOut;
-        timerTasks.put(streamId, schedule(ctx, new IdleTimeoutTask(ctx, streamId, expectContinue),
-                TimeUnit.MILLISECONDS.toNanos(timeOut)));
+        // timeOut is in milliseconds; idle times are kept in nanoseconds everywhere else in this class. Floored
+        // the same way the default is, so a socket idle timeout small enough to divide down to zero (see
+        // WaitingFor100Continue) does not leave the stream with a budget that has expired before it is set.
+        long idleTimeNanos = Math.max(TimeUnit.MILLISECONDS.toNanos(timeOut), MIN_TIMEOUT_NANOS);
+        timerTasks.put(streamId,
+                       schedule(ctx, new IdleTimeoutTask(ctx, streamId, expectContinue, idleTimeNanos),
+                                idleTimeNanos));
     }
 
     @Override
@@ -125,6 +136,7 @@ public class Http2ClientTimeoutHandler implements Http2DataEventListener {
 
     @Override
     public void onStreamClose(int streamId) {
+        flowControlStallTracker.remove(streamId);
         ScheduledFuture timerTask = timerTasks.get(streamId);
         if (timerTask != null) {
             timerTask.cancel(false);
@@ -136,6 +148,7 @@ public class Http2ClientTimeoutHandler implements Http2DataEventListener {
     public void destroy() {
         timerTasks.forEach((streamId, task) -> task.cancel(false));
         timerTasks.clear();
+        flowControlStallTracker.clear();
     }
 
     private void updateLastReadTime(int streamId, boolean endOfStream) {
@@ -168,11 +181,15 @@ public class Http2ClientTimeoutHandler implements Http2DataEventListener {
         private ChannelHandlerContext ctx;
         private int streamId;
         private boolean expectContinue;
+        // Captured per task rather than read off the handler, so this stream's budget cannot be overwritten
+        // by another stream on the same connection creating its own timer task (e.g. Expect: 100-continue).
+        private final long idleTimeNanos;
 
-        IdleTimeoutTask(ChannelHandlerContext ctx, int streamId, boolean expectContinue) {
+        IdleTimeoutTask(ChannelHandlerContext ctx, int streamId, boolean expectContinue, long idleTimeNanos) {
             this.ctx = ctx;
             this.streamId = streamId;
             this.expectContinue = expectContinue;
+            this.idleTimeNanos = idleTimeNanos;
         }
 
         @Override
@@ -189,18 +206,27 @@ public class Http2ClientTimeoutHandler implements Http2DataEventListener {
 
         private void runTimeOutLogic(OutboundMsgHolder msgHolder, boolean primary) {
             long nextDelay = getNextDelay(msgHolder);
-            if (nextDelay <= 0) {
-                if (!expectContinue) {
-                    closeStream(streamId, ctx);
-                }
-                if (primary) {
-                    handlePrimaryResponseTimeout(msgHolder);
-                } else {
-                    handlePushResponseTimeout(msgHolder);
-                }
-            } else {
+            if (nextDelay > 0) {
                 // Write occurred before the timeout - set a new timeout with shorter delay.
+                flowControlStallTracker.recordProgress(streamId);
                 timerTasks.put(streamId, schedule(ctx, this, nextDelay));
+                return;
+            }
+            if (flowControlStallTracker.isStalledByFlowControl(streamId)) {
+                // lastReadWriteTime is left untouched: bumping it would make the next getNextDelay() see
+                // real progress and call recordProgress(), letting a permanently stalled stream renew its
+                // excuse forever instead of ever hitting maxBackPressureStallTime.
+                long recheckDelay = flowControlStallTracker.nextRecheckDelayNanos(streamId, idleTimeNanos);
+                timerTasks.put(streamId, schedule(ctx, this, recheckDelay));
+                return;
+            }
+            if (!expectContinue) {
+                closeStream(streamId, ctx);
+            }
+            if (primary) {
+                handlePrimaryResponseTimeout(msgHolder);
+            } else {
+                handlePushResponseTimeout(msgHolder);
             }
         }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/http2/RequestWriteStarter.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/http2/RequestWriteStarter.java
@@ -72,7 +72,8 @@ public class RequestWriteStarter {
                 new Http2PassthroughBackPressureListener((Http2InboundContentListener) inboundListener));
         } else if (inboundListener instanceof DefaultListener) {
             outboundMsgHolder.getBackPressureObservable().setListener(
-                new PassthroughBackPressureListener(outboundMsgHolder.getRequest().getSourceContext()));
+                new PassthroughBackPressureListener(outboundMsgHolder.getRequest().getSourceContext(),
+                                                     (DefaultListener) inboundListener));
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/states/Sending100Continue.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/states/Sending100Continue.java
@@ -21,6 +21,7 @@ package io.ballerina.stdlib.http.transport.contractimpl.sender.states;
 import io.ballerina.stdlib.http.transport.contract.Constants;
 import io.ballerina.stdlib.http.transport.contract.HttpResponseFuture;
 import io.ballerina.stdlib.http.transport.contract.exceptions.ClientConnectorException;
+import io.ballerina.stdlib.http.transport.contractimpl.common.BackPressureAwareIdleStateHandler;
 import io.ballerina.stdlib.http.transport.contractimpl.common.states.SenderReqRespStateManager;
 import io.ballerina.stdlib.http.transport.contractimpl.sender.TargetHandler;
 import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
@@ -65,7 +66,8 @@ public class Sending100Continue implements SenderState {
 
     private void configIdleTimeoutTrigger(int socketIdleTimeout) {
         ChannelPipeline pipeline = senderReqRespStateManager.nettyTargetChannel.pipeline();
-        IdleStateHandler idleStateHandler = new IdleStateHandler(0, 0, socketIdleTimeout, TimeUnit.MILLISECONDS);
+        IdleStateHandler idleStateHandler =
+                new BackPressureAwareIdleStateHandler(socketIdleTimeout, TimeUnit.MILLISECONDS);
         safelyRemoveHandlers(pipeline, Constants.IDLE_STATE_HANDLER);
         if (pipeline.get(Constants.TARGET_HANDLER) == null) {
             pipeline.addLast(Constants.IDLE_STATE_HANDLER, idleStateHandler);

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/states/SendingHeaders.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/contractimpl/sender/states/SendingHeaders.java
@@ -21,6 +21,7 @@ package io.ballerina.stdlib.http.transport.contractimpl.sender.states;
 import io.ballerina.stdlib.http.transport.contract.Constants;
 import io.ballerina.stdlib.http.transport.contract.HttpResponseFuture;
 import io.ballerina.stdlib.http.transport.contract.config.ChunkConfig;
+import io.ballerina.stdlib.http.transport.contractimpl.common.BackPressureAwareIdleStateHandler;
 import io.ballerina.stdlib.http.transport.contractimpl.common.Util;
 import io.ballerina.stdlib.http.transport.contractimpl.common.states.SenderReqRespStateManager;
 import io.ballerina.stdlib.http.transport.contractimpl.sender.TargetHandler;
@@ -84,7 +85,8 @@ public class SendingHeaders implements SenderState {
 
     private void configIdleTimeoutTrigger(int socketIdleTimeout) {
         ChannelPipeline pipeline = senderReqRespStateManager.nettyTargetChannel.pipeline();
-        IdleStateHandler idleStateHandler = new IdleStateHandler(0, 0, socketIdleTimeout, TimeUnit.MILLISECONDS);
+        IdleStateHandler idleStateHandler =
+                new BackPressureAwareIdleStateHandler(socketIdleTimeout, TimeUnit.MILLISECONDS);
         if (pipeline.get(Constants.TARGET_HANDLER) == null) {
             pipeline.addLast(Constants.IDLE_STATE_HANDLER, idleStateHandler);
         } else {

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/message/DefaultListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/message/DefaultListener.java
@@ -18,7 +18,9 @@
 
 package io.ballerina.stdlib.http.transport.message;
 
+import io.ballerina.stdlib.http.transport.contractimpl.common.BackPressureAwareIdleStateHandler;
 import io.ballerina.stdlib.http.transport.contractimpl.common.Util;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpContent;
 
@@ -30,10 +32,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class DefaultListener implements Listener {
 
     private static final int MAXIMUM_BYTE_SIZE = 2097152; //Maximum threshold of reading bytes(2MB)
-    private AtomicInteger cumulativeByteQuantity = new AtomicInteger(0);
-    private ChannelHandlerContext ctx;
-    private boolean readCompleted = false;
+    private final AtomicInteger cumulativeByteQuantity = new AtomicInteger(0);
+    private volatile ChannelHandlerContext ctx;
+    private volatile boolean readCompleted = false;
     private boolean first = true;
+    // Set by a PassthroughBackPressureListener when the downstream leg this response (or request) is being
+    // relayed to goes unwritable. That listener suspends reads on this channel the same way onAdd's own cap
+    // does, so the idle timeout must treat it as back-pressure too, not just the internal queue cap below.
+    private volatile boolean downstreamBackPressured = false;
 
     public DefaultListener(ChannelHandlerContext ctx) {
         this.ctx = ctx;
@@ -43,32 +49,84 @@ public class DefaultListener implements Listener {
     public void onAdd(HttpContent httpContent) {
         if (first) {
             this.ctx.channel().config().setAutoRead(false);
+            // From here on the socket is only read on demand, so the idle timeout needs to be able to tell
+            // whether the transport has deliberately stopped asking the peer for data.
+            BackPressureAwareIdleStateHandler.trackInboundReads(this.ctx.channel(), this, this::isReadSuspended);
             first = false;
         }
         int count = this.cumulativeByteQuantity.addAndGet(httpContent.content().readableBytes());
-        if (count < MAXIMUM_BYTE_SIZE && !readCompleted) {
-            if (Util.isLastHttpContent(httpContent)) {
-                readCompleted = true;
-                this.ctx.channel().config().setAutoRead(true);
-                this.ctx = null;
-            } else {
-                this.ctx.channel().read();
-            }
+        if (readCompleted) {
+            return;
         }
+        if (Util.isLastHttpContent(httpContent)) {
+            // Restore default read behaviour regardless of how much content is still queued, so a pooled
+            // connection is not handed back with its reads suspended.
+            Channel channel = this.ctx.channel();
+            readCompleted = true;
+            this.ctx = null;
+            BackPressureAwareIdleStateHandler.untrackInboundReads(channel, this);
+            channel.config().setAutoRead(true);
+        } else if (count < MAXIMUM_BYTE_SIZE) {
+            BackPressureAwareIdleStateHandler.inboundReadsResumed(this.ctx.channel(), this);
+            this.ctx.channel().read();
+        }
+        // Otherwise reads stay suspended until the application drains what is already queued.
     }
 
     @Override
     public void onRemove(HttpContent httpContent) {
+        ChannelHandlerContext currentCtx = this.ctx;
+        if (currentCtx == null) {
+            this.cumulativeByteQuantity.addAndGet(-(httpContent.content().readableBytes()));
+            return;
+        }
+        // Recorded before the reduced count is published, so that whoever observes the lower count also
+        // observes the refreshed progress time instead of a stale one that could time the peer out early: the
+        // read this drain is about to reissue has to be given a full period to be answered. Guarded by
+        // identity: if this call is delayed past the point where a pooled channel has moved on to tracking a
+        // new message, it must not resurrect that new message's stall clock.
+        BackPressureAwareIdleStateHandler.inboundReadsResumed(currentCtx.channel(), this);
         int count = this.cumulativeByteQuantity.addAndGet(-(httpContent.content().readableBytes()));
         if (count < MAXIMUM_BYTE_SIZE && !readCompleted) {
-            this.ctx.channel().read();
+            currentCtx.channel().read();
         }
     }
 
     @Override
     public void resumeReadInterest() {
-        if (this.ctx != null) {
-            ctx.channel().config().setAutoRead(true);
+        ChannelHandlerContext currentCtx = this.ctx;
+        if (currentCtx != null) {
+            // This listener is being detached, so it will never report progress on the channel again and
+            // must not be left as the answer to "are the reads suspended".
+            BackPressureAwareIdleStateHandler.untrackInboundReads(currentCtx.channel(), this);
+            currentCtx.channel().config().setAutoRead(true);
+        }
+    }
+
+    // Derived from the queue itself rather than a latched flag, so the event loop adding content and the
+    // application thread draining it cannot leave the two disagreeing.
+    private boolean isReadSuspended() {
+        return !readCompleted && (cumulativeByteQuantity.get() >= MAXIMUM_BYTE_SIZE || downstreamBackPressured);
+    }
+
+    /**
+     * Called by a {@link PassthroughBackPressureListener} when the downstream leg this message is being
+     * relayed to has gone unwritable and reads on this channel have been suspended as a result.
+     */
+    public void onDownstreamUnwritable() {
+        downstreamBackPressured = true;
+    }
+
+    /**
+     * Called by a {@link PassthroughBackPressureListener} when the downstream leg this message is being
+     * relayed to has become writable again. Restarts the idle countdown the same way resuming reads for the
+     * internal queue cap does, since the peer was excused from it for the same reason.
+     */
+    public void onDownstreamWritable() {
+        downstreamBackPressured = false;
+        ChannelHandlerContext currentCtx = this.ctx;
+        if (currentCtx != null) {
+            BackPressureAwareIdleStateHandler.inboundReadsResumed(currentCtx.channel(), this);
         }
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/message/PassthroughBackPressureListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/message/PassthroughBackPressureListener.java
@@ -30,14 +30,18 @@ public class PassthroughBackPressureListener implements BackPressureListener {
     private static final Logger LOG = LoggerFactory.getLogger(PassthroughBackPressureListener.class);
 
     private Channel inChannel;
+    private final DefaultListener inboundListener;
 
     /**
      * Sets the incoming and outgoing message channels.
      *
-     * @param inContext  This will be used to block and resume read interest of the incoming channel.
+     * @param inContext      This will be used to block and resume read interest of the incoming channel.
+     * @param inboundListener the listener reading the incoming channel's content, told about the suspension so
+     *                        the idle timeout on that channel does not mistake it for an unresponsive peer.
      */
-    public PassthroughBackPressureListener(ChannelHandlerContext inContext) {
+    public PassthroughBackPressureListener(ChannelHandlerContext inContext, DefaultListener inboundListener) {
         inChannel = inContext.channel();
+        this.inboundListener = inboundListener;
     }
 
     @Override
@@ -46,6 +50,7 @@ public class PassthroughBackPressureListener implements BackPressureListener {
             LOG.debug("Read disabled for inChannel {}", inChannel.id());
         }
         inChannel.config().setAutoRead(false);
+        inboundListener.onDownstreamUnwritable();
     }
 
     @Override
@@ -54,5 +59,6 @@ public class PassthroughBackPressureListener implements BackPressureListener {
             LOG.debug("Read enabled for inChannel {}", inChannel.id());
         }
         inChannel.config().setAutoRead(true);
+        inboundListener.onDownstreamWritable();
     }
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/BackPressureStallLimitTestCase.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/BackPressureStallLimitTestCase.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.transport;
+
+import io.ballerina.stdlib.http.transport.contract.HttpClientConnector;
+import io.ballerina.stdlib.http.transport.contract.HttpResponseFuture;
+import io.ballerina.stdlib.http.transport.contract.HttpWsConnectorFactory;
+import io.ballerina.stdlib.http.transport.contract.config.SenderConfiguration;
+import io.ballerina.stdlib.http.transport.contract.exceptions.ServerConnectorException;
+import io.ballerina.stdlib.http.transport.contractimpl.DefaultHttpWsConnectorFactory;
+import io.ballerina.stdlib.http.transport.contractimpl.common.Util;
+import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
+import io.ballerina.stdlib.http.transport.message.HttpMessageDataStreamer;
+import io.ballerina.stdlib.http.transport.util.DefaultHttpConnectorListener;
+import io.ballerina.stdlib.http.transport.util.TestUtil;
+import io.ballerina.stdlib.http.transport.util.server.HttpServer;
+import io.ballerina.stdlib.http.transport.util.server.initializers.LargeResponseServerInitializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies that {@code maxBackPressureStallTime} is checked on its own schedule - close to
+ * {@code SOCKET_IDLE_TIMEOUT + cap} - rather than only on Netty's own coarser once-per-idle-timeout cadence,
+ * which would let a stall run close to {@code SOCKET_IDLE_TIMEOUT * 2} before being noticed.
+ */
+public class BackPressureStallLimitTestCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BackPressureStallLimitTestCase.class);
+
+    // Large enough to push the inbound content past the 2MB threshold at which reads are throttled.
+    private static final int RESPONSE_SIZE = 4 * 1024 * 1024;
+    private static final int SOCKET_IDLE_TIMEOUT = 2000;
+    private static final double MAX_BACK_PRESSURE_STALL_SECONDS = 0.4;
+    private static final int READ_SLICE = 64 * 1024;
+    // Past SOCKET_IDLE_TIMEOUT + (MAX_BACK_PRESSURE_STALL_SECONDS * 1000) = 2400ms, so the cap should already
+    // have been enforced by the time the consumer wakes up, but well short of SOCKET_IDLE_TIMEOUT * 2 = 4000ms.
+    private static final int CONSUMER_PAUSE = 2600;
+    // Comfortably above the ~2400ms the cap is expected to take, comfortably below the ~4000ms it would take
+    // if the recheck fell back to Netty's own once-per-idle-timeout schedule.
+    private static final long RECLAIM_DEADLINE_MILLIS = 3200;
+    // A regression here shows up as a stalled transfer rather than a quick error, so the test methods and the
+    // tear down are bounded to keep a failure a red test instead of a hung build.
+    private static final int TEST_TIME_OUT = 60000;
+    private static final int CLEAN_UP_TIME_OUT = 30000;
+
+    private HttpServer httpServer;
+    private HttpClientConnector httpClientConnector;
+    private HttpWsConnectorFactory connectorFactory;
+
+    @BeforeClass
+    public void setup() {
+        Util.setMaxBackPressureStallTime(MAX_BACK_PRESSURE_STALL_SECONDS);
+
+        httpServer = TestUtil.startHTTPServer(TestUtil.HTTP_SERVER_PORT,
+                                              new LargeResponseServerInitializer(RESPONSE_SIZE));
+
+        connectorFactory = new DefaultHttpWsConnectorFactory();
+        SenderConfiguration senderConfiguration = new SenderConfiguration();
+        senderConfiguration.setSocketIdleTimeout(SOCKET_IDLE_TIMEOUT);
+        httpClientConnector = connectorFactory.createHttpClientConnector(new HashMap<>(), senderConfiguration);
+    }
+
+    @Test(timeOut = TEST_TIME_OUT,
+          description = "A consumer stalled for longer than maxBackPressureStallTime must have its connection "
+                  + "reclaimed once the cap elapses, rather than being excused until the socket idle timeout "
+                  + "would separately have fired.")
+    public void testStallPastCapIsReclaimed() throws Exception {
+        HttpCarbonMessage msg = TestUtil.createHttpPostReq(TestUtil.HTTP_SERVER_PORT, "Test request body", "");
+
+        CountDownLatch latch = new CountDownLatch(1);
+        DefaultHttpConnectorListener listener = new DefaultHttpConnectorListener(latch);
+        HttpResponseFuture responseFuture = httpClientConnector.send(msg);
+        responseFuture.setHttpConnectorListener(listener);
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "Did not receive the response headers");
+        HttpCarbonMessage response = listener.getHttpResponseMessage();
+        assertNotNull(response, "Response message is null: " + listener.getHttpErrorMessage());
+
+        byte[] received = new byte[RESPONSE_SIZE];
+        int totalRead = 0;
+        long stallStartMillis = System.currentTimeMillis();
+
+        try (InputStream inputStream = new HttpMessageDataStreamer(response).getInputStream()) {
+            int firstRead = inputStream.read(received, 0, READ_SLICE);
+            assertTrue(firstRead > 0, "Expected to read some content before stalling");
+            totalRead += firstRead;
+
+            LOG.debug("Stalling the consumer for {}ms, well past the {}s back-pressure stall cap",
+                       CONSUMER_PAUSE, MAX_BACK_PRESSURE_STALL_SECONDS);
+            Thread.sleep(CONSUMER_PAUSE);
+
+            // Only content queued before reads were suspended can be drained without blocking; after that
+            // the next read blocks until the connection is reclaimed.
+            try {
+                while (totalRead < RESPONSE_SIZE) {
+                    int toRead = Math.min(READ_SLICE, RESPONSE_SIZE - totalRead);
+                    int readCount = inputStream.read(received, totalRead, toRead);
+                    if (readCount == -1) {
+                        break;
+                    }
+                    totalRead += readCount;
+                }
+            } catch (RuntimeException e) {
+                LOG.debug("Reading failed as expected once the reclaimed connection's content ran out: {}",
+                           e.getMessage());
+            }
+        }
+
+        long reclaimDurationMillis = System.currentTimeMillis() - stallStartMillis;
+        assertTrue(totalRead < RESPONSE_SIZE,
+                   "Response body was not truncated even though the consumer stalled past the configured "
+                           + "maxBackPressureStallTime cap");
+        assertTrue(reclaimDurationMillis < RECLAIM_DEADLINE_MILLIS,
+                   "Connection was not reclaimed until " + reclaimDurationMillis + "ms into the stall, which is "
+                           + "close to twice the socket idle timeout rather than close to the configured "
+                           + "maxBackPressureStallTime cap");
+    }
+
+    // alwaysRun: setup() applies the shortened stall cap before it can fail (e.g. a port still in TIME_WAIT),
+    // and that global setting must not leak into later test classes even when setup() never finishes.
+    @AfterClass(alwaysRun = true, timeOut = CLEAN_UP_TIME_OUT)
+    public void cleanUp() throws ServerConnectorException {
+        // Restore the default so this global setting does not leak into other test classes.
+        Util.setMaxBackPressureStallTime(Util.DEFAULT_MAX_BACK_PRESSURE_STALL_TIME);
+        try {
+            if (httpServer != null) {
+                httpServer.shutdown();
+            }
+            if (connectorFactory != null) {
+                connectorFactory.shutdown();
+            }
+        } catch (InterruptedException e) {
+            LOG.error("Failed to shutdown the test server");
+        }
+    }
+}

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/SlowInboundResponseBodyConsumerTestCase.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/SlowInboundResponseBodyConsumerTestCase.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.transport;
+
+import io.ballerina.stdlib.http.transport.contract.HttpClientConnector;
+import io.ballerina.stdlib.http.transport.contract.HttpResponseFuture;
+import io.ballerina.stdlib.http.transport.contract.HttpWsConnectorFactory;
+import io.ballerina.stdlib.http.transport.contract.config.SenderConfiguration;
+import io.ballerina.stdlib.http.transport.contract.exceptions.ServerConnectorException;
+import io.ballerina.stdlib.http.transport.contractimpl.DefaultHttpWsConnectorFactory;
+import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
+import io.ballerina.stdlib.http.transport.message.HttpMessageDataStreamer;
+import io.ballerina.stdlib.http.transport.util.DefaultHttpConnectorListener;
+import io.ballerina.stdlib.http.transport.util.TestUtil;
+import io.ballerina.stdlib.http.transport.util.server.HttpServer;
+import io.ballerina.stdlib.http.transport.util.server.initializers.LargeResponseServerInitializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies that a client which consumes a large inbound response body slowly is not disconnected by the socket
+ * idle timeout: reads paused waiting on the application must not be counted as an idle connection.
+ */
+public class SlowInboundResponseBodyConsumerTestCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SlowInboundResponseBodyConsumerTestCase.class);
+
+    // Large enough to push the inbound content past the 2MB threshold at which reads are throttled.
+    private static final int RESPONSE_SIZE = 4 * 1024 * 1024;
+    private static final int SOCKET_IDLE_TIMEOUT = 2000;
+    // Read in slices that are small relative to the body, pausing for longer than the idle timeout in between.
+    private static final int READ_SLICE = 64 * 1024;
+    private static final int CONSUMER_PAUSE = SOCKET_IDLE_TIMEOUT + SOCKET_IDLE_TIMEOUT / 2;
+    private static final int PAUSED_READS = 2;
+    // A regression here shows up as a stalled transfer rather than a quick error, so the test methods and the
+    // tear down are bounded to keep a failure a red test instead of a hung build.
+    private static final int TEST_TIME_OUT = 60000;
+    private static final int CLEAN_UP_TIME_OUT = 30000;
+
+    private HttpServer httpServer;
+    private HttpClientConnector httpClientConnector;
+    private HttpWsConnectorFactory connectorFactory;
+
+    @BeforeClass
+    public void setup() {
+        httpServer = TestUtil.startHTTPServer(TestUtil.HTTP_SERVER_PORT,
+                                              new LargeResponseServerInitializer(RESPONSE_SIZE));
+
+        connectorFactory = new DefaultHttpWsConnectorFactory();
+        SenderConfiguration senderConfiguration = new SenderConfiguration();
+        senderConfiguration.setSocketIdleTimeout(SOCKET_IDLE_TIMEOUT);
+        httpClientConnector = connectorFactory.createHttpClientConnector(new HashMap<>(), senderConfiguration);
+    }
+
+    @Test(timeOut = TEST_TIME_OUT,
+          description = "A response body consumed more slowly than the socket idle timeout must still arrive "
+                  + "in full, because the idleness is caused by the consumer rather than by the remote server.")
+    public void testSlowlyConsumedLargeResponseIsNotTruncated() throws Exception {
+        HttpCarbonMessage msg = TestUtil.createHttpPostReq(TestUtil.HTTP_SERVER_PORT, "Test request body", "");
+
+        CountDownLatch latch = new CountDownLatch(1);
+        DefaultHttpConnectorListener listener = new DefaultHttpConnectorListener(latch);
+        HttpResponseFuture responseFuture = httpClientConnector.send(msg);
+        responseFuture.setHttpConnectorListener(listener);
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "Did not receive the response headers");
+        HttpCarbonMessage response = listener.getHttpResponseMessage();
+        assertNotNull(response, "Response message is null: " + listener.getHttpErrorMessage());
+
+        byte[] expected = LargeResponseServerInitializer.buildExpectedPayload(RESPONSE_SIZE);
+        byte[] received = new byte[RESPONSE_SIZE];
+        int totalRead = 0;
+        int pausesTaken = 0;
+
+        try (InputStream inputStream = new HttpMessageDataStreamer(response).getInputStream()) {
+            while (totalRead < RESPONSE_SIZE) {
+                int toRead = Math.min(READ_SLICE, RESPONSE_SIZE - totalRead);
+                int readCount = inputStream.read(received, totalRead, toRead);
+                if (readCount == -1) {
+                    break;
+                }
+                totalRead += readCount;
+
+                // Stall the consumer for longer than the idle timeout a handful of times. Before the fix the
+                // connection was closed during the very first of these pauses.
+                if (pausesTaken < PAUSED_READS) {
+                    pausesTaken++;
+                    LOG.debug("Pausing the consumer after reading {} bytes", totalRead);
+                    Thread.sleep(CONSUMER_PAUSE);
+                }
+            }
+        }
+
+        assertEquals(totalRead, RESPONSE_SIZE, "Response body was truncated");
+        assertEquals(received, expected, "Response body content does not match what the server sent");
+    }
+
+    @AfterClass(timeOut = CLEAN_UP_TIME_OUT)
+    public void cleanUp() throws ServerConnectorException {
+        try {
+            httpServer.shutdown();
+            connectorFactory.shutdown();
+        } catch (InterruptedException e) {
+            LOG.error("Failed to shutdown the test server");
+        }
+    }
+}

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/contractimpl/common/BackPressureAwareIdleStateHandlerTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/contractimpl/common/BackPressureAwareIdleStateHandlerTest.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.transport.contractimpl.common;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.timeout.IdleStateEvent;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies how {@link BackPressureAwareIdleStateHandler} decides that silence on a connection is the
+ * application's own back-pressure rather than an unresponsive peer: which progress excuses a timeout, how much
+ * of a fresh period the peer gets once reads resume, and that state belonging to one message on a pooled or
+ * keep-alive channel is never applied to another that has since been tracked in its place.
+ */
+public class BackPressureAwareIdleStateHandlerTest {
+
+    private static final long IDLE_TIMEOUT_MILLIS = 300;
+    // Short relative to IDLE_TIMEOUT_MILLIS so the stall is checked on its own precise schedule rather than
+    // waiting on Netty's coarser once-per-idle-timeout cadence, giving predictable, well separated timings:
+    // a stall recorded at IDLE_TIMEOUT_MILLIS is reclaimed ~STALL_MILLIS later if never restarted, or not
+    // until a further IDLE_TIMEOUT_MILLIS + STALL_MILLIS after that if it is.
+    private static final double MAX_STALL_SECONDS = 0.15;
+    private static final long STALL_MILLIS = (long) (MAX_STALL_SECONDS * 1000);
+    private static final long POLL_STEP_MILLIS = 25;
+    // Generous margin over IDLE_TIMEOUT_MILLIS/STALL_MILLIS so ordinary test/JVM scheduling overhead cannot
+    // push either check past the boundary it is meant to land clearly on the near or far side of.
+    private static final long MARGIN_MILLIS = 60;
+
+    @AfterMethod
+    public void resetStallLimit() {
+        Util.setMaxBackPressureStallTime(Util.DEFAULT_MAX_BACK_PRESSURE_STALL_TIME);
+    }
+
+    @Test(description = "A resumed() call whose owner no longer matches the channel's current owner - state "
+            + "left behind by a message superseded by a new one on a reused channel - must not clear a stall "
+            + "the current owner is relying on to still be excused")
+    public void testStaleResumedFromPreviousOwnerDoesNotClearCurrentOwnersStall() throws Exception {
+        Util.setMaxBackPressureStallTime(MAX_STALL_SECONDS);
+        RecordingHandler recorder = new RecordingHandler();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new BackPressureAwareIdleStateHandler(IDLE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), recorder);
+        try {
+            Object staleOwner = new Object();
+            Object currentOwner = new Object();
+
+            // currentOwner is permanently suspended, so the first idle check excuses it and starts its stall
+            // clock instead of firing straight away.
+            BackPressureAwareIdleStateHandler.trackInboundReads(channel, currentOwner, () -> true);
+            pollFor(channel, IDLE_TIMEOUT_MILLIS + MARGIN_MILLIS);
+            assertTrue(recorder.events.isEmpty(), "Idle event fired before the stall allowance even began");
+
+            // A stale call from a message that no longer owns this channel's tracking state - it must be a
+            // no-op rather than clearing currentOwner's stall clock.
+            BackPressureAwareIdleStateHandler.inboundReadsResumed(channel, staleOwner);
+
+            // Past when the stall clock started above would exceed its allowance, but well short of when a
+            // (wrongly) restarted one, or Netty's own next natural recheck, would land.
+            pollFor(channel, STALL_MILLIS + MARGIN_MILLIS);
+
+            assertTrue(!recorder.events.isEmpty(),
+                       "Stall was not reclaimed - the stale resumed() call incorrectly cleared its clock");
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test(description = "A resumed() call from the owner that is actually current must restart the stall "
+            + "clock, giving a still-suspended stream a fresh allowance rather than letting the original one "
+            + "run out on schedule")
+    public void testResumedFromCurrentOwnerRestartsTheStallClock() throws Exception {
+        Util.setMaxBackPressureStallTime(MAX_STALL_SECONDS);
+        RecordingHandler recorder = new RecordingHandler();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new BackPressureAwareIdleStateHandler(IDLE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), recorder);
+        try {
+            Object currentOwner = new Object();
+
+            BackPressureAwareIdleStateHandler.trackInboundReads(channel, currentOwner, () -> true);
+            pollFor(channel, IDLE_TIMEOUT_MILLIS + MARGIN_MILLIS);
+            assertTrue(recorder.events.isEmpty(), "Idle event fired before the stall allowance even began");
+
+            // The actual current owner reporting progress - this must restart the allowance.
+            BackPressureAwareIdleStateHandler.inboundReadsResumed(channel, currentOwner);
+
+            // Past when the original stall clock would have exceeded its allowance if left alone, but well
+            // short of when Netty's own next natural recheck - and so a freshly restarted clock - would land.
+            pollFor(channel, STALL_MILLIS + MARGIN_MILLIS);
+
+            assertTrue(recorder.events.isEmpty(),
+                       "Idle event fired even though the current owner's progress should have restarted the "
+                               + "stall allowance");
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test(description = "A connection nobody has applied back-pressure to must time out on schedule even when "
+            + "a socket read carried no decoded message - a partial chunk or TLS record advances the raw read "
+            + "time without being progress the idle timeout is meant to excuse")
+    public void testUntrackedChannelIsNotExcusedByAReadThatCarriedNoMessage() throws Exception {
+        RecordingHandler recorder = new RecordingHandler();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new BackPressureAwareIdleStateHandler(IDLE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), recorder);
+        try {
+            // No trackInboundReads at all: nothing on this channel has ever suspended reads.
+            pollFor(channel, IDLE_TIMEOUT_MILLIS / 2);
+
+            // A read that produced no message for the handlers below this one, so the superclass's own idle
+            // baseline - which only advances alongside a channelRead - is deliberately left where it was.
+            channel.pipeline().fireChannelReadComplete();
+
+            pollFor(channel, IDLE_TIMEOUT_MILLIS / 2 + MARGIN_MILLIS);
+
+            assertFalse(recorder.events.isEmpty(),
+                        "Idle event was deferred on a connection with no application back-pressure at all");
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test(description = "Once the application drains and reads are reissued, the peer gets a full fresh period "
+            + "to answer them - the time it spent excused while the transport was not asking it for anything "
+            + "must not be counted against it")
+    public void testPeerGetsAFullPeriodAfterReadsResume() throws Exception {
+        RecordingHandler recorder = new RecordingHandler();
+        long startNanos = System.nanoTime();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new BackPressureAwareIdleStateHandler(IDLE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), recorder);
+        try {
+            Object owner = new Object();
+            AtomicBoolean suspended = new AtomicBoolean(true);
+            BackPressureAwareIdleStateHandler.trackInboundReads(channel, owner, suspended::get);
+
+            // Held suspended until just short of the second idle check, so the resume below lands in the worst
+            // place it can: with the next check about to run and nothing having arrived from the peer yet.
+            pollUntil(channel, startNanos + TimeUnit.MILLISECONDS.toNanos(
+                    2 * IDLE_TIMEOUT_MILLIS - MARGIN_MILLIS));
+            assertTrue(recorder.events.isEmpty(), "Idle event fired while reads were still suspended");
+
+            // The application drains: reads are reissued, but the peer has not answered them yet.
+            suspended.set(false);
+            BackPressureAwareIdleStateHandler.inboundReadsResumed(channel, owner);
+
+            // Past the check that was already due, but far short of a full period after the resume.
+            pollFor(channel, 2 * MARGIN_MILLIS);
+
+            assertTrue(recorder.events.isEmpty(),
+                       "Peer was timed out moments after reads resumed, without being given a full period to "
+                               + "answer the read it had only just been sent");
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test(description = "Progress reported by a message whose reads were never suspended must not extend the "
+            + "countdown: with nothing holding the transfer up, a peer that has gone quiet is still due to be "
+            + "timed out on schedule")
+    public void testProgressWithoutASuspensionDoesNotExtendTheCountdown() throws Exception {
+        RecordingHandler recorder = new RecordingHandler();
+        long startNanos = System.nanoTime();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new BackPressureAwareIdleStateHandler(IDLE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), recorder);
+        try {
+            Object owner = new Object();
+            // Tracked, but the application keeps up with the message throughout - reads are never suspended.
+            BackPressureAwareIdleStateHandler.trackInboundReads(channel, owner, () -> false);
+
+            // A drain reported just short of the idle check that is already due.
+            pollUntil(channel, startNanos + TimeUnit.MILLISECONDS.toNanos(
+                    IDLE_TIMEOUT_MILLIS - MARGIN_MILLIS));
+            BackPressureAwareIdleStateHandler.inboundReadsResumed(channel, owner);
+
+            pollFor(channel, 2 * MARGIN_MILLIS);
+
+            assertFalse(recorder.events.isEmpty(),
+                        "Idle event was deferred by progress on a transfer nothing was holding up");
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test(description = "A message that ends without ever untracking - an aborted request on a connection "
+            + "whose handler is installed once and reused - must not leave its stall clock behind for the next "
+            + "message on that channel to be reclaimed against")
+    public void testNewOwnerDoesNotInheritThePreviousOwnersStallClock() throws Exception {
+        Util.setMaxBackPressureStallTime(MAX_STALL_SECONDS);
+        RecordingHandler recorder = new RecordingHandler();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new BackPressureAwareIdleStateHandler(IDLE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), recorder);
+        try {
+            // The first message stalls long enough to start a stall clock, then goes away without untracking.
+            BackPressureAwareIdleStateHandler.trackInboundReads(channel, new Object(), () -> true);
+            pollFor(channel, IDLE_TIMEOUT_MILLIS + MARGIN_MILLIS);
+            assertTrue(recorder.events.isEmpty(), "Idle event fired before the stall allowance even began");
+
+            // A new message starts on the same channel. Its allowance is its own, and has only just started.
+            BackPressureAwareIdleStateHandler.trackInboundReads(channel, new Object(), () -> true);
+
+            // Past when the clock left behind by the first message would have run out.
+            pollFor(channel, STALL_MILLIS + MARGIN_MILLIS);
+
+            assertTrue(recorder.events.isEmpty(),
+                       "New message was reclaimed against the stall clock left behind by the previous one");
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test(description = "An untrack call left over from a message that no longer owns this channel's tracking "
+            + "state must not clear the suspension the message tracked in its place is relying on")
+    public void testStaleUntrackFromPreviousOwnerDoesNotClearCurrentOwnersSuspension() throws Exception {
+        RecordingHandler recorder = new RecordingHandler();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new BackPressureAwareIdleStateHandler(IDLE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), recorder);
+        try {
+            Object staleOwner = new Object();
+            Object currentOwner = new Object();
+
+            BackPressureAwareIdleStateHandler.trackInboundReads(channel, staleOwner, () -> false);
+            // The channel has moved on: the message being read now is the one that is suspended.
+            BackPressureAwareIdleStateHandler.trackInboundReads(channel, currentOwner, () -> true);
+
+            // The superseded message detaching its listener late - a no-op, not a wipe of currentOwner's state.
+            BackPressureAwareIdleStateHandler.untrackInboundReads(channel, staleOwner);
+
+            pollFor(channel, IDLE_TIMEOUT_MILLIS + MARGIN_MILLIS);
+
+            assertTrue(recorder.events.isEmpty(),
+                       "Idle event fired even though the current owner's reads were suspended - the stale "
+                               + "untrack cleared the suspension it no longer owned");
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    private void pollUntil(EmbeddedChannel channel, long deadlineNanos) throws InterruptedException {
+        while (System.nanoTime() < deadlineNanos) {
+            Thread.sleep(POLL_STEP_MILLIS);
+            channel.runScheduledPendingTasks();
+        }
+    }
+
+    private void pollFor(EmbeddedChannel channel, long totalMillis) throws InterruptedException {
+        long elapsed = 0;
+        while (elapsed < totalMillis) {
+            long step = Math.min(POLL_STEP_MILLIS, totalMillis - elapsed);
+            Thread.sleep(step);
+            elapsed += step;
+            channel.runScheduledPendingTasks();
+        }
+    }
+
+    private static final class RecordingHandler extends ChannelInboundHandlerAdapter {
+
+        private final List<IdleStateEvent> events = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            if (evt instanceof IdleStateEvent) {
+                events.add((IdleStateEvent) evt);
+            }
+        }
+    }
+}

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/contractimpl/sender/http2/Http2ClientTimeoutHandlerConcurrentStreamTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/contractimpl/sender/http2/Http2ClientTimeoutHandlerConcurrentStreamTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.transport.contractimpl.sender.http2;
+
+import io.ballerina.stdlib.http.transport.contract.Constants;
+import io.ballerina.stdlib.http.transport.message.HttpCarbonRequest;
+import io.ballerina.stdlib.http.transport.message.HttpCarbonResponse;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http2.Http2Error;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that {@link Http2ClientTimeoutHandler} keeps a separate idle budget per stream. Streams share one
+ * handler instance per connection, and {@code createTimerTask} - used for the much shorter
+ * {@code Expect: 100-continue} wait - must not corrupt the budget an unrelated, concurrently in-flight and
+ * otherwise healthy stream on the same connection is judged against.
+ */
+public class Http2ClientTimeoutHandlerConcurrentStreamTest {
+
+    private static final int STREAM_A = 1;
+    private static final int STREAM_B = 3;
+
+    // Stream A's real budget. Comfortably longer than the gap between the simulated progress updates below, so
+    // a healthy stream fed progress every PROGRESS_INTERVAL_MILLIS never legitimately goes idle.
+    private static final long STREAM_A_IDLE_MILLIS = 300;
+    // What a concurrent Expect: 100-continue wait installs for stream B - much shorter than stream A's own
+    // budget, mirroring socketIdleTimeout / 5 in WaitingFor100Continue.
+    private static final long STREAM_B_CONTINUE_BUDGET_MILLIS = 50;
+    private static final long PROGRESS_INTERVAL_MILLIS = 100;
+    private static final int PROGRESS_UPDATES = 8;
+
+    @Test(description = "A healthy stream fed regular progress must not be reset just because another stream "
+            + "on the same connection is concurrently waiting on a much shorter Expect: 100-continue budget")
+    public void testConcurrentExpectContinueStreamDoesNotShortenAnotherStreamsBudget() throws Exception {
+        Http2ClientChannel http2ClientChannel = mock(Http2ClientChannel.class);
+
+        OutboundMsgHolder msgHolderA = new OutboundMsgHolder(
+                new HttpCarbonRequest(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/a")));
+        // Headers have already arrived for stream A - it is genuinely mid-transfer, not merely just sent.
+        msgHolderA.setResponse(
+                new HttpCarbonResponse(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)));
+
+        when(http2ClientChannel.getInFlightMessage(STREAM_A)).thenReturn(msgHolderA);
+        when(http2ClientChannel.getPromisedMessage(anyInt())).thenReturn(null);
+
+        Http2TargetHandler targetHandler = mock(Http2TargetHandler.class);
+        ChannelInboundHandlerAdapter marker = new ChannelInboundHandlerAdapter();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline().addLast(Constants.HTTP2_TARGET_HANDLER, targetHandler);
+        channel.pipeline().addLast("marker", marker);
+        ChannelHandlerContext ctx = channel.pipeline().context(marker);
+
+        try {
+            Http2ClientTimeoutHandler timeoutHandler = new Http2ClientTimeoutHandler(STREAM_A_IDLE_MILLIS,
+                                                                                      http2ClientChannel);
+            timeoutHandler.onStreamInit(ctx, STREAM_A);
+
+            // Stream B starts waiting on Expect: 100-continue - the moment this happens is what corrupted the
+            // shared idle budget pre-fix.
+            timeoutHandler.createTimerTask(ctx, STREAM_B, STREAM_B_CONTINUE_BUDGET_MILLIS, true);
+
+            // Feed stream A regular progress, comfortably within its own real budget but far apart relative to
+            // stream B's much shorter one. Due timers are run against the *previous* progress update before a
+            // fresh one is recorded, so a check that lands mid-gap sees the gap rather than an instant refresh.
+            for (int i = 0; i < PROGRESS_UPDATES; i++) {
+                Thread.sleep(PROGRESS_INTERVAL_MILLIS);
+                channel.runScheduledPendingTasks();
+                msgHolderA.setLastReadWriteTime(System.nanoTime());
+            }
+
+            verify(targetHandler, never()).resetStream(eq(ctx), eq(STREAM_A), any(Http2Error.class));
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+}

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/clienttimeout/Http2ClientBackPressureStallLimitTestCase.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/clienttimeout/Http2ClientBackPressureStallLimitTestCase.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.transport.http2.clienttimeout;
+
+import io.ballerina.stdlib.http.transport.contract.Constants;
+import io.ballerina.stdlib.http.transport.contract.HttpClientConnector;
+import io.ballerina.stdlib.http.transport.contract.HttpResponseFuture;
+import io.ballerina.stdlib.http.transport.contract.HttpWsConnectorFactory;
+import io.ballerina.stdlib.http.transport.contract.ServerConnector;
+import io.ballerina.stdlib.http.transport.contract.ServerConnectorFuture;
+import io.ballerina.stdlib.http.transport.contract.config.ListenerConfiguration;
+import io.ballerina.stdlib.http.transport.contractimpl.DefaultHttpWsConnectorFactory;
+import io.ballerina.stdlib.http.transport.contractimpl.common.Util;
+import io.ballerina.stdlib.http.transport.http2.listeners.Http2ServerLargeResponseListener;
+import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
+import io.ballerina.stdlib.http.transport.message.HttpMessageDataStreamer;
+import io.ballerina.stdlib.http.transport.util.DefaultHttpConnectorListener;
+import io.ballerina.stdlib.http.transport.util.TestUtil;
+import io.ballerina.stdlib.http.transport.util.client.http2.MessageGenerator;
+import io.netty.handler.codec.http.HttpMethod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.InputStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static io.ballerina.stdlib.http.transport.util.Http2Util.getHttp2Client;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies that {@code maxBackPressureStallTime} is a genuine ceiling on an HTTP/2 stream that is permanently
+ * stalled by flow control, not just one that is slow and eventually resumes like
+ * {@link Http2SlowInboundResponseBodyConsumerTestCase}.
+ */
+public class Http2ClientBackPressureStallLimitTestCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Http2ClientBackPressureStallLimitTestCase.class);
+
+    // Comfortably larger than the default 64KB inbound flow control window.
+    private static final int RESPONSE_SIZE = 1024 * 1024;
+    private static final int SOCKET_IDLE_TIMEOUT = 2000;
+    private static final double MAX_BACK_PRESSURE_STALL_SECONDS = 0.4;
+    private static final int READ_SLICE = 16 * 1024;
+    // Past SOCKET_IDLE_TIMEOUT + (MAX_BACK_PRESSURE_STALL_SECONDS * 1000) = 2400ms, well short of what a
+    // bypassed cap would need (the stream would never be reclaimed at all).
+    private static final int CONSUMER_PAUSE = 2600;
+    private static final long RECLAIM_DEADLINE_MILLIS = 3200;
+    // A regression here is a permanently stalled read rather than a quick error, so the test method is bounded
+    // to keep a failure a red test instead of a hung build.
+    private static final int TEST_TIME_OUT = 60000;
+    // Tearing down a connection whose stream was just reset with a large amount of still-buffered outbound
+    // data can take noticeably longer on some platforms (observed on Windows CI) than on others, so this is
+    // generous rather than tight.
+    private static final int CLEAN_UP_TIME_OUT = 60000;
+
+    private HttpClientConnector h2Client;
+    private ServerConnector serverConnector;
+    private HttpWsConnectorFactory connectorFactory;
+
+    @BeforeClass
+    public void setup() throws InterruptedException {
+        Util.setMaxBackPressureStallTime(MAX_BACK_PRESSURE_STALL_SECONDS);
+
+        connectorFactory = new DefaultHttpWsConnectorFactory();
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
+        listenerConfiguration.setPort(TestUtil.HTTP_SERVER_PORT);
+        listenerConfiguration.setScheme(Constants.HTTP_SCHEME);
+        listenerConfiguration.setVersion(Constants.HTTP_2_0);
+        // Keep the server well out of the way, the client side timing is what is under test.
+        listenerConfiguration.setSocketIdleTimeout(500000);
+        serverConnector = connectorFactory
+                .createServerConnector(TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
+        ServerConnectorFuture future = serverConnector.start();
+        future.setHttpConnectorListener(new Http2ServerLargeResponseListener(RESPONSE_SIZE));
+        future.sync();
+
+        h2Client = getHttp2Client(connectorFactory, true, SOCKET_IDLE_TIMEOUT);
+    }
+
+    @Test(timeOut = TEST_TIME_OUT,
+          description = "A stream that never resumes reading after stalling must still be reclaimed once the "
+                  + "configured cap elapses, rather than being excused forever")
+    public void testPermanentlyStalledStreamIsReclaimed() throws Exception {
+        HttpCarbonMessage request = MessageGenerator.generateRequest(HttpMethod.POST, "test");
+
+        CountDownLatch latch = new CountDownLatch(1);
+        DefaultHttpConnectorListener listener = new DefaultHttpConnectorListener(latch);
+        HttpResponseFuture responseFuture = h2Client.send(request);
+        responseFuture.setHttpConnectorListener(listener);
+
+        assertTrue(latch.await(TestUtil.HTTP2_RESPONSE_TIME_OUT, TimeUnit.SECONDS),
+                   "Did not receive the response headers");
+        HttpCarbonMessage response = listener.getHttpResponseMessage();
+        assertNotNull(response, "Response message is null: " + listener.getHttpErrorMessage());
+
+        byte[] received = new byte[RESPONSE_SIZE];
+        int totalRead = 0;
+        long stallStartMillis;
+
+        try (InputStream inputStream = new HttpMessageDataStreamer(response).getInputStream()) {
+            int firstRead = inputStream.read(received, 0, READ_SLICE);
+            assertTrue(firstRead > 0, "Expected to read some content before stalling");
+            totalRead += firstRead;
+            stallStartMillis = System.currentTimeMillis();
+
+            // Deliberately not read again until the pause has elapsed: any read here reopens the window
+            // and lets the transfer continue, masking the very stall the cap is meant to bound.
+            LOG.debug("Stalling the consumer for {}ms, well past the {}s back-pressure stall cap",
+                       CONSUMER_PAUSE, MAX_BACK_PRESSURE_STALL_SECONDS);
+            Thread.sleep(CONSUMER_PAUSE);
+
+            // Only content queued before the stall began can still be drained here; once that runs out
+            // the stream must already have been reclaimed and reset independently of any read of ours.
+            try {
+                while (totalRead < RESPONSE_SIZE) {
+                    int toRead = Math.min(READ_SLICE, RESPONSE_SIZE - totalRead);
+                    int readCount = inputStream.read(received, totalRead, toRead);
+                    if (readCount == -1) {
+                        break;
+                    }
+                    totalRead += readCount;
+                }
+            } catch (RuntimeException e) {
+                LOG.debug("Reading failed as expected once the reclaimed stream's content ran out: {}",
+                           e.getMessage());
+            }
+        }
+
+        long reclaimDurationMillis = System.currentTimeMillis() - stallStartMillis;
+        assertTrue(totalRead < RESPONSE_SIZE,
+                   "Response body was not truncated even though the consumer stalled past the configured "
+                           + "maxBackPressureStallTime cap - the flow control window must have reopened and let "
+                           + "the transfer continue");
+        assertTrue(reclaimDurationMillis < RECLAIM_DEADLINE_MILLIS,
+                   "Stream was not reclaimed until " + reclaimDurationMillis + "ms into the stall - if this "
+                           + "matches the test timeout instead, the stall was excused indefinitely");
+    }
+
+    // alwaysRun: setup() applies the shortened stall cap before it can fail (e.g. a port still in TIME_WAIT),
+    // and that global setting must not leak into later test classes even when setup() never finishes.
+    @AfterClass(alwaysRun = true, timeOut = CLEAN_UP_TIME_OUT)
+    public void cleanUp() {
+        // Restore the default so this global setting does not leak into other test classes.
+        Util.setMaxBackPressureStallTime(Util.DEFAULT_MAX_BACK_PRESSURE_STALL_TIME);
+        if (h2Client != null) {
+            h2Client.close();
+        }
+        if (serverConnector != null) {
+            serverConnector.stop();
+        }
+        try {
+            if (connectorFactory != null) {
+                connectorFactory.shutdown();
+            }
+        } catch (InterruptedException e) {
+            LOG.warn("Interrupted while waiting for HttpWsFactory to close");
+        }
+    }
+}

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/clienttimeout/Http2SlowInboundResponseBodyConsumerTestCase.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/clienttimeout/Http2SlowInboundResponseBodyConsumerTestCase.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.transport.http2.clienttimeout;
+
+import io.ballerina.stdlib.http.transport.contract.Constants;
+import io.ballerina.stdlib.http.transport.contract.HttpClientConnector;
+import io.ballerina.stdlib.http.transport.contract.HttpResponseFuture;
+import io.ballerina.stdlib.http.transport.contract.HttpWsConnectorFactory;
+import io.ballerina.stdlib.http.transport.contract.ServerConnector;
+import io.ballerina.stdlib.http.transport.contract.ServerConnectorFuture;
+import io.ballerina.stdlib.http.transport.contract.config.ListenerConfiguration;
+import io.ballerina.stdlib.http.transport.contractimpl.DefaultHttpWsConnectorFactory;
+import io.ballerina.stdlib.http.transport.http2.listeners.Http2ServerLargeResponseListener;
+import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
+import io.ballerina.stdlib.http.transport.message.HttpMessageDataStreamer;
+import io.ballerina.stdlib.http.transport.util.DefaultHttpConnectorListener;
+import io.ballerina.stdlib.http.transport.util.TestUtil;
+import io.ballerina.stdlib.http.transport.util.client.http2.MessageGenerator;
+import io.netty.handler.codec.http.HttpMethod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.InputStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static io.ballerina.stdlib.http.transport.util.Http2Util.getHttp2Client;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies that an HTTP/2 client which consumes a large inbound response body slowly is not timed out: a slow
+ * consumer closes the (default 64KB) inbound flow control window, and that must not be mistaken for a stalled
+ * peer.
+ */
+public class Http2SlowInboundResponseBodyConsumerTestCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Http2SlowInboundResponseBodyConsumerTestCase.class);
+
+    // Comfortably larger than the default 64KB inbound flow control window.
+    private static final int RESPONSE_SIZE = 1024 * 1024;
+    private static final int SOCKET_IDLE_TIMEOUT = 2000;
+    private static final int READ_SLICE = 16 * 1024;
+    private static final int CONSUMER_PAUSE = SOCKET_IDLE_TIMEOUT + SOCKET_IDLE_TIMEOUT / 2;
+    private static final int PAUSED_READS = 2;
+    // A regression here shows up as a stalled transfer rather than a quick error, so the test methods and the
+    // tear down are bounded to keep a failure a red test instead of a hung build.
+    private static final int TEST_TIME_OUT = 60000;
+    private static final int CLEAN_UP_TIME_OUT = 30000;
+
+    private HttpClientConnector h2PriorOnClient;
+    private HttpClientConnector h2PriorOffClient;
+    private ServerConnector serverConnector;
+    private HttpWsConnectorFactory connectorFactory;
+
+    @BeforeClass
+    public void setup() throws InterruptedException {
+        connectorFactory = new DefaultHttpWsConnectorFactory();
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
+        listenerConfiguration.setPort(TestUtil.HTTP_SERVER_PORT);
+        listenerConfiguration.setScheme(Constants.HTTP_SCHEME);
+        listenerConfiguration.setVersion(Constants.HTTP_2_0);
+        // Keep the server well out of the way, the client side timing is what is under test.
+        listenerConfiguration.setSocketIdleTimeout(500000);
+        serverConnector = connectorFactory
+                .createServerConnector(TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
+        ServerConnectorFuture future = serverConnector.start();
+        future.setHttpConnectorListener(new Http2ServerLargeResponseListener(RESPONSE_SIZE));
+        future.sync();
+
+        h2PriorOnClient = getHttp2Client(connectorFactory, true, SOCKET_IDLE_TIMEOUT);
+        h2PriorOffClient = getHttp2Client(connectorFactory, false, SOCKET_IDLE_TIMEOUT);
+    }
+
+    @Test(timeOut = TEST_TIME_OUT,
+          description = "A slowly consumed HTTP/2 response body must arrive in full when prior knowledge is on")
+    public void testSlowlyConsumedLargeResponseWithPriorOn() throws Exception {
+        assertResponseIsNotTruncated(h2PriorOnClient);
+    }
+
+    @Test(timeOut = TEST_TIME_OUT,
+          description = "A slowly consumed HTTP/2 response body must arrive in full when prior knowledge is off")
+    public void testSlowlyConsumedLargeResponseWithPriorOff() throws Exception {
+        assertResponseIsNotTruncated(h2PriorOffClient);
+    }
+
+    private void assertResponseIsNotTruncated(HttpClientConnector h2Client) throws Exception {
+        HttpCarbonMessage request = MessageGenerator.generateRequest(HttpMethod.POST, "test");
+
+        CountDownLatch latch = new CountDownLatch(1);
+        DefaultHttpConnectorListener listener = new DefaultHttpConnectorListener(latch);
+        HttpResponseFuture responseFuture = h2Client.send(request);
+        responseFuture.setHttpConnectorListener(listener);
+
+        assertTrue(latch.await(TestUtil.HTTP2_RESPONSE_TIME_OUT, TimeUnit.SECONDS),
+                   "Did not receive the response headers");
+        HttpCarbonMessage response = listener.getHttpResponseMessage();
+        assertNotNull(response, "Response message is null: " + listener.getHttpErrorMessage());
+
+        byte[] expected = Http2ServerLargeResponseListener.buildExpectedPayload(RESPONSE_SIZE);
+        byte[] received = new byte[RESPONSE_SIZE];
+        int totalRead = 0;
+        int pausesTaken = 0;
+
+        try (InputStream inputStream = new HttpMessageDataStreamer(response).getInputStream()) {
+            while (totalRead < RESPONSE_SIZE) {
+                int toRead = Math.min(READ_SLICE, RESPONSE_SIZE - totalRead);
+                int readCount = inputStream.read(received, totalRead, toRead);
+                if (readCount == -1) {
+                    break;
+                }
+                totalRead += readCount;
+
+                if (pausesTaken < PAUSED_READS) {
+                    pausesTaken++;
+                    LOG.debug("Pausing the consumer after reading {} bytes", totalRead);
+                    Thread.sleep(CONSUMER_PAUSE);
+                }
+            }
+        }
+
+        assertEquals(totalRead, RESPONSE_SIZE, "Response body was truncated");
+        assertEquals(received, expected, "Response body content does not match what the server sent");
+    }
+
+    @AfterClass(timeOut = CLEAN_UP_TIME_OUT)
+    public void cleanUp() {
+        h2PriorOnClient.close();
+        h2PriorOffClient.close();
+        serverConnector.stop();
+        try {
+            connectorFactory.shutdown();
+        } catch (InterruptedException e) {
+            LOG.warn("Interrupted while waiting for HttpWsFactory to close");
+        }
+    }
+}

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/listeners/Http2ServerLargeResponseListener.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/listeners/Http2ServerLargeResponseListener.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.transport.http2.listeners;
+
+import io.ballerina.stdlib.http.transport.contract.Constants;
+import io.ballerina.stdlib.http.transport.contract.HttpConnectorListener;
+import io.ballerina.stdlib.http.transport.contract.HttpResponseFuture;
+import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
+import io.ballerina.stdlib.http.transport.message.HttpCarbonResponse;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Responds with a body that is large enough to exhaust the HTTP/2 inbound flow control window of a client that
+ * does not consume it promptly.
+ */
+public class Http2ServerLargeResponseListener implements HttpConnectorListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Http2ServerLargeResponseListener.class);
+    private static final int CHUNK_SIZE = 8192;
+
+    private final int responseSize;
+
+    public Http2ServerLargeResponseListener(int responseSize) {
+        this.responseSize = responseSize;
+    }
+
+    public static byte[] buildExpectedPayload(int size) {
+        byte[] payload = new byte[size];
+        for (int i = 0; i < size; i++) {
+            payload[i] = (byte) ('A' + (i % 26));
+        }
+        return payload;
+    }
+
+    @Override
+    public void onMessage(HttpCarbonMessage httpRequest) {
+        Thread.startVirtualThread(() -> {
+            try {
+                HttpCarbonMessage httpResponse = new HttpCarbonResponse(
+                        new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
+                httpResponse.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), Constants.TEXT_PLAIN);
+                httpResponse.setHttpStatusCode(HttpResponseStatus.OK.code());
+
+                HttpResponseFuture responseFuture = httpRequest.respond(httpResponse);
+
+                byte[] payload = buildExpectedPayload(responseSize);
+                for (int offset = 0; offset < responseSize; offset += CHUNK_SIZE) {
+                    int length = Math.min(CHUNK_SIZE, responseSize - offset);
+                    httpResponse.addHttpContent(
+                            new DefaultHttpContent(Unpooled.copiedBuffer(payload, offset, length)));
+                }
+                httpResponse.addHttpContent(new DefaultLastHttpContent());
+
+                responseFuture.sync();
+                Throwable error = responseFuture.getStatus().getCause();
+                if (error != null) {
+                    responseFuture.resetStatus();
+                    LOG.error("Error occurred while sending the response {}", error.getMessage());
+                }
+            } catch (Exception e) {
+                LOG.error("Error occurred while processing message: {}", e.getMessage());
+            }
+        });
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        LOG.error("Error occurred in Http2ServerLargeResponseListener: {}", throwable.getMessage());
+    }
+}

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/listeners/Http2SlowRequestBodyConsumerListener.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/listeners/Http2SlowRequestBodyConsumerListener.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.transport.http2.listeners;
+
+import io.ballerina.stdlib.http.transport.contract.HttpConnectorListener;
+import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
+import io.ballerina.stdlib.http.transport.message.HttpMessageDataStreamer;
+import io.ballerina.stdlib.http.transport.util.client.http2.MessageGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+
+/**
+ * Consumes the inbound request body deliberately slowly, then responds with the byte count on success or
+ * {@code error: <message>} if reading failed, so a test can tell a complete read from a cut-short stream.
+ */
+public class Http2SlowRequestBodyConsumerListener implements HttpConnectorListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Http2SlowRequestBodyConsumerListener.class);
+
+    public static final String ERROR_PREFIX = "error: ";
+
+    private final int readSlice;
+    private final long pauseMillis;
+    private final int pausedReads;
+
+    public Http2SlowRequestBodyConsumerListener(int readSlice, long pauseMillis, int pausedReads) {
+        this.readSlice = readSlice;
+        this.pauseMillis = pauseMillis;
+        this.pausedReads = pausedReads;
+    }
+
+    @Override
+    public void onMessage(HttpCarbonMessage httpRequest) {
+        Thread.startVirtualThread(() -> {
+            String result = readBodySlowly(httpRequest);
+            try {
+                httpRequest.respond(MessageGenerator.generateResponse(result)).sync();
+            } catch (Exception e) {
+                LOG.error("Error occurred while sending the response: {}", e.getMessage());
+            }
+        });
+    }
+
+    private String readBodySlowly(HttpCarbonMessage httpRequest) {
+        long totalRead = 0;
+        int pausesTaken = 0;
+        try (InputStream inputStream = new HttpMessageDataStreamer(httpRequest).getInputStream()) {
+            byte[] buffer = new byte[readSlice];
+            while (true) {
+                int readCount = inputStream.read(buffer, 0, readSlice);
+                if (readCount == -1) {
+                    break;
+                }
+                totalRead += readCount;
+
+                // Stall for longer than the server idle timeout a handful of times. Before the fix the stream
+                // was failed during the very first of these pauses.
+                if (pausesTaken < pausedReads) {
+                    pausesTaken++;
+                    LOG.debug("Pausing the request body consumer after reading {} bytes", totalRead);
+                    Thread.sleep(pauseMillis);
+                }
+            }
+            return Long.toString(totalRead);
+        } catch (Exception e) {
+            LOG.warn("Failed to read the request body after {} bytes: {}", totalRead, e.getMessage());
+            return ERROR_PREFIX + e.getMessage();
+        }
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        LOG.error("Error occurred in Http2SlowRequestBodyConsumerListener: {}", throwable.getMessage());
+    }
+}

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/servertimeout/Http2SlowInboundRequestBodyConsumerTestCase.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/servertimeout/Http2SlowInboundRequestBodyConsumerTestCase.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.transport.http2.servertimeout;
+
+import io.ballerina.stdlib.http.transport.contract.Constants;
+import io.ballerina.stdlib.http.transport.contract.HttpClientConnector;
+import io.ballerina.stdlib.http.transport.contract.HttpWsConnectorFactory;
+import io.ballerina.stdlib.http.transport.contract.ServerConnector;
+import io.ballerina.stdlib.http.transport.contract.ServerConnectorFuture;
+import io.ballerina.stdlib.http.transport.contract.config.ListenerConfiguration;
+import io.ballerina.stdlib.http.transport.contract.config.SenderConfiguration;
+import io.ballerina.stdlib.http.transport.contract.config.TransportsConfiguration;
+import io.ballerina.stdlib.http.transport.contractimpl.DefaultHttpWsConnectorFactory;
+import io.ballerina.stdlib.http.transport.http2.listeners.Http2SlowRequestBodyConsumerListener;
+import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
+import io.ballerina.stdlib.http.transport.message.HttpConnectorUtil;
+import io.ballerina.stdlib.http.transport.message.HttpMessageDataStreamer;
+import io.ballerina.stdlib.http.transport.util.TestUtil;
+import io.ballerina.stdlib.http.transport.util.client.http2.MessageGenerator;
+import io.ballerina.stdlib.http.transport.util.client.http2.MessageSender;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Verifies that an HTTP/2 service which consumes a large inbound request body slowly is not timed out - the
+ * request-side counterpart of
+ * {@link io.ballerina.stdlib.http.transport.http2.clienttimeout.Http2SlowInboundResponseBodyConsumerTestCase}.
+ */
+public class Http2SlowInboundRequestBodyConsumerTestCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Http2SlowInboundRequestBodyConsumerTestCase.class);
+
+    // Comfortably larger than the default 64KB inbound flow control window.
+    private static final int REQUEST_SIZE = 1024 * 1024;
+    private static final int CHUNK_SIZE = 8192;
+    private static final int SERVER_IDLE_TIMEOUT = 2000;
+    private static final int READ_SLICE = 16 * 1024;
+    private static final int CONSUMER_PAUSE = SERVER_IDLE_TIMEOUT + SERVER_IDLE_TIMEOUT / 2;
+    private static final int PAUSED_READS = 2;
+    // A regression here shows up as a stalled transfer rather than a quick error, so the test methods and the
+    // tear down are bounded to keep a failure a red test instead of a hung build.
+    private static final int TEST_TIME_OUT = 60000;
+    private static final int CLEAN_UP_TIME_OUT = 30000;
+
+    private HttpClientConnector h2ClientWithPriorKnowledge;
+    private ServerConnector serverConnector;
+    private HttpWsConnectorFactory connectorFactory;
+
+    @BeforeClass
+    public void setup() throws InterruptedException {
+        connectorFactory = new DefaultHttpWsConnectorFactory();
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
+        listenerConfiguration.setPort(TestUtil.HTTP_SERVER_PORT);
+        listenerConfiguration.setScheme(Constants.HTTP_SCHEME);
+        listenerConfiguration.setVersion(Constants.HTTP_2_0);
+        listenerConfiguration.setSocketIdleTimeout(SERVER_IDLE_TIMEOUT);
+        serverConnector = connectorFactory
+                .createServerConnector(TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
+        ServerConnectorFuture future = serverConnector.start();
+        future.setHttpConnectorListener(
+                new Http2SlowRequestBodyConsumerListener(READ_SLICE, CONSUMER_PAUSE, PAUSED_READS));
+        future.sync();
+
+        TransportsConfiguration transportsConfiguration = new TransportsConfiguration();
+        SenderConfiguration senderConfiguration = new SenderConfiguration();
+        senderConfiguration.setScheme(Constants.HTTP_SCHEME);
+        senderConfiguration.setHttpVersion(Constants.HTTP_2_0);
+        senderConfiguration.setForceHttp2(true);
+        // Keep the client well out of the way, the server side timing is what is under test.
+        senderConfiguration.setSocketIdleTimeout(500000);
+        h2ClientWithPriorKnowledge = connectorFactory.createHttpClientConnector(
+                HttpConnectorUtil.getTransportProperties(transportsConfiguration), senderConfiguration);
+    }
+
+    @Test(timeOut = TEST_TIME_OUT,
+          description = "A request body consumed more slowly than the server socket idle timeout must still "
+                  + "arrive in full, because the idleness is caused by the service rather than by the client.")
+    public void testSlowlyConsumedLargeRequestIsNotTruncated() {
+        HttpCarbonMessage request = MessageGenerator.generateDelayedRequest(HttpMethod.POST);
+
+        byte[] payload = new byte[REQUEST_SIZE];
+        for (int i = 0; i < REQUEST_SIZE; i++) {
+            payload[i] = (byte) ('A' + (i % 26));
+        }
+        for (int offset = 0; offset < REQUEST_SIZE; offset += CHUNK_SIZE) {
+            int length = Math.min(CHUNK_SIZE, REQUEST_SIZE - offset);
+            request.addHttpContent(new DefaultHttpContent(Unpooled.copiedBuffer(payload, offset, length)));
+        }
+        request.addHttpContent(new DefaultLastHttpContent());
+
+        HttpCarbonMessage response = new MessageSender(h2ClientWithPriorKnowledge).sendMessage(request);
+        assertNotNull(response, "Did not receive a response");
+        assertEquals(response.getHttpStatusCode().intValue(), HttpResponseStatus.OK.code(),
+                     "Expected the request to be served rather than timed out");
+
+        String receivedByteCount =
+                TestUtil.getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream());
+        assertEquals(receivedByteCount, Integer.toString(REQUEST_SIZE),
+                     "The service did not read the complete request body");
+    }
+
+    @AfterClass(timeOut = CLEAN_UP_TIME_OUT)
+    public void cleanUp() {
+        h2ClientWithPriorKnowledge.close();
+        serverConnector.stop();
+        try {
+            connectorFactory.shutdown();
+        } catch (InterruptedException e) {
+            LOG.warn("Interrupted while waiting for HttpWsFactory to close");
+        }
+    }
+}

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/servertimeout/Http2SlowOutboundResponseWriteTestCase.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/servertimeout/Http2SlowOutboundResponseWriteTestCase.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.transport.http2.servertimeout;
+
+import io.ballerina.stdlib.http.transport.contract.Constants;
+import io.ballerina.stdlib.http.transport.contract.HttpClientConnector;
+import io.ballerina.stdlib.http.transport.contract.HttpResponseFuture;
+import io.ballerina.stdlib.http.transport.contract.HttpWsConnectorFactory;
+import io.ballerina.stdlib.http.transport.contract.ServerConnector;
+import io.ballerina.stdlib.http.transport.contract.ServerConnectorFuture;
+import io.ballerina.stdlib.http.transport.contract.config.ListenerConfiguration;
+import io.ballerina.stdlib.http.transport.contractimpl.DefaultHttpWsConnectorFactory;
+import io.ballerina.stdlib.http.transport.http2.listeners.Http2ServerLargeResponseListener;
+import io.ballerina.stdlib.http.transport.message.HttpCarbonMessage;
+import io.ballerina.stdlib.http.transport.message.HttpMessageDataStreamer;
+import io.ballerina.stdlib.http.transport.util.DefaultHttpConnectorListener;
+import io.ballerina.stdlib.http.transport.util.TestUtil;
+import io.ballerina.stdlib.http.transport.util.client.http2.MessageGenerator;
+import io.netty.handler.codec.http.HttpMethod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.InputStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static io.ballerina.stdlib.http.transport.util.Http2Util.getHttp2Client;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies that an HTTP/2 server writing a large response to a slow client is not timed out by its own stream
+ * timer: a closed client window leaves the response queued in the remote flow controller, which must not be
+ * mistaken for an idle stream. The server idle timeout is deliberately short and the client's long, the
+ * reverse of the inbound tests, so the server timer is the one under test.
+ */
+public class Http2SlowOutboundResponseWriteTestCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Http2SlowOutboundResponseWriteTestCase.class);
+
+    // Large enough that the server cannot hand the whole response to the encoder before the client's window
+    // closes; a response small enough to write in one go completes the stream and cancels the timer.
+    private static final int RESPONSE_SIZE = 4 * 1024 * 1024;
+    private static final int SERVER_IDLE_TIMEOUT = 2000;
+    private static final int READ_SLICE = 16 * 1024;
+    private static final int CONSUMER_PAUSE = SERVER_IDLE_TIMEOUT + SERVER_IDLE_TIMEOUT / 2;
+    private static final int PAUSED_READS = 2;
+    // A regression here shows up as a stalled transfer rather than a quick error, so the test methods and the
+    // tear down are bounded to keep a failure a red test instead of a hung build.
+    private static final int TEST_TIME_OUT = 60000;
+    private static final int CLEAN_UP_TIME_OUT = 30000;
+
+    private HttpClientConnector h2PriorOnClient;
+    private ServerConnector serverConnector;
+    private HttpWsConnectorFactory connectorFactory;
+
+    @BeforeClass
+    public void setup() throws InterruptedException {
+        connectorFactory = new DefaultHttpWsConnectorFactory();
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
+        listenerConfiguration.setPort(TestUtil.HTTP_SERVER_PORT);
+        listenerConfiguration.setScheme(Constants.HTTP_SCHEME);
+        listenerConfiguration.setVersion(Constants.HTTP_2_0);
+        listenerConfiguration.setSocketIdleTimeout(SERVER_IDLE_TIMEOUT);
+        serverConnector = connectorFactory
+                .createServerConnector(TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
+        ServerConnectorFuture future = serverConnector.start();
+        future.setHttpConnectorListener(new Http2ServerLargeResponseListener(RESPONSE_SIZE));
+        future.sync();
+
+        // Keep the client well out of the way, the server side timing is what is under test.
+        h2PriorOnClient = getHttp2Client(connectorFactory, true, 500000);
+    }
+
+    @Test(timeOut = TEST_TIME_OUT,
+          description = "A large response written to a slow client must not be reset by the server's own "
+                  + "stream timer, because the stream is quiet due to flow control rather than a stalled peer.")
+    public void testSlowlyReadResponseIsNotResetByServer() throws Exception {
+        HttpCarbonMessage request = MessageGenerator.generateRequest(HttpMethod.POST, "test");
+
+        CountDownLatch latch = new CountDownLatch(1);
+        DefaultHttpConnectorListener listener = new DefaultHttpConnectorListener(latch);
+        HttpResponseFuture responseFuture = h2PriorOnClient.send(request);
+        responseFuture.setHttpConnectorListener(listener);
+
+        assertTrue(latch.await(TestUtil.HTTP2_RESPONSE_TIME_OUT, TimeUnit.SECONDS),
+                   "Did not receive the response headers");
+        HttpCarbonMessage response = listener.getHttpResponseMessage();
+        assertNotNull(response, "Response message is null: " + listener.getHttpErrorMessage());
+
+        byte[] expected = Http2ServerLargeResponseListener.buildExpectedPayload(RESPONSE_SIZE);
+        byte[] received = new byte[RESPONSE_SIZE];
+        int totalRead = 0;
+        int pausesTaken = 0;
+
+        try (InputStream inputStream = new HttpMessageDataStreamer(response).getInputStream()) {
+            while (totalRead < RESPONSE_SIZE) {
+                int toRead = Math.min(READ_SLICE, RESPONSE_SIZE - totalRead);
+                int readCount = inputStream.read(received, totalRead, toRead);
+                if (readCount == -1) {
+                    break;
+                }
+                totalRead += readCount;
+
+                if (pausesTaken < PAUSED_READS) {
+                    pausesTaken++;
+                    LOG.debug("Pausing the consumer after reading {} bytes", totalRead);
+                    Thread.sleep(CONSUMER_PAUSE);
+                }
+            }
+        }
+
+        assertEquals(totalRead, RESPONSE_SIZE, "Response body was truncated");
+        assertEquals(received, expected, "Response body content does not match what the server sent");
+    }
+
+    @AfterClass(timeOut = CLEAN_UP_TIME_OUT)
+    public void cleanUp() {
+        h2PriorOnClient.close();
+        serverConnector.stop();
+        try {
+            connectorFactory.shutdown();
+        } catch (InterruptedException e) {
+            LOG.warn("Interrupted while waiting for HttpWsFactory to close");
+        }
+    }
+}

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/message/PassthroughBackPressureListenerTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/message/PassthroughBackPressureListenerTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.transport.message;
+
+import io.ballerina.stdlib.http.transport.contractimpl.common.BackPressureAwareIdleStateHandler;
+import io.ballerina.stdlib.http.transport.contractimpl.common.Util;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.timeout.IdleStateEvent;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies that a {@link PassthroughBackPressureListener} suspending reads because its downstream leg went
+ * unwritable is visible to {@link BackPressureAwareIdleStateHandler}, the same way {@link DefaultListener}'s own
+ * internal queue cap already is - so the idle timeout does not mistake that back-pressure for an unresponsive
+ * peer and tear the connection down mid-transfer.
+ */
+public class PassthroughBackPressureListenerTest {
+
+    private static final long IDLE_TIMEOUT_MILLIS = 150;
+
+    @AfterMethod
+    public void resetStallLimit() {
+        Util.setMaxBackPressureStallTime(Util.DEFAULT_MAX_BACK_PRESSURE_STALL_TIME);
+    }
+
+    @Test(description = "Reads suspended by a PassthroughBackPressureListener must excuse the idle timeout")
+    public void testDownstreamUnwritableExcusesIdleTimeout() throws Exception {
+        Util.setMaxBackPressureStallTime(Util.DEFAULT_MAX_BACK_PRESSURE_STALL_TIME);
+        RecordingHandler recorder = new RecordingHandler();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new BackPressureAwareIdleStateHandler(IDLE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), recorder);
+        try {
+            ChannelHandlerContext ctx = channel.pipeline().context(recorder);
+            DefaultListener defaultListener = new DefaultListener(ctx);
+            defaultListener.onAdd(new DefaultHttpContent(Unpooled.wrappedBuffer(new byte[]{1})));
+
+            PassthroughBackPressureListener passthroughListener =
+                    new PassthroughBackPressureListener(ctx, defaultListener);
+            passthroughListener.onUnWritable();
+
+            waitPastIdleTimeoutAndRunDueTasks(channel);
+
+            assertTrue(recorder.events.isEmpty(),
+                       "Idle event fired even though reads were suspended by downstream back-pressure");
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test(description = "Control case: suspending reads without going through PassthroughBackPressureListener - "
+            + "the state before this fix - leaves the idle timeout blind to the suspension")
+    public void testAutoReadAloneWithoutNotifyingTheListenerDoesNotExcuseIdleTimeout() throws Exception {
+        Util.setMaxBackPressureStallTime(Util.DEFAULT_MAX_BACK_PRESSURE_STALL_TIME);
+        RecordingHandler recorder = new RecordingHandler();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new BackPressureAwareIdleStateHandler(IDLE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), recorder);
+        try {
+            ChannelHandlerContext ctx = channel.pipeline().context(recorder);
+            DefaultListener defaultListener = new DefaultListener(ctx);
+            defaultListener.onAdd(new DefaultHttpContent(Unpooled.wrappedBuffer(new byte[]{1})));
+
+            // Suspends reads the same way PassthroughBackPressureListener does, but without telling
+            // DefaultListener - reproducing the gap this test guards against.
+            channel.config().setAutoRead(false);
+
+            waitPastIdleTimeoutAndRunDueTasks(channel);
+
+            assertFalse(recorder.events.isEmpty(),
+                        "Expected the idle event to fire when the suspension isn't tracked");
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    private void waitPastIdleTimeoutAndRunDueTasks(EmbeddedChannel channel) throws InterruptedException {
+        Thread.sleep(IDLE_TIMEOUT_MILLIS * 3);
+        channel.runScheduledPendingTasks();
+    }
+
+    private static final class RecordingHandler extends ChannelInboundHandlerAdapter {
+
+        private final List<IdleStateEvent> events = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            if (evt instanceof IdleStateEvent) {
+                events.add((IdleStateEvent) evt);
+            }
+        }
+    }
+}

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/util/server/initializers/LargeResponseServerInitializer.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/util/server/initializers/LargeResponseServerInitializer.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.http.transport.util.server.initializers;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.LastHttpContent;
+
+import static io.ballerina.stdlib.http.transport.contract.Constants.TEXT_PLAIN;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+/**
+ * An initializer which responds with a complete, content-length delimited body that is large enough to make
+ * the client throttle its inbound reads. Used to verify that a client which consumes such a body slowly is not
+ * disconnected by the socket idle timeout.
+ */
+public class LargeResponseServerInitializer extends HttpServerInitializer {
+
+    private static final int CHUNK_SIZE = 8192;
+
+    private final int responseSize;
+
+    public LargeResponseServerInitializer(int responseSize) {
+        this.responseSize = responseSize;
+    }
+
+    protected void addBusinessLogicHandler(Channel channel) {
+        channel.pipeline().addLast("handler", new LargeResponseServerHandler());
+    }
+
+    public static byte[] buildExpectedPayload(int size) {
+        byte[] payload = new byte[size];
+        for (int i = 0; i < size; i++) {
+            payload[i] = (byte) ('A' + (i % 26));
+        }
+        return payload;
+    }
+
+    private class LargeResponseServerHandler extends ChannelInboundHandlerAdapter {
+
+        private HttpRequest req;
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+            if (msg instanceof HttpRequest) {
+                req = (HttpRequest) msg;
+            } else if (msg instanceof LastHttpContent) {
+                respond(ctx);
+            }
+        }
+
+        private void respond(ChannelHandlerContext ctx) {
+            HttpResponse response = new DefaultHttpResponse(HTTP_1_1, HttpResponseStatus.OK);
+            response.headers().set(CONTENT_TYPE, TEXT_PLAIN);
+            response.headers().set(CONTENT_LENGTH, responseSize);
+            response.headers().set(CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+            ctx.write(response);
+
+            byte[] payload = buildExpectedPayload(responseSize);
+            for (int offset = 0; offset < responseSize; offset += CHUNK_SIZE) {
+                int length = Math.min(CHUNK_SIZE, responseSize - offset);
+                ctx.write(new DefaultHttpContent(Unpooled.copiedBuffer(payload, offset, length)));
+            }
+            ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            ctx.close();
+        }
+    }
+}

--- a/native/src/test/resources/testng.xml
+++ b/native/src/test/resources/testng.xml
@@ -61,6 +61,8 @@
             <class name="io.ballerina.stdlib.http.transport.ClientConnectorTimeoutTestCase" />
             <class name="io.ballerina.stdlib.http.transport.ClientTimeoutWhileWritingBodyTestCase" />
             <class name="io.ballerina.stdlib.http.transport.ClientTimeoutWhileReadingBodyTestCase" />
+            <class name="io.ballerina.stdlib.http.transport.SlowInboundResponseBodyConsumerTestCase" />
+            <class name="io.ballerina.stdlib.http.transport.BackPressureStallLimitTestCase" />
             <class name="io.ballerina.stdlib.http.transport.ServerCloseWhileReadingBodyTestCase" />
             <class name="io.ballerina.stdlib.http.transport.ServerCloseWhileWritingBodyTestCase" />
             <class name="io.ballerina.stdlib.http.transport.ClientConnectorConnectionRefusedTestCase" />
@@ -130,6 +132,8 @@
             <class name="io.ballerina.stdlib.http.transport.http2.clienttimeout.TimeoutAfterRequestWrite"/>
             <class name="io.ballerina.stdlib.http.transport.http2.clienttimeout.TimeoutDuringRequestWrite"/>
             <class name="io.ballerina.stdlib.http.transport.http2.clienttimeout.TimeoutDuringResponseReceive"/>
+            <class name="io.ballerina.stdlib.http.transport.http2.clienttimeout.Http2SlowInboundResponseBodyConsumerTestCase"/>
+            <class name="io.ballerina.stdlib.http.transport.http2.clienttimeout.Http2ClientBackPressureStallLimitTestCase"/>
             <class name="io.ballerina.stdlib.http.transport.http2.Http2WithHttp2ResetContent"/>
             <class name="io.ballerina.stdlib.http.transport.http2.Http2WithPriorKnowledgeTestCase"/>
             <class name="io.ballerina.stdlib.http.transport.http2.Http2MaxConcurrentStreamsTestCase"/>
@@ -140,6 +144,8 @@
             <class name="io.ballerina.stdlib.http.transport.http2.TestExhaustedStreamIdForClient"/>
             <class name="io.ballerina.stdlib.http.transport.http2.servertimeout.TimeoutDuringRequestReceive"/>
             <class name="io.ballerina.stdlib.http.transport.http2.servertimeout.TimeoutAfterRequestReceived"/>
+            <class name="io.ballerina.stdlib.http.transport.http2.servertimeout.Http2SlowInboundRequestBodyConsumerTestCase"/>
+            <class name="io.ballerina.stdlib.http.transport.http2.servertimeout.Http2SlowOutboundResponseWriteTestCase"/>
             <class name="io.ballerina.stdlib.http.transport.http2.http2forwardedextension.Http2ForwardedDefaultTestCase"/>
             <class name="io.ballerina.stdlib.http.transport.http2.http2forwardedextension.Http2ForwardedEnableTestCase"/>
             <class name="io.ballerina.stdlib.http.transport.http2.http2forwardedextension.Http2ForwardedTransitionTestCase"/>
@@ -229,6 +235,9 @@
             <class name="io.ballerina.stdlib.http.transport.contractimpl.listener.HttpTraceLoggingHandlerTest"/>
             <class name="io.ballerina.stdlib.http.transport.contractimpl.common.FrameLoggerTest"/>
             <class name="io.ballerina.stdlib.http.transport.contractimpl.common.certificatevalidation.cache.CacheControllerTest"/>
+            <class name="io.ballerina.stdlib.http.transport.contractimpl.sender.http2.Http2ClientTimeoutHandlerConcurrentStreamTest"/>
+            <class name="io.ballerina.stdlib.http.transport.contractimpl.common.BackPressureAwareIdleStateHandlerTest"/>
+            <class name="io.ballerina.stdlib.http.transport.message.PassthroughBackPressureListenerTest"/>
         </classes>
     </test>
     <test name="Ballerina Http native Tests" parallel="false">


### PR DESCRIPTION
## Summary
Backport of #2669 to the `2.16.x` release line.

Inbound entity bodies are pulled off the socket on demand, but the idle timeout could not distinguish "the peer stalled" from "we deliberately stopped asking because the application hasn't consumed what's already queued". A consumer slower than the configured timeout had its connection torn down mid-transfer, truncating large streamed messages (surfacing as, e.g., an unexpected-EOF XML parser error). The same issue existed on the HTTP/2 side via flow control.

This backport is scoped to the fix itself, cherry-picked from the squashed master commit (21ed24423) with the following excluded, since they are unrelated to this fix and had only accumulated on that long-lived branch:
- Automated dependency/version bumps (mime-native, io, task, data.jsondata, url, Ballerina distribution, ballerina-to-openapi)
- An unrelated test-coverage commit (access log rotation / URI template parser tests)

## Test plan
- [x] `./gradlew :http-native:compileJava :http-native:compileTestJava :http-native:checkstyleMain :http-native:checkstyleTest` - clean
- [x] Full back-pressure/idle-timeout related test suite (49 tests: `BackPressureAwareIdleStateHandlerTest`, `PassthroughBackPressureListenerTest`, `Http2ClientTimeoutHandlerConcurrentStreamTest`, `BackPressureStallLimitTestCase`, `SlowInboundResponseBodyConsumerTestCase`, HTTP/2 client/server timeout suites, `Expect: 100-continue` suites, passthrough/proxy tests) - all passing

Fixes ballerina-platform/ballerina-library#9033