### PR TITLE
[2.16.x] Fix an HTTP/2 server deadlock between the response writer and the event loop

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Fix large streamed message being truncated when the application consumes it more slowly than the socket idle timeout](https://github.com/ballerina-platform/ballerina-library/issues/9033)
 - [Update Netty version to 4.1.137.Final and Netty tcnative version to 2.0.83.Final](https://github.com/ballerina-platform/ballerina-library/issues/9093)
+- Fix an HTTP/2 server deadlock between a parked response writer and the event loop failing its queued writes
 
 ## [2.16.6] - 2026-07-27
 

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/message/HttpCarbonMessage.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/message/HttpCarbonMessage.java
@@ -147,8 +147,10 @@ public class HttpCarbonMessage {
      */
     public HttpContent getHttpContent() {
         HttpContent httpContent = this.blockingEntityCollector.getHttpContent();
-        this.contentObservable.notifyGetListener(httpContent);
+        // Null once the collector has timed out waiting for content, and the listeners dereference what they
+        // are handed, so there is nothing to report to them in that case.
         if (httpContent != null) {
+            this.contentObservable.notifyGetListener(httpContent);
             this.contentSize += httpContent.content().readableBytes();
         }
         return httpContent;

--- a/native/src/main/java/io/ballerina/stdlib/http/transport/message/HttpCarbonMessage.java
+++ b/native/src/main/java/io/ballerina/stdlib/http/transport/message/HttpCarbonMessage.java
@@ -63,7 +63,9 @@ public class HttpCarbonMessage {
     private final DefaultHttpResponseFuture httpOutboundRespStatusFuture = new DefaultHttpResponseFuture();
     private final Observable contentObservable = new DefaultObservable();
     private final HttpHeaders httpTrailerHeaders = new DefaultLastHttpContent().trailingHeaders();
-    private IOException ioException;
+    // Read and written from the event loop while a content writer may be parked inside the
+    // synchronized addHttpContent, so these accessors must never contend for that monitor.
+    private volatile IOException ioException;
     public ListenerReqRespStateManager listenerReqRespStateManager;
     private Http2MessageStateContext http2MessageStateContext;
     private FullHttpMessageFuture fullHttpMessageFuture;
@@ -499,11 +501,11 @@ public class HttpCarbonMessage {
         return (HttpResponse) this.httpMessage;
     }
 
-    public synchronized IOException getIoException() {
+    public IOException getIoException() {
         return ioException;
     }
 
-    public synchronized void setIoException(IOException ioException) {
+    public void setIoException(IOException ioException) {
         this.ioException = ioException;
     }
 

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ChannelCloseAfterConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ChannelCloseAfterConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
@@ -55,7 +55,7 @@ public class Http2ChannelCloseAfterConnectionEvictionAfterTcpServerGoAwayScenari
     private static final Logger LOGGER =
             LoggerFactory.getLogger(Http2ChannelCloseAfterConnectionEvictionAfterTcpServerGoAwayScenarioTest.class);
     private HttpClientConnector h2ClientWithPriorKnowledge;
-    private ServerSocket serverSocket;
+    private volatile ServerSocket serverSocket;
 
     public HttpClientConnector setupHttp2PriorKnowledgeClient(long minIdleTimeInStaleState,
                                                               long timeBetweenStaleEviction) {
@@ -129,6 +129,8 @@ public class Http2ChannelCloseAfterConnectionEvictionAfterTcpServerGoAwayScenari
     @AfterClass
     public void cleanUp() throws IOException {
         h2ClientWithPriorKnowledge.close();
-        serverSocket.close();
+        if (serverSocket != null) {
+            serverSocket.close();
+        }
     }
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ChannelCloseAfterConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ChannelCloseAfterConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
@@ -99,8 +99,7 @@ public class Http2ChannelCloseAfterConnectionEvictionAfterTcpServerGoAwayScenari
         try {
             serverSocket = new ServerSocket(port);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage());
-            return;
+            throw new IllegalStateException("Could not bind the test server to port " + port, e);
         }
         LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ChannelCloseAfterConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ChannelCloseAfterConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
@@ -96,10 +96,15 @@ public class Http2ChannelCloseAfterConnectionEvictionAfterTcpServerGoAwayScenari
         if (serverSocket != null) {
             serverSocket.close();
         }
+        try {
+            serverSocket = new ServerSocket(port);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+            return;
+        }
+        LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {
             try {
-                serverSocket = new ServerSocket(port);
-                LOGGER.info("HTTP/2 TCP Server listening on port " + port);
                 Socket clientSocket = serverSocket.accept();
                 LOGGER.info("Accepted connection from: " + clientSocket.getInetAddress());
                 try (OutputStream outputStream = clientSocket.getOutputStream()) {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ChannelCloseBeforeConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ChannelCloseBeforeConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
@@ -99,8 +99,7 @@ public class Http2ChannelCloseBeforeConnectionEvictionAfterTcpServerGoAwayScenar
         try {
             serverSocket = new ServerSocket(port);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage());
-            return;
+            throw new IllegalStateException("Could not bind the test server to port " + port, e);
         }
         LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ChannelCloseBeforeConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ChannelCloseBeforeConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
@@ -96,10 +96,15 @@ public class Http2ChannelCloseBeforeConnectionEvictionAfterTcpServerGoAwayScenar
         if (serverSocket != null) {
             serverSocket.close();
         }
+        try {
+            serverSocket = new ServerSocket(port);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+            return;
+        }
+        LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {
             try {
-                serverSocket = new ServerSocket(port);
-                LOGGER.info("HTTP/2 TCP Server listening on port " + port);
                 Socket clientSocket = serverSocket.accept();
                 LOGGER.info("Accepted connection from: " + clientSocket.getInetAddress());
                 try (OutputStream outputStream = clientSocket.getOutputStream()) {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ChannelCloseBeforeConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ChannelCloseBeforeConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
@@ -55,7 +55,7 @@ public class Http2ChannelCloseBeforeConnectionEvictionAfterTcpServerGoAwayScenar
     private static final Logger LOGGER =
             LoggerFactory.getLogger(Http2ChannelCloseBeforeConnectionEvictionAfterTcpServerGoAwayScenarioTest.class);
     private HttpClientConnector h2ClientWithPriorKnowledge;
-    private ServerSocket serverSocket;
+    private volatile ServerSocket serverSocket;
 
     public HttpClientConnector setupHttp2PriorKnowledgeClient(long minIdleTimeInStaleState,
                                                               long timeBetweenStaleEviction) {
@@ -129,6 +129,8 @@ public class Http2ChannelCloseBeforeConnectionEvictionAfterTcpServerGoAwayScenar
     @AfterClass
     public void cleanUp() throws IOException {
         h2ClientWithPriorKnowledge.close();
-        serverSocket.close();
+        if (serverSocket != null) {
+            serverSocket.close();
+        }
     }
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
@@ -147,8 +147,7 @@ public class Http2ConnectionEvictionAfterTcpServerGoAwayScenarioTest {
         try {
             serverSocket = new ServerSocket(port);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage());
-            return;
+            throw new IllegalStateException("Could not bind the test server to port " + port, e);
         }
         LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
@@ -59,7 +59,7 @@ public class Http2ConnectionEvictionAfterTcpServerGoAwayScenarioTest {
     private static final Logger LOGGER =
             LoggerFactory.getLogger(Http2ConnectionEvictionAfterTcpServerGoAwayScenarioTest.class);
     private HttpClientConnector h2ClientWithPriorKnowledge;
-    private ServerSocket serverSocket;
+    private volatile ServerSocket serverSocket;
     private int numOfConnections = 0;
 
     public HttpClientConnector setupHttp2PriorKnowledgeClient(long minIdleTimeInStaleState,
@@ -202,6 +202,8 @@ public class Http2ConnectionEvictionAfterTcpServerGoAwayScenarioTest {
     @AfterClass
     public void cleanUp() throws IOException {
         h2ClientWithPriorKnowledge.close();
-        serverSocket.close();
+        if (serverSocket != null) {
+            serverSocket.close();
+        }
     }
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ConnectionEvictionAfterTcpServerGoAwayScenarioTest.java
@@ -144,10 +144,15 @@ public class Http2ConnectionEvictionAfterTcpServerGoAwayScenarioTest {
             serverSocket.close();
         }
         numOfConnections = 0;
+        try {
+            serverSocket = new ServerSocket(port);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+            return;
+        }
+        LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {
             try {
-                serverSocket = new ServerSocket(port);
-                LOGGER.info("HTTP/2 TCP Server listening on port " + port);
                 while (numOfConnections < 2) {
                     Socket clientSocket = serverSocket.accept();
                     LOGGER.info("Accepted connection from: " + clientSocket.getInetAddress());

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ServerAbruptClosureInALPNScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ServerAbruptClosureInALPNScenarioTest.java
@@ -91,10 +91,15 @@ public class Http2ServerAbruptClosureInALPNScenarioTest {
     }
 
     private void runTcpServer(int port) {
+        try {
+            serverSocket = new ServerSocket(port);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+            return;
+        }
+        LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {
             try {
-                serverSocket = new ServerSocket(port);
-                LOGGER.info("HTTP/2 TCP Server listening on port " + port);
                 while (numOfConnections < 2) {
                     Socket clientSocket = serverSocket.accept();
                     LOGGER.info("Accepted connection from: " + clientSocket.getInetAddress());

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ServerAbruptClosureInALPNScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ServerAbruptClosureInALPNScenarioTest.java
@@ -52,7 +52,7 @@ public class Http2ServerAbruptClosureInALPNScenarioTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Http2ServerAbruptClosureInALPNScenarioTest.class);
     private HttpClientConnector h2ClientWithUpgrade;
-    private ServerSocket serverSocket;
+    private volatile ServerSocket serverSocket;
     private int numOfConnections = 0;
 
     @BeforeClass
@@ -128,6 +128,8 @@ public class Http2ServerAbruptClosureInALPNScenarioTest {
     @AfterClass
     public void cleanUp() throws IOException {
         h2ClientWithUpgrade.close();
-        serverSocket.close();
+        if (serverSocket != null) {
+            serverSocket.close();
+        }
     }
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ServerAbruptClosureInALPNScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ServerAbruptClosureInALPNScenarioTest.java
@@ -94,8 +94,7 @@ public class Http2ServerAbruptClosureInALPNScenarioTest {
         try {
             serverSocket = new ServerSocket(port);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage());
-            return;
+            throw new IllegalStateException("Could not bind the test server to port " + port, e);
         }
         LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ServerAbruptClosureInUpgradeScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ServerAbruptClosureInUpgradeScenarioTest.java
@@ -53,7 +53,7 @@ public class Http2ServerAbruptClosureInUpgradeScenarioTest {
     private static final Logger LOGGER =
             LoggerFactory.getLogger(Http2ServerAbruptClosureInUpgradeScenarioTest.class);
     private HttpClientConnector h2ClientWithUpgrade;
-    private ServerSocket serverSocket;
+    private volatile ServerSocket serverSocket;
     private int numOfConnections = 0;
 
     @BeforeClass
@@ -133,6 +133,8 @@ public class Http2ServerAbruptClosureInUpgradeScenarioTest {
     @AfterClass
     public void cleanUp() throws IOException {
         h2ClientWithUpgrade.close();
-        serverSocket.close();
+        if (serverSocket != null) {
+            serverSocket.close();
+        }
     }
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ServerAbruptClosureInUpgradeScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ServerAbruptClosureInUpgradeScenarioTest.java
@@ -98,8 +98,7 @@ public class Http2ServerAbruptClosureInUpgradeScenarioTest {
         try {
             serverSocket = new ServerSocket(port);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage());
-            return;
+            throw new IllegalStateException("Could not bind the test server to port " + port, e);
         }
         LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ServerAbruptClosureInUpgradeScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2ServerAbruptClosureInUpgradeScenarioTest.java
@@ -95,10 +95,15 @@ public class Http2ServerAbruptClosureInUpgradeScenarioTest {
     }
 
     private void runTcpServer(int port) {
+        try {
+            serverSocket = new ServerSocket(port);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+            return;
+        }
+        LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {
             try {
-                serverSocket = new ServerSocket(port);
-                LOGGER.info("HTTP/2 TCP Server listening on port " + port);
                 while (numOfConnections < 2) {
                     Socket clientSocket = serverSocket.accept();
                     LOGGER.info("Accepted connection from: " + clientSocket.getInetAddress());

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAway100ContinueScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAway100ContinueScenarioTest.java
@@ -79,8 +79,7 @@ public class Http2TcpServerGoAway100ContinueScenarioTest {
         try {
             serverSocket = new ServerSocket(port);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage());
-            return;
+            throw new IllegalStateException("Could not bind the test server to port " + port, e);
         }
         LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAway100ContinueScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAway100ContinueScenarioTest.java
@@ -49,7 +49,7 @@ public class Http2TcpServerGoAway100ContinueScenarioTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Http2TcpServerGoAway100ContinueScenarioTest.class);
     private HttpClientConnector h2ClientWithPriorKnowledge;
-    private ServerSocket serverSocket;
+    private volatile ServerSocket serverSocket;
 
     @BeforeMethod
     public void setup(Method method) throws InterruptedException {
@@ -105,6 +105,8 @@ public class Http2TcpServerGoAway100ContinueScenarioTest {
     @AfterMethod
     public void cleanUp() throws IOException {
         h2ClientWithPriorKnowledge.close();
-        serverSocket.close();
+        if (serverSocket != null) {
+            serverSocket.close();
+        }
     }
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAway100ContinueScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAway100ContinueScenarioTest.java
@@ -76,10 +76,15 @@ public class Http2TcpServerGoAway100ContinueScenarioTest {
     }
 
     private void runTcpServer(int port) {
+        try {
+            serverSocket = new ServerSocket(port);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+            return;
+        }
+        LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {
             try {
-                serverSocket = new ServerSocket(port);
-                LOGGER.info("HTTP/2 TCP Server listening on port " + port);
                 Socket clientSocket = serverSocket.accept();
                 LOGGER.info("Accepted connection from: " + clientSocket.getInetAddress());
                 try (OutputStream outputStream = clientSocket.getOutputStream()) {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwayMultipleStreamScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwayMultipleStreamScenarioTest.java
@@ -87,8 +87,7 @@ public class Http2TcpServerGoAwayMultipleStreamScenarioTest {
         try {
             serverSocket = new ServerSocket(port);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage());
-            return;
+            throw new IllegalStateException("Could not bind the test server to port " + port, e);
         }
         LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwayMultipleStreamScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwayMultipleStreamScenarioTest.java
@@ -48,7 +48,7 @@ public class Http2TcpServerGoAwayMultipleStreamScenarioTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Http2TcpServerGoAwayMultipleStreamScenarioTest.class);
     private HttpClientConnector h2ClientWithPriorKnowledge;
-    private ServerSocket serverSocket;
+    private volatile ServerSocket serverSocket;
 
     @BeforeClass
     public void setup() throws InterruptedException {
@@ -128,6 +128,8 @@ public class Http2TcpServerGoAwayMultipleStreamScenarioTest {
     @AfterClass
     public void cleanUp() throws IOException {
         h2ClientWithPriorKnowledge.close();
-        serverSocket.close();
+        if (serverSocket != null) {
+            serverSocket.close();
+        }
     }
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwayMultipleStreamScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwayMultipleStreamScenarioTest.java
@@ -84,10 +84,15 @@ public class Http2TcpServerGoAwayMultipleStreamScenarioTest {
     }
 
     private void runTcpServer(int port) {
+        try {
+            serverSocket = new ServerSocket(port);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+            return;
+        }
+        LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {
             try {
-                serverSocket = new ServerSocket(port);
-                LOGGER.info("HTTP/2 TCP Server listening on port " + port);
                 Socket clientSocket = serverSocket.accept();
                 LOGGER.info("Accepted connection from: " + clientSocket.getInetAddress());
                 try (OutputStream outputStream = clientSocket.getOutputStream()) {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwaySingleStreamScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwaySingleStreamScenarioTest.java
@@ -48,7 +48,7 @@ public class Http2TcpServerGoAwaySingleStreamScenarioTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Http2TcpServerGoAwaySingleStreamScenarioTest.class);
     private HttpClientConnector h2ClientWithPriorKnowledge;
-    private ServerSocket serverSocket;
+    private volatile ServerSocket serverSocket;
 
     @BeforeMethod
     public void setup(Method method) throws InterruptedException {
@@ -133,6 +133,8 @@ public class Http2TcpServerGoAwaySingleStreamScenarioTest {
     @AfterMethod
     public void cleanUp() throws IOException {
         h2ClientWithPriorKnowledge.close();
-        serverSocket.close();
+        if (serverSocket != null) {
+            serverSocket.close();
+        }
     }
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwaySingleStreamScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwaySingleStreamScenarioTest.java
@@ -86,8 +86,7 @@ public class Http2TcpServerGoAwaySingleStreamScenarioTest {
         try {
             serverSocket = new ServerSocket(port);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage());
-            return;
+            throw new IllegalStateException("Could not bind the test server to port " + port, e);
         }
         LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwaySingleStreamScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwaySingleStreamScenarioTest.java
@@ -83,10 +83,15 @@ public class Http2TcpServerGoAwaySingleStreamScenarioTest {
     }
 
     private void runTcpServer(int port, int option) {
+        try {
+            serverSocket = new ServerSocket(port);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+            return;
+        }
+        LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {
             try {
-                serverSocket = new ServerSocket(port);
-                LOGGER.info("HTTP/2 TCP Server listening on port " + port);
                 Socket clientSocket = serverSocket.accept();
                 LOGGER.info("Accepted connection from: " + clientSocket.getInetAddress());
                 try (OutputStream outputStream = clientSocket.getOutputStream()) {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwayWhileReceivingBodyScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwayWhileReceivingBodyScenarioTest.java
@@ -69,10 +69,15 @@ public class Http2TcpServerGoAwayWhileReceivingBodyScenarioTest {
     }
 
     private void runTcpServer(int port) {
+        try {
+            serverSocket = new ServerSocket(port);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+            return;
+        }
+        LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {
             try {
-                serverSocket = new ServerSocket(port);
-                LOGGER.info("HTTP/2 TCP Server listening on port " + port);
                 Socket clientSocket = serverSocket.accept();
                 LOGGER.info("Accepted connection from: " + clientSocket.getInetAddress());
                 try (OutputStream outputStream = clientSocket.getOutputStream()) {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwayWhileReceivingBodyScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwayWhileReceivingBodyScenarioTest.java
@@ -47,7 +47,7 @@ public class Http2TcpServerGoAwayWhileReceivingBodyScenarioTest {
     private static final Logger LOGGER =
             LoggerFactory.getLogger(Http2TcpServerGoAwayWhileReceivingBodyScenarioTest.class);
     private HttpClientConnector h2ClientWithPriorKnowledge;
-    private ServerSocket serverSocket;
+    private volatile ServerSocket serverSocket;
 
     @BeforeClass
     public void setup() throws InterruptedException {
@@ -102,6 +102,8 @@ public class Http2TcpServerGoAwayWhileReceivingBodyScenarioTest {
     @AfterMethod
     public void cleanUp() throws IOException {
         h2ClientWithPriorKnowledge.close();
-        serverSocket.close();
+        if (serverSocket != null) {
+            serverSocket.close();
+        }
     }
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwayWhileReceivingBodyScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerGoAwayWhileReceivingBodyScenarioTest.java
@@ -72,8 +72,7 @@ public class Http2TcpServerGoAwayWhileReceivingBodyScenarioTest {
         try {
             serverSocket = new ServerSocket(port);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage());
-            return;
+            throw new IllegalStateException("Could not bind the test server to port " + port, e);
         }
         LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameFor100ContinueTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameFor100ContinueTest.java
@@ -48,7 +48,7 @@ public class Http2TcpServerRSTStreamFrameFor100ContinueTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Http2TcpServerRSTStreamFrameFor100ContinueTest.class);
     private HttpClientConnector h2ClientWithPriorKnowledge;
-    private ServerSocket serverSocket;
+    private volatile ServerSocket serverSocket;
 
     @BeforeClass
     public void setup() throws InterruptedException {
@@ -104,6 +104,8 @@ public class Http2TcpServerRSTStreamFrameFor100ContinueTest {
     @AfterMethod
     public void cleanUp() throws IOException {
         h2ClientWithPriorKnowledge.close();
-        serverSocket.close();
+        if (serverSocket != null) {
+            serverSocket.close();
+        }
     }
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameFor100ContinueTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameFor100ContinueTest.java
@@ -75,10 +75,15 @@ public class Http2TcpServerRSTStreamFrameFor100ContinueTest {
     }
 
     private void runTcpServer(int port) {
+        try {
+            serverSocket = new ServerSocket(port);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+            return;
+        }
+        LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {
             try {
-                serverSocket = new ServerSocket(port);
-                LOGGER.info("HTTP/2 TCP Server listening on port " + port);
                 Socket clientSocket = serverSocket.accept();
                 LOGGER.info("Accepted connection from: " + clientSocket.getInetAddress());
                 try (OutputStream outputStream = clientSocket.getOutputStream()) {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameFor100ContinueTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameFor100ContinueTest.java
@@ -78,8 +78,7 @@ public class Http2TcpServerRSTStreamFrameFor100ContinueTest {
         try {
             serverSocket = new ServerSocket(port);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage());
-            return;
+            throw new IllegalStateException("Could not bind the test server to port " + port, e);
         }
         LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameForMultipleStreamsTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameForMultipleStreamsTest.java
@@ -83,10 +83,15 @@ public class Http2TcpServerRSTStreamFrameForMultipleStreamsTest {
     }
 
     private void runTcpServer(int port) {
+        try {
+            serverSocket = new ServerSocket(port);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+            return;
+        }
+        LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {
             try {
-                serverSocket = new ServerSocket(port);
-                LOGGER.info("HTTP/2 TCP Server listening on port " + port);
                 Socket clientSocket = serverSocket.accept();
                 LOGGER.info("Accepted connection from: " + clientSocket.getInetAddress());
                 try (OutputStream outputStream = clientSocket.getOutputStream()) {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameForMultipleStreamsTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameForMultipleStreamsTest.java
@@ -86,8 +86,7 @@ public class Http2TcpServerRSTStreamFrameForMultipleStreamsTest {
         try {
             serverSocket = new ServerSocket(port);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage());
-            return;
+            throw new IllegalStateException("Could not bind the test server to port " + port, e);
         }
         LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameForMultipleStreamsTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameForMultipleStreamsTest.java
@@ -51,7 +51,7 @@ public class Http2TcpServerRSTStreamFrameForMultipleStreamsTest {
     private HttpClientConnector h2ClientWithPriorKnowledge;
     Semaphore readSemaphore = new Semaphore(0);
     Semaphore writeSemaphore = new Semaphore(0);
-    private ServerSocket serverSocket;
+    private volatile ServerSocket serverSocket;
 
     @BeforeClass
     public void setup() throws InterruptedException {
@@ -132,6 +132,8 @@ public class Http2TcpServerRSTStreamFrameForMultipleStreamsTest {
     @AfterMethod
     public void cleanUp() throws IOException {
         h2ClientWithPriorKnowledge.close();
-        serverSocket.close();
+        if (serverSocket != null) {
+            serverSocket.close();
+        }
     }
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameForSingleStreamTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameForSingleStreamTest.java
@@ -68,10 +68,15 @@ public class Http2TcpServerRSTStreamFrameForSingleStreamTest {
     }
 
     private void runTcpServer(int port) {
+        try {
+            serverSocket = new ServerSocket(port);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+            return;
+        }
+        LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {
             try {
-                serverSocket = new ServerSocket(port);
-                LOGGER.info("HTTP/2 TCP Server listening on port " + port);
                 Socket clientSocket = serverSocket.accept();
                 LOGGER.info("Accepted connection from: " + clientSocket.getInetAddress());
                 try (OutputStream outputStream = clientSocket.getOutputStream()) {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameForSingleStreamTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameForSingleStreamTest.java
@@ -46,7 +46,7 @@ public class Http2TcpServerRSTStreamFrameForSingleStreamTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Http2TcpServerRSTStreamFrameForSingleStreamTest.class);
     private HttpClientConnector h2ClientWithPriorKnowledge;
-    private ServerSocket serverSocket;
+    private volatile ServerSocket serverSocket;
 
     @BeforeClass
     public void setup() throws InterruptedException {
@@ -98,6 +98,8 @@ public class Http2TcpServerRSTStreamFrameForSingleStreamTest {
     @AfterMethod
     public void cleanUp() throws IOException {
         h2ClientWithPriorKnowledge.close();
-        serverSocket.close();
+        if (serverSocket != null) {
+            serverSocket.close();
+        }
     }
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameForSingleStreamTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameForSingleStreamTest.java
@@ -71,8 +71,7 @@ public class Http2TcpServerRSTStreamFrameForSingleStreamTest {
         try {
             serverSocket = new ServerSocket(port);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage());
-            return;
+            throw new IllegalStateException("Could not bind the test server to port " + port, e);
         }
         LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameWhenReadingBodyForSingleStreamTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameWhenReadingBodyForSingleStreamTest.java
@@ -70,10 +70,15 @@ public class Http2TcpServerRSTStreamFrameWhenReadingBodyForSingleStreamTest {
     }
 
     private void runTcpServer(int port) {
+        try {
+            serverSocket = new ServerSocket(port);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+            return;
+        }
+        LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {
             try {
-                serverSocket = new ServerSocket(port);
-                LOGGER.info("HTTP/2 TCP Server listening on port " + port);
                 Socket clientSocket = serverSocket.accept();
                 LOGGER.info("Accepted connection from: " + clientSocket.getInetAddress());
                 try (OutputStream outputStream = clientSocket.getOutputStream()) {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameWhenReadingBodyForSingleStreamTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameWhenReadingBodyForSingleStreamTest.java
@@ -73,8 +73,7 @@ public class Http2TcpServerRSTStreamFrameWhenReadingBodyForSingleStreamTest {
         try {
             serverSocket = new ServerSocket(port);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage());
-            return;
+            throw new IllegalStateException("Could not bind the test server to port " + port, e);
         }
         LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameWhenReadingBodyForSingleStreamTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerRSTStreamFrameWhenReadingBodyForSingleStreamTest.java
@@ -47,7 +47,7 @@ public class Http2TcpServerRSTStreamFrameWhenReadingBodyForSingleStreamTest {
     private static final Logger LOGGER =
             LoggerFactory.getLogger(Http2TcpServerRSTStreamFrameWhenReadingBodyForSingleStreamTest.class);
     private HttpClientConnector h2ClientWithPriorKnowledge;
-    private ServerSocket serverSocket;
+    private volatile ServerSocket serverSocket;
 
     @BeforeClass
     public void setup() throws InterruptedException {
@@ -102,6 +102,8 @@ public class Http2TcpServerRSTStreamFrameWhenReadingBodyForSingleStreamTest {
     @AfterMethod
     public void cleanUp() throws IOException {
         h2ClientWithPriorKnowledge.close();
-        serverSocket.close();
+        if (serverSocket != null) {
+            serverSocket.close();
+        }
     }
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerSendGoAwayForAllStreamsScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerSendGoAwayForAllStreamsScenarioTest.java
@@ -85,11 +85,16 @@ public class Http2TcpServerSendGoAwayForAllStreamsScenarioTest {
     }
 
     private void runTcpServer(int port) {
+        try {
+            serverSocket = new ServerSocket(port);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+            return;
+        }
+        LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {
             try {
-                serverSocket = new ServerSocket(port);
                 int numberOfConnections = 0;
-                LOGGER.info("HTTP/2 TCP Server listening on port " + port);
                 while (numberOfConnections < 6) {
                     Socket clientSocket = serverSocket.accept();
                     LOGGER.info("Accepted connection from: " + clientSocket.getInetAddress());

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerSendGoAwayForAllStreamsScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerSendGoAwayForAllStreamsScenarioTest.java
@@ -48,7 +48,7 @@ public class Http2TcpServerSendGoAwayForAllStreamsScenarioTest {
             LoggerFactory.getLogger(Http2TcpServerSendGoAwayForAllStreamsScenarioTest.class);
 
     private HttpClientConnector h2ClientWithPriorKnowledge;
-    private ServerSocket serverSocket;
+    private volatile ServerSocket serverSocket;
     Semaphore semaphore = new Semaphore(0);
 
     @BeforeClass
@@ -139,6 +139,8 @@ public class Http2TcpServerSendGoAwayForAllStreamsScenarioTest {
     @AfterMethod
     public void cleanUp() throws IOException {
         h2ClientWithPriorKnowledge.close();
-        serverSocket.close();
+        if (serverSocket != null) {
+            serverSocket.close();
+        }
     }
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerSendGoAwayForAllStreamsScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerSendGoAwayForAllStreamsScenarioTest.java
@@ -88,8 +88,7 @@ public class Http2TcpServerSendGoAwayForAllStreamsScenarioTest {
         try {
             serverSocket = new ServerSocket(port);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage());
-            return;
+            throw new IllegalStateException("Could not bind the test server to port " + port, e);
         }
         LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerSuccessScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerSuccessScenarioTest.java
@@ -66,10 +66,15 @@ public class Http2TcpServerSuccessScenarioTest {
     }
 
     private void runTcpServer(int port) {
+        try {
+            serverSocket = new ServerSocket(port);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+            return;
+        }
+        LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {
             try {
-                serverSocket = new ServerSocket(port);
-                LOGGER.info("HTTP/2 TCP Server listening on port " + port);
                 Socket clientSocket = serverSocket.accept();
                 LOGGER.info("Accepted connection from: " + clientSocket.getInetAddress());
                 try (OutputStream outputStream = clientSocket.getOutputStream()) {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerSuccessScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerSuccessScenarioTest.java
@@ -45,7 +45,7 @@ public class Http2TcpServerSuccessScenarioTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Http2TcpServerSuccessScenarioTest.class);
     private HttpClientConnector h2ClientWithPriorKnowledge;
-    private ServerSocket serverSocket;
+    private volatile ServerSocket serverSocket;
 
     @BeforeClass
     public void setup() throws InterruptedException {
@@ -98,6 +98,8 @@ public class Http2TcpServerSuccessScenarioTest {
     @AfterMethod
     public void cleanUp() throws IOException {
         h2ClientWithPriorKnowledge.close();
-        serverSocket.close();
+        if (serverSocket != null) {
+            serverSocket.close();
+        }
     }
 }

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerSuccessScenarioTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/http2/frameleveltests/client/Http2TcpServerSuccessScenarioTest.java
@@ -69,8 +69,7 @@ public class Http2TcpServerSuccessScenarioTest {
         try {
             serverSocket = new ServerSocket(port);
         } catch (IOException e) {
-            LOGGER.error(e.getMessage());
-            return;
+            throw new IllegalStateException("Could not bind the test server to port " + port, e);
         }
         LOGGER.info("HTTP/2 TCP Server listening on port " + port);
         new Thread(() -> {

--- a/native/src/test/java/io/ballerina/stdlib/http/transport/message/HttpCarbonMessageTest.java
+++ b/native/src/test/java/io/ballerina/stdlib/http/transport/message/HttpCarbonMessageTest.java
@@ -28,8 +28,12 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 /**
  * A unit test class for Transport module HttpCarbonMessage class functions.
@@ -124,4 +128,41 @@ public class HttpCarbonMessageTest {
         httpCarbonMessage.notifyContentFailure(new Exception());
     }
 
+
+    // A content writer parked inside addHttpContent - the HTTP/2 outbound path blocks there when the peer's
+    // flow control window is shut - used to hold the message monitor, so the event loop failing the queued
+    // writes after an RST_STREAM deadlocked against it and the connection could never be closed.
+    @Test(timeOut = 30000)
+    public void testSetIoExceptionIsNotBlockedByAParkedContentWriter() throws Exception {
+        HttpMessage httpMessage = mock(HttpMessage.class);
+        Listener contentListener = mock(Listener.class);
+        HttpCarbonMessage httpCarbonMessage = new HttpCarbonMessage(httpMessage, 100, contentListener);
+
+        CountDownLatch writerParked = new CountDownLatch(1);
+        CountDownLatch releaseWriter = new CountDownLatch(1);
+        httpCarbonMessage.getHttpContentAsync().setMessageListener(httpContent -> {
+            writerParked.countDown();
+            try {
+                releaseWriter.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        Thread writer = new Thread(() -> httpCarbonMessage.addHttpContent(mock(HttpContent.class)));
+        Thread failer = new Thread(() -> httpCarbonMessage.setIoException(new IOException("write failed")));
+        writer.start();
+        try {
+            assertTrue(writerParked.await(10, TimeUnit.SECONDS),
+                       "Content writer never reached the message listener");
+            failer.start();
+            failer.join(TimeUnit.SECONDS.toMillis(10));
+            assertFalse(failer.isAlive(),
+                        "setIoException blocked behind a content writer parked inside addHttpContent");
+        } finally {
+            releaseWriter.countDown();
+            writer.join(TimeUnit.SECONDS.toMillis(10));
+            failer.join(TimeUnit.SECONDS.toMillis(10));
+        }
+    }
 }


### PR DESCRIPTION
## Purpose

Backport of #2683.

Fixes a deadlock between an HTTP/2 response writer and the worker event loop that loses the event loop permanently, taking every connection bound to it with it.

### The deadlock

`HttpCarbonMessage.addHttpContent` is `synchronized` and notifies the content listener from inside that monitor. On the HTTP/2 server path that listener runs `checkStreamUnwritability`, which parks the calling thread on a semaphore until the peer reopens its flow control window. A service streaming a response to a slow consumer therefore sits parked *while holding the message monitor*.

When the peer then resets the stream, the event loop fails every write still queued in the remote flow controller, and the write failure listener calls `setIoException` on that same message. That accessor was `synchronized`, so the event loop blocked on the monitor the parked writer holds. The only thing that can release that writer is `removeBackPressureListener()` - three lines further down the very same failure listener (`Util.java:809` vs `:816`). Neither side can proceed.

```
virtual thread                        nioEventLoopGroup-* (BLOCKED)
addHttpContent [synchronized]         onRstStreamRead
  -> notifyMessageListener              -> FlowState.cancel -> writeError
    -> checkStreamUnwritability           -> releaseAndFailAll -> tryFailure
      -> Semaphore.acquire  <-------+       -> setIoException [synchronized] <--+
         parked, holds the monitor  |          needs that monitor               |
                                    +------------------------------------------+
```

Both stacks are from a thread dump taken on a hung Windows CI run.

### The fix

Hold `ioException` in a `volatile` field. The accessors keep the same visibility guarantee without taking the monitor, so the failure listener runs to completion, releases the parked writer, and the writer observes the exception on its next `addHttpContent`.

### Scope

This is not new. `git log -S` puts both halves at `45dd1192a`, a package rename, so they predate that too. It surfaced now only because #2669 added `Http2ClientBackPressureStallLimitTestCase`, which reliably creates the precondition - a stream reset while a large response is still queued behind a shut window. Any HTTP/2 service streaming a large response to a client that resets mid-stream can hit it today.

Symptom seen in CI: `Http2ClientBackPressureStallLimitTestCase.cleanUp` timing out on Windows. The channel's close future can never complete once its event loop is gone, so `ServerConnector.stop()` never returns.

### Follow-up not in this PR

The general shape - application code parking while holding the `HttpCarbonMessage` monitor - remains. Any other event loop path calling a `synchronized` method on that class during a stall would deadlock the same way; `notifyContentFailure` and `removeMessageFuture` are worth auditing. The real cure is moving `checkStreamUnwritability` out of the synchronized region, which is a larger change.

## Also in this PR

Two problems that the deadlock fix exposed rather than caused, both of which turned a single flaky test into a suite that hangs for minutes.

### The frame level test servers were not bound before the test sent its request

`runTcpServer` started a thread and returned at once, so a test could send its request before that thread reached `new ServerSocket(port)`. The connect was refused, the listener was handed an error instead of a response, and the test failed on a null response message. That is the intermittent failure seen in these classes: the client never connects, `Accepted connection` never appears in the log, and the server reports that it is listening a moment too late.

The socket is now bound on the calling thread and the accept loop starts afterwards, so by the time `runTcpServer` returns the port is bound, and a bind failure is reported where it happens instead of racing the request.

### A failing test then leaked its server socket

Every `frameleveltests` class binds `TestUtil.HTTP_SERVER_PORT` and closes it once, in `@AfterClass`. The socket is created inside the thread `runTcpServer` starts and read back from the TestNG thread, with nothing establishing a happens-before between the two, so `cleanUp` could see a stale `null` and throw at `serverSocket.close()` before closing anything. Port 9000 then stayed bound for the rest of the run: the next class logged `SEVERE: Address already in use: bind`, its client waited on a server that never accepted, and the suite stalled for six and a half minutes.

Fifteen classes had this shape and only three null checked. The field is now published safely and closed only when there is something to close.

### getHttpContent() handed a null content to its listeners

`BlockingEntityCollector.getHttpContent()` returns `null` once it has timed out waiting for content. `HttpCarbonMessage.getHttpContent()` passed that straight to `notifyGetListener` and only null checked on the following line, so `Http2InboundContentListener.onRemove` threw a `NullPointerException` out of whatever thread was draining the message. Reached during the stall above, but the guard is worth having regardless.

## Examples

N/A

## Checklist
- [ ] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
- [ ] Checked the impact on OpenAPI generation
