### PR TITLE
Add `trigger-metadata.json` file to the connector

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/ballerina-platform/module-ballerina-http"
 icon = "icon.png"
 license = ["Apache-2.0"]
 distribution = "2201.13.3"
+include = ["metadata"]
 
 [[package.modules]]
 name = "http.httpscerr"

--- a/ballerina/metadata/trigger-metadata.json
+++ b/ballerina/metadata/trigger-metadata.json
@@ -1,0 +1,122 @@
+{
+  "version": "v1.0",
+
+  "listeners": [
+    {
+      "id": "$listener",
+      "doc": "HTTP listener that dispatches each inbound request to the resource method matching its verb and path.",
+      "type": { "name": "Listener" },
+      "services": ["$service"],
+      "multipleServicesAllowed": true,
+      "multipleServicesOfSameTypeAllowed": true
+    }
+  ],
+
+  "serviceTypes": [
+    {
+      "id": "$service",
+      "doc": "An HTTP service. Each resource method is one endpoint, its accessor the HTTP verb and its path the URL path.",
+      "type": { "name": "Service" },
+      "concrete": false,
+      "multipleListenersAllowed": true,
+      "annotations": ["$serviceConfig"],
+      "identifier": { "presence": "required", "form": ["basePath"] },
+      "handlers": {
+        "backedByConcreteType": false,
+        "options": [
+          {
+            "id": "$service.resource",
+            "name": "*",
+            "kind": "resource",
+            "addMode": "many",
+            "doc": "One resource method per HTTP endpoint. The accessor is the HTTP verb and the resource path is the URL path, both are written into the method signature rather than configured here.",
+            "accessor": { "presence": "required", "values": ["get", "post", "put", "delete", "patch", "head", "options", "default"] },
+            "path": { "presence": "required" },
+            "annotations": ["$resourceConfig"],
+            "params": [
+              {
+                "id": "$service.resource.caller",
+                "name": "caller",
+                "doc": "Handle for building and sending the response explicitly, instead of returning a value.",
+                "type": { "name": "Caller" },
+                "presence": "optional",
+                "annotations": ["$callerInfo"]
+              },
+              {
+                "id": "$service.resource.request",
+                "name": "request",
+                "doc": "The raw inbound request, for anything the bound parameters do not expose.",
+                "type": { "name": "Request" },
+                "presence": "optional"
+              },
+              {
+                "id": "$service.resource.headers",
+                "name": "headers",
+                "doc": "Read-only access to the inbound request headers.",
+                "type": { "name": "Headers" },
+                "presence": "optional"
+              },
+              {
+                "id": "$service.resource.payload",
+                "name": "payload",
+                "doc": "The request body, bound to the declared type, see the requestPayload data-binding rule.",
+                "type": { "name": "anydata", "builtin": true },
+                "presence": "optional",
+                "dataBinding": { "typedescs": [{ "constraint": { "name": "anydata", "builtin": true }, "shapes": [{ "form": "bare" }] }] },
+                "annotations": ["$payload"]
+              },
+              {
+                "id": "$service.resource.queryParam",
+                "doc": "One URL query parameter. Repeat the slot once per parameter the resource accepts; the user names each one and the name becomes the query key.",
+                "type": [{ "name": "string", "builtin": true }, { "name": "int", "builtin": true }, { "name": "boolean", "builtin": true }, { "name": "decimal", "builtin": true }, { "name": "float", "builtin": true }],
+                "presence": "optional",
+                "addMode": "many",
+                "annotations": ["$query"]
+              },
+              {
+                "id": "$service.resource.headerParam",
+                "doc": "One request header. Repeat the slot once per header the resource reads; the user names each one, and the Header annotation carries the header name when it differs from the parameter name.",
+                "type": [{ "name": "string", "builtin": true }, { "name": "int", "builtin": true }, { "name": "boolean", "builtin": true }, { "name": "decimal", "builtin": true }, { "name": "float", "builtin": true }],
+                "presence": "optional",
+                "addMode": "many",
+                "annotations": ["$header"]
+              }
+            ],
+            "returns": {
+              "id": "$service.resource.returns",
+              "type": [
+                { "name": "anydata", "builtin": true },
+                { "name": "Response" },
+                { "name": "StatusCodeResponse", "subtypeFamily": true },
+                { "name": "error", "builtin": true }
+              ],
+              "dataBinding": {
+                "typedescs": [
+                  {
+                    "constraint": { "name": "anydata", "builtin": true },
+                    "shapes": [{ "form": "bare" }]
+                  },
+                  {
+                    "constraint": { "name": "anydata", "builtin": true },
+                    "shapes": [{ "form": "included", "envelope": { "name": "StatusCodeResponse", "subtypeFamily": true }, "bindableFields": ["body"] }]
+                  }
+                ]
+              },
+              "annotations": ["$cache"]
+            }
+          }
+        ]
+      }
+    }
+  ],
+
+  "annotations": [
+    { "id": "$serviceConfig", "type": { "name": "ServiceConfig" }, "attachPoint": "service", "presence": "optional" },
+    { "id": "$resourceConfig", "type": { "name": "ResourceConfig" }, "attachPoint": "function", "presence": "optional" },
+    { "id": "$payload", "type": { "name": "Payload" }, "attachPoint": "parameter", "presence": "optional" },
+    { "id": "$callerInfo", "type": { "name": "CallerInfo" }, "attachPoint": "parameter", "presence": "optional" },
+    { "id": "$header", "type": { "name": "Header" }, "attachPoint": "parameter", "presence": "optional" },
+    { "id": "$query", "type": { "name": "Query" }, "attachPoint": "parameter", "presence": "optional" },
+    { "id": "$cache", "type": { "name": "Cache" }, "attachPoint": "return", "presence": "optional" }
+  ]
+}

--- a/ballerina/metadata/trigger-metadata.json
+++ b/ballerina/metadata/trigger-metadata.json
@@ -5,7 +5,7 @@
       "id": "$listener",
       "doc": "HTTP listener that dispatches each inbound request to the resource method matching its verb and path.",
       "type": { "name": "Listener" },
-      "services": ["$service"],
+      "services": ["$service", "$interceptableService"],
       "multipleServicesAllowed": true,
       "multipleServicesOfSameTypeAllowed": true
     }
@@ -149,6 +149,265 @@
           "message": "When the caller param is declared, the resource must return only error? (or nothing) since the response is sent explicitly via the caller instead of via the return value."
         }
       ]
+    },
+    {
+      "id": "$interceptableService",
+      "doc": "An HTTP service that also runs an interceptor pipeline around its resources. Implements http:InterceptableService, which is *Service plus createInterceptors() — so its resource methods behave exactly like $service's, and it additionally supplies the interceptor pipeline. Declare this instead of $service when the service needs interceptors. See $requestInterceptor and https://ballerina.io/learn/by-example/http-request-interceptor/.",
+      "type": { "name": "InterceptableService" },
+      "concrete": false,
+      "multipleListenersAllowed": true,
+      "annotations": ["$serviceConfig"],
+      "identifier": { "presence": "optional", "form": ["basePath"] },
+      "handlers": {
+        "backedByConcreteType": false,
+        "options": [
+          {
+            "id": "$interceptableService.resource",
+            "name": "*",
+            "kind": "resource",
+            "addMode": "many",
+            "doc": "One resource method per HTTP endpoint, identical in shape to $service.resource.",
+            "accessor": { "presence": "required", "values": ["*"] },
+            "path": { "presence": "required" },
+            "annotations": ["$resourceConfig"],
+            "params": [
+              {
+                "id": "$interceptableService.resource.caller",
+                "name": "caller",
+                "doc": "Handle for building and sending the response explicitly, instead of returning a value.",
+                "type": { "name": "Caller" },
+                "presence": "optional",
+                "annotations": ["$callerInfo"]
+              },
+              {
+                "id": "$interceptableService.resource.request",
+                "name": "request",
+                "doc": "The raw inbound request, for anything the bound parameters do not expose.",
+                "type": { "name": "Request" },
+                "presence": "optional"
+              },
+              {
+                "id": "$interceptableService.resource.requestContext",
+                "name": "ctx",
+                "doc": "Per-request context object used to pass state between interceptor functions and the resource method.",
+                "type": { "name": "RequestContext" },
+                "presence": "optional"
+              },
+              {
+                "id": "$interceptableService.resource.headers",
+                "name": "headers",
+                "doc": "Read-only access to the inbound request headers.",
+                "type": { "name": "Headers" },
+                "presence": "optional"
+              },
+              {
+                "id": "$interceptableService.resource.payload",
+                "name": "payload",
+                "doc": "The request body, bound to the declared type, see the requestPayload data-binding rule.",
+                "type": { "name": "anydata", "builtin": true },
+                "presence": "optional",
+                "dataBinding": { "typedescs": [{ "constraint": { "name": "anydata", "builtin": true }, "shapes": [{ "form": "bare" }] }] },
+                "annotations": ["$payload"]
+              },
+              {
+                "id": "$interceptableService.resource.queryParam",
+                "doc": "One URL query parameter. Repeat the slot once per parameter the resource accepts; the user names each one and the name becomes the query key.",
+                "type": [
+                  { "name": "string", "builtin": true },
+                  { "name": "int", "builtin": true },
+                  { "name": "boolean", "builtin": true },
+                  { "name": "decimal", "builtin": true },
+                  { "name": "float", "builtin": true },
+                  { "shape": "array", "elementType": { "name": "string", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "int", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "boolean", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "decimal", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "float", "builtin": true } },
+                  { "name": "map", "builtin": true },
+                  { "name": "()", "builtin": true }
+                ],
+                "presence": "optional",
+                "addMode": "many",
+                "annotations": ["$query"]
+              },
+              {
+                "id": "$interceptableService.resource.headerParam",
+                "doc": "One request header. Repeat the slot once per header the resource reads; the user names each one, and the Header annotation carries the header name when it differs from the parameter name.",
+                "type": [
+                  { "name": "string", "builtin": true },
+                  { "name": "int", "builtin": true },
+                  { "name": "boolean", "builtin": true },
+                  { "name": "decimal", "builtin": true },
+                  { "name": "float", "builtin": true },
+                  { "shape": "array", "elementType": { "name": "string", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "int", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "boolean", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "decimal", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "float", "builtin": true } },
+                  { "name": "()", "builtin": true }
+                ],
+                "presence": "optional",
+                "addMode": "many",
+                "annotations": ["$header"]
+              }
+            ],
+            "returns": {
+              "id": "$interceptableService.resource.returns",
+              "type": [
+                { "name": "anydata", "builtin": true },
+                { "name": "Response" },
+                { "name": "StatusCodeResponse", "subtypeFamily": true },
+                { "name": "error", "builtin": true }
+              ],
+              "dataBinding": {
+                "typedescs": [
+                  {
+                    "constraint": { "name": "anydata", "builtin": true },
+                    "shapes": [{ "form": "bare" }]
+                  },
+                  {
+                    "constraint": { "name": "anydata", "builtin": true },
+                    "shapes": [{ "form": "included", "envelope": { "name": "StatusCodeResponse", "subtypeFamily": true }, "bindableFields": ["body", "headers"] }]
+                  }
+                ]
+              },
+              "annotations": ["$cache", "$payloadReturn"]
+            }
+          },
+          {
+            "id": "$interceptableService.createInterceptors",
+            "name": "createInterceptors",
+            "kind": "remote",
+            "presence": "required",
+            "doc": "What makes this an http:InterceptableService. Declared as a plain method, `public function createInterceptors() returns http:Interceptor|http:Interceptor[]` — no resource or remote qualifier in source, despite this construct's kind. Returns the interceptor pipeline instantiated for every request the service receives: request interceptors run in declaration order before the matched resource, response interceptors run in reverse order after it, and request/response error interceptors run in their place when an earlier stage errors. See $requestInterceptor and https://ballerina.io/learn/by-example/http-request-interceptor/.",
+            "returns": {
+              "id": "$interceptableService.createInterceptors.returns",
+              "type": [
+                { "name": "Interceptor" },
+                { "shape": "array", "elementType": { "name": "Interceptor" } }
+              ]
+            }
+          }
+        ]
+      },
+      "rules": [
+        {
+          "id": "$interceptableService.resource.callerReturnConstraint",
+          "rule": "returnType.restrictedByParam",
+          "subjects": [
+            { "kind": "param", "id": "$interceptableService.resource.caller", "serviceType": "$interceptableService", "role": "trigger" },
+            { "kind": "handler", "id": "$interceptableService.resource", "serviceType": "$interceptableService", "role": "constrainedReturn" }
+          ],
+          "severity": "error",
+          "message": "When the caller param is declared, the resource must return only error? (or nothing) since the response is sent explicitly via the caller instead of via the return value."
+        }
+      ]
+    },
+    {
+      "id": "$requestInterceptor",
+      "doc": "A request interceptor: a service class implementing http:RequestInterceptor, one of the pipeline stages an http:InterceptableService's createInterceptors() can return. Its single resource method runs once per matching request, before the target resource. Call ctx.next() to forward to the next interceptor (or the resource) in the pipeline; return a response, or respond via caller, to short-circuit it instead. See https://ballerina.io/learn/by-example/http-request-interceptor/.",
+      "type": { "name": "RequestInterceptor" },
+      "concrete": false,
+      "multipleListenersAllowed": false,
+      "handlers": {
+        "backedByConcreteType": false,
+        "options": [
+          {
+            "id": "$requestInterceptor.interceptRequest",
+            "name": "interceptRequest",
+            "kind": "resource",
+            "doc": "The single request-interception resource. No function-level annotation is allowed on it. The accessor may be a specific HTTP verb or 'default (any verb); the path is conventionally [string... path], matching every path the interceptor should run for.",
+            "presence": "required",
+            "accessor": { "presence": "required", "values": ["*"] },
+            "path": { "presence": "required" },
+            "params": [
+              {
+                "id": "$requestInterceptor.interceptRequest.ctx",
+                "name": "ctx",
+                "doc": "Per-request context shared across interceptors and the resource; call ctx.next() to forward to the next pipeline stage.",
+                "type": { "name": "RequestContext" },
+                "presence": "optional"
+              },
+              {
+                "id": "$requestInterceptor.interceptRequest.request",
+                "name": "request",
+                "doc": "The inbound request.",
+                "type": { "name": "Request" },
+                "presence": "optional"
+              },
+              {
+                "id": "$requestInterceptor.interceptRequest.caller",
+                "name": "caller",
+                "doc": "Handle for sending the response explicitly, instead of returning a value or continuing the pipeline.",
+                "type": { "name": "Caller" },
+                "presence": "optional",
+                "annotations": ["$callerInfo"]
+              },
+              {
+                "id": "$requestInterceptor.interceptRequest.payload",
+                "name": "payload",
+                "doc": "The request body, bound to the declared type, as on a regular resource method.",
+                "type": { "name": "anydata", "builtin": true },
+                "presence": "optional",
+                "dataBinding": { "typedescs": [{ "constraint": { "name": "anydata", "builtin": true }, "shapes": [{ "form": "bare" }] }] },
+                "annotations": ["$payload"]
+              },
+              {
+                "id": "$requestInterceptor.interceptRequest.queryParam",
+                "doc": "One URL query parameter, as on a regular resource method. Repeat the slot once per parameter the interceptor reads.",
+                "type": [
+                  { "name": "string", "builtin": true },
+                  { "name": "int", "builtin": true },
+                  { "name": "boolean", "builtin": true },
+                  { "name": "decimal", "builtin": true },
+                  { "name": "float", "builtin": true },
+                  { "shape": "array", "elementType": { "name": "string", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "int", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "boolean", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "decimal", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "float", "builtin": true } },
+                  { "name": "map", "builtin": true },
+                  { "name": "()", "builtin": true }
+                ],
+                "presence": "optional",
+                "addMode": "many",
+                "annotations": ["$query"]
+              },
+              {
+                "id": "$requestInterceptor.interceptRequest.headerParam",
+                "doc": "One request header, as on a regular resource method. Repeat the slot once per header the interceptor reads.",
+                "type": [
+                  { "name": "string", "builtin": true },
+                  { "name": "int", "builtin": true },
+                  { "name": "boolean", "builtin": true },
+                  { "name": "decimal", "builtin": true },
+                  { "name": "float", "builtin": true },
+                  { "shape": "array", "elementType": { "name": "string", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "int", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "boolean", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "decimal", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "float", "builtin": true } },
+                  { "name": "()", "builtin": true }
+                ],
+                "presence": "optional",
+                "addMode": "many",
+                "annotations": ["$header"]
+              }
+            ],
+            "returns": {
+              "id": "$requestInterceptor.interceptRequest.returns",
+              "type": [
+                { "name": "anydata", "builtin": true },
+                { "name": "Response" },
+                { "name": "StatusCodeResponse", "subtypeFamily": true },
+                { "name": "NextService" },
+                { "name": "error", "builtin": true },
+                { "name": "()", "builtin": true }
+              ]
+            }
+          }
+        ]
+      }
     }
   ],
   "annotations": [

--- a/ballerina/metadata/trigger-metadata.json
+++ b/ballerina/metadata/trigger-metadata.json
@@ -1,6 +1,5 @@
 {
   "version": "v1.0",
-
   "listeners": [
     {
       "id": "$listener",
@@ -11,16 +10,15 @@
       "multipleServicesOfSameTypeAllowed": true
     }
   ],
-
   "serviceTypes": [
     {
       "id": "$service",
-      "doc": "An HTTP service. Each resource method is one endpoint, its accessor the HTTP verb and its path the URL path.",
+      "doc": "An HTTP service attached to a listener. Each resource method's accessor is the HTTP verb and its path the URL path it handles, together identifying one route within the service.",
       "type": { "name": "Service" },
       "concrete": false,
       "multipleListenersAllowed": true,
       "annotations": ["$serviceConfig"],
-      "identifier": { "presence": "required", "form": ["basePath"] },
+      "identifier": { "presence": "optional", "form": ["basePath"] },
       "handlers": {
         "backedByConcreteType": false,
         "options": [
@@ -29,8 +27,8 @@
             "name": "*",
             "kind": "resource",
             "addMode": "many",
-            "doc": "One resource method per HTTP endpoint. The accessor is the HTTP verb and the resource path is the URL path, both are written into the method signature rather than configured here.",
-            "accessor": { "presence": "required", "values": ["get", "post", "put", "delete", "patch", "head", "options", "default"] },
+            "doc": "One resource method per HTTP endpoint. The accessor and path are not separately configurable properties: a generator must render and edit them as part of the function signature itself (resource function <accessor> <path>(...)), not as annotation or config fields.",
+            "accessor": { "presence": "required", "values": ["*"] },
             "path": { "presence": "required" },
             "annotations": ["$resourceConfig"],
             "params": [
@@ -47,6 +45,13 @@
                 "name": "request",
                 "doc": "The raw inbound request, for anything the bound parameters do not expose.",
                 "type": { "name": "Request" },
+                "presence": "optional"
+              },
+              {
+                "id": "$service.resource.requestContext",
+                "name": "ctx",
+                "doc": "Per-request context object used to pass state between interceptor functions and the resource method.",
+                "type": { "name": "RequestContext" },
                 "presence": "optional"
               },
               {
@@ -68,7 +73,20 @@
               {
                 "id": "$service.resource.queryParam",
                 "doc": "One URL query parameter. Repeat the slot once per parameter the resource accepts; the user names each one and the name becomes the query key.",
-                "type": [{ "name": "string", "builtin": true }, { "name": "int", "builtin": true }, { "name": "boolean", "builtin": true }, { "name": "decimal", "builtin": true }, { "name": "float", "builtin": true }],
+                "type": [
+                  { "name": "string", "builtin": true },
+                  { "name": "int", "builtin": true },
+                  { "name": "boolean", "builtin": true },
+                  { "name": "decimal", "builtin": true },
+                  { "name": "float", "builtin": true },
+                  { "shape": "array", "elementType": { "name": "string", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "int", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "boolean", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "decimal", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "float", "builtin": true } },
+                  { "name": "map", "builtin": true },
+                  { "name": "()", "builtin": true }
+                ],
                 "presence": "optional",
                 "addMode": "many",
                 "annotations": ["$query"]
@@ -76,7 +94,19 @@
               {
                 "id": "$service.resource.headerParam",
                 "doc": "One request header. Repeat the slot once per header the resource reads; the user names each one, and the Header annotation carries the header name when it differs from the parameter name.",
-                "type": [{ "name": "string", "builtin": true }, { "name": "int", "builtin": true }, { "name": "boolean", "builtin": true }, { "name": "decimal", "builtin": true }, { "name": "float", "builtin": true }],
+                "type": [
+                  { "name": "string", "builtin": true },
+                  { "name": "int", "builtin": true },
+                  { "name": "boolean", "builtin": true },
+                  { "name": "decimal", "builtin": true },
+                  { "name": "float", "builtin": true },
+                  { "shape": "array", "elementType": { "name": "string", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "int", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "boolean", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "decimal", "builtin": true } },
+                  { "shape": "array", "elementType": { "name": "float", "builtin": true } },
+                  { "name": "()", "builtin": true }
+                ],
                 "presence": "optional",
                 "addMode": "many",
                 "annotations": ["$header"]
@@ -98,22 +128,34 @@
                   },
                   {
                     "constraint": { "name": "anydata", "builtin": true },
-                    "shapes": [{ "form": "included", "envelope": { "name": "StatusCodeResponse", "subtypeFamily": true }, "bindableFields": ["body"] }]
+                    "shapes": [{ "form": "included", "envelope": { "name": "StatusCodeResponse", "subtypeFamily": true }, "bindableFields": ["body", "headers"] }]
                   }
                 ]
               },
-              "annotations": ["$cache"]
+              "annotations": ["$cache", "$payloadReturn"]
             }
           }
         ]
-      }
+      },
+      "rules": [
+        {
+          "id": "$service.resource.callerReturnConstraint",
+          "rule": "returnType.restrictedByParam",
+          "subjects": [
+            { "kind": "param", "id": "$service.resource.caller", "serviceType": "$service", "role": "trigger" },
+            { "kind": "handler", "id": "$service.resource", "serviceType": "$service", "role": "constrainedReturn" }
+          ],
+          "severity": "error",
+          "message": "When the caller param is declared, the resource must return only error? (or nothing) since the response is sent explicitly via the caller instead of via the return value."
+        }
+      ]
     }
   ],
-
   "annotations": [
     { "id": "$serviceConfig", "type": { "name": "ServiceConfig" }, "attachPoint": "service", "presence": "optional" },
     { "id": "$resourceConfig", "type": { "name": "ResourceConfig" }, "attachPoint": "function", "presence": "optional" },
     { "id": "$payload", "type": { "name": "Payload" }, "attachPoint": "parameter", "presence": "optional" },
+    { "id": "$payloadReturn", "type": { "name": "Payload" }, "attachPoint": "return", "presence": "optional" },
     { "id": "$callerInfo", "type": { "name": "CallerInfo" }, "attachPoint": "parameter", "presence": "optional" },
     { "id": "$header", "type": { "name": "Header" }, "attachPoint": "parameter", "presence": "optional" },
     { "id": "$query", "type": { "name": "Query" }, "attachPoint": "parameter", "presence": "optional" },

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/ballerina-platform/module-ballerina-http"
 icon = "icon.png"
 license = ["Apache-2.0"]
 distribution = "2201.13.3"
+include = ["metadata"]
 
 [[package.modules]]
 name = "http.httpscerr"


### PR DESCRIPTION
## Purpose
$subject

Fixes https://github.com/wso2-enterprise/integration-engineering/issues/2752

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
- [ ] Checked the impact on OpenAPI generation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds HTTP trigger metadata for listeners, services, resources, parameters, responses, and request interception.

Includes the `metadata` directory in built and published packages. Updates the `http-native` dependency to the release artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->