### PR TITLE
Report warning for unsupported endpoint export

### DIFF
--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnostic.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpDiagnostic.java
@@ -128,6 +128,8 @@ public enum HttpDiagnostic {
     HTTP_WARNING_101("HTTP_WARNING_101", "generated open-api definition is empty due to the errors " +
             "in the generation", WARNING),
     HTTP_WARNING_102("HTTP_WARNING_102", "The openapi definition is overridden by the `embed: true` option", WARNING),
+    HTTP_WARNING_103("HTTP_WARNING_103", "The Ballerina version is not supported for endpoints.yaml. " +
+            "Try using Ballerina 2201.13.6 or above", WARNING),
 
     HTTP_HINT_101("HTTP_HINT_101", "Payload annotation can be added", INTERNAL),
     HTTP_HINT_102("HTTP_HINT_102", "Header annotation can be added", INTERNAL),

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/endpointyaml/generator/EndpointMetadataTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/endpointyaml/generator/EndpointMetadataTask.java
@@ -18,8 +18,12 @@
 
 package io.ballerina.stdlib.http.compiler.endpointyaml.generator;
 
+import io.ballerina.openapi.service.mapper.utils.MapperCommonUtils;
 import io.ballerina.projects.plugins.CompilerLifecycleEventContext;
 import io.ballerina.projects.plugins.CompilerLifecycleTask;
+import io.ballerina.stdlib.http.compiler.HttpCompilerPluginUtil;
+import io.ballerina.stdlib.http.compiler.HttpDiagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -49,23 +53,26 @@ public class EndpointMetadataTask implements CompilerLifecycleTask<CompilerLifec
         if (endpoints == null || endpoints.isEmpty()) {
             return;
         }
-        for (Endpoint endpoint : endpoints) {
-            addEndpointMetadata(context, endpoint);
+        try {
+            for (Endpoint endpoint : endpoints) {
+                addEndpointMetadata(context, endpoint);
+            }
+        } catch (ReflectiveOperationException | SecurityException e) {
+            context.reportDiagnostic(DiagnosticFactory.createDiagnostic(
+                    HttpCompilerPluginUtil.getDiagnosticInfo(HttpDiagnostic.HTTP_WARNING_103),
+                    new MapperCommonUtils.NullLocation()));
         }
     }
 
-    private void addEndpointMetadata(CompilerLifecycleEventContext context, Endpoint endpoint) {
-        try {
-            Class<?> endpointMetaInfoClass = Class.forName(ENDPOINT_META_INFO_CLASS);
-            Constructor<?> constructor = endpointMetaInfoClass.getConstructor(String.class, int.class, String.class,
-                    String.class, String.class);
-            Object endpointMetaInfo = constructor.newInstance(endpoint.getName(), endpoint.getPort(),
-                    endpoint.getBasePath(), endpoint.getType(), endpoint.getSchemaPath());
-            Method method = context.getClass().getMethod(ADD_ENDPOINT_METADATA_METHOD, endpointMetaInfoClass);
-            method.setAccessible(true);
-            method.invoke(context, endpointMetaInfo);
-        } catch (ReflectiveOperationException | SecurityException e) {
-            // Endpoint metadata export is supported only with newer Ballerina lang versions.
-        }
+    private void addEndpointMetadata(CompilerLifecycleEventContext context, Endpoint endpoint)
+            throws ReflectiveOperationException {
+        Class<?> endpointMetaInfoClass = Class.forName(ENDPOINT_META_INFO_CLASS);
+        Constructor<?> constructor = endpointMetaInfoClass.getConstructor(String.class, int.class, String.class,
+                String.class, String.class);
+        Object endpointMetaInfo = constructor.newInstance(endpoint.getName(), endpoint.getPort(),
+                endpoint.getBasePath(), endpoint.getType(), endpoint.getSchemaPath());
+        Method method = context.getClass().getMethod(ADD_ENDPOINT_METADATA_METHOD, endpointMetaInfoClass);
+        method.setAccessible(true);
+        method.invoke(context, endpointMetaInfo);
     }
 }


### PR DESCRIPTION
## Purpose

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
- [ ] Checked the impact on OpenAPI generation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added `HTTP_WARNING_103` to report unsupported Ballerina versions during `endpoints.yaml` export.
- Updated endpoint metadata processing to catch reflection errors and report the warning instead of ignoring the export issue.
- Refactored reflection handling into a helper method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->