### PR TITLE
[2.15.x] Fix compiler validations skipped for service classes with multiple type qualifiers

### DIFF
--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/http/compiler/CompilerPluginTest.java
@@ -18,7 +18,10 @@
 
 package io.ballerina.stdlib.http.compiler;
 
+import io.ballerina.projects.CodeModifierResult;
 import io.ballerina.projects.DiagnosticResult;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.Module;
 import io.ballerina.projects.Package;
 import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.ProjectEnvironmentBuilder;
@@ -523,6 +526,17 @@ public class CompilerPluginTest {
     }
 
     @Test
+    public void testIsolatedInterceptorServiceClass() {
+        Package currentPackage = loadPackage("sample_package_52");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errorCount(), 3);
+        assertError(diagnosticResult, 0, "RequestInterceptor must have a resource method", HTTP_132);
+        assertError(diagnosticResult, 1, "RequestInterceptor must have a resource method", HTTP_132);
+        assertError(diagnosticResult, 2, "RequestInterceptor must have a resource method", HTTP_132);
+    }
+
+    @Test
     public void testReadonlyReturnTypes() {
         Package currentPackage = loadPackage("sample_package_20");
         PackageCompilation compilation = currentPackage.getCompilation();
@@ -744,8 +758,25 @@ public class CompilerPluginTest {
     @Test
     public void testCodeModifierWithServiceClassesPayloadAnnotation() {
         Package currentPackage = loadPackage("sample_package_36");
-        DiagnosticResult modifierDiagnosticResult = currentPackage.runCodeGenAndModifyPlugins();
-        Assert.assertEquals(modifierDiagnosticResult.errorCount(), 0);
+        CodeModifierResult modifierResult = currentPackage.runCodeModifierPlugins();
+
+        Assert.assertEquals(modifierResult.reportedDiagnostics().errorCount(), 0);
+
+        Package modifiedPackage = modifierResult.updatedPackage()
+                .orElseThrow(() -> new AssertionError("Expected the code modifier to return an updated package"));
+
+        Module module = modifiedPackage.getDefaultModule();
+        DocumentId documentId = module.documentIds().iterator().next();
+        String modifiedSource = module.document(documentId)
+                .syntaxTree()
+                .toSourceCode();
+
+        Assert.assertTrue(modifiedSource.contains(
+                        "resource function post foo(@http:Payload map<json> p)"),
+                "Expected @http:Payload to be added in the service class");
+        Assert.assertTrue(modifiedSource.contains(
+                        "resource function post bar(@http:Payload map<json> q)"),
+                "Expected @http:Payload to be added in the isolated service class");
     }
 
     @Test

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_36/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_36/service.bal
@@ -35,6 +35,13 @@ service class SClass {
    }
 }
 
+isolated service class IsolatedSClass {
+   *http:Service;
+   resource function post bar(map<json> q) returns string {
+       return "done";
+   }
+}
+
 service class InterceptorService {
     *http:RequestInterceptor;
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_52/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_52/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "http_test"
+name = "sample_52"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_52/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_52/service.bal
@@ -1,0 +1,29 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+service class PlainInterceptor {
+    *http:RequestInterceptor;
+}
+
+isolated service class IsolatedInterceptor {
+    *http:RequestInterceptor;
+}
+
+distinct service class DistinctInterceptor {
+    *http:RequestInterceptor;
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpInterceptorServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/HttpInterceptorServiceValidator.java
@@ -70,7 +70,7 @@ public class HttpInterceptorServiceValidator implements AnalysisTask<SyntaxNodeA
         if (tokens.isEmpty()) {
             return;
         }
-        if (!tokens.stream().allMatch(token -> token.text().equals(Constants.SERVICE_KEYWORD))) {
+        if (tokens.stream().noneMatch(token -> token.text().equals(Constants.SERVICE_KEYWORD))) {
             return;
         }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/payload/HttpPayloadParamIdentifier.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/http/compiler/codemodifier/payload/HttpPayloadParamIdentifier.java
@@ -153,7 +153,7 @@ public class HttpPayloadParamIdentifier extends HttpServiceValidator {
         if (tokens.isEmpty()) {
             return;
         }
-        if (!tokens.stream().allMatch(token -> token.text().equals(Constants.SERVICE_KEYWORD))) {
+        if (tokens.stream().noneMatch(token -> token.text().equals(Constants.SERVICE_KEYWORD))) {
             return;
         }
         NodeList<Node> members = classDefinitionNode.members();


### PR DESCRIPTION
## Purpose

Backport of #2668 to 2.15.x.

`HttpInterceptorServiceValidator` and `HttpPayloadParamIdentifier` required the
`service` keyword to be the only class type qualifier, so `isolated`, `distinct`,
`readonly` and `client` service classes skipped validation entirely.

Fixes ballerina-platform/ballerina-library#5085

## Approach

The affected lines are identical on this branch
(`HttpInterceptorServiceValidator:73`, `HttpPayloadParamIdentifier:156`), so the
patch applies unchanged from master.

No changelog entry, this branch has no `[Unreleased]` section, so I've left that
for the release. Happy to add one if preferred.

## Tests

`testIsolatedInterceptorServiceClass` and `testCodeModifierWithServiceClassesPayloadAnnotation`
both cover the change. Compiler-plugin suite green at 70/70 locally.